### PR TITLE
Don't assume secrets are Base64 encoded

### DIFF
--- a/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -8,6 +8,7 @@ import org.apache.commons.codec.binary.Base64;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
@@ -23,7 +24,7 @@ import java.util.Map;
  */
 public class JWTVerifier {
 
-    private final String secret;
+    private final byte[] secret;
     private final String audience;
     private final String issuer;
     private final Base64 decoder;
@@ -32,8 +33,8 @@ public class JWTVerifier {
 
     private Map<String, String> algorithms;
 
-    public JWTVerifier(String secret, String audience, String issuer) {
-        if (secret == null || "".equals(secret)) {
+    public JWTVerifier(byte[] secret, String audience, String issuer) {
+        if (secret == null || secret.length == 0) {
             throw new IllegalArgumentException("Secret cannot be null or empty");
         }
 
@@ -45,9 +46,17 @@ public class JWTVerifier {
         algorithms.put("HS384", "HmacSHA384");
         algorithms.put("HS512", "HmacSHA512");
 
-        this.secret = secret;
+        this.secret = secret.clone();
         this.audience = audience;
         this.issuer = issuer;
+    }
+
+    public JWTVerifier(byte[] secret, String audience) {
+        this(secret, audience, null);
+    }
+
+    public JWTVerifier(String secret, String audience, String issuer) {
+        this((secret == null) ? null : secret.getBytes(Charset.forName("UTF-8")), audience, issuer);
     }
 
     public JWTVerifier(String secret, String audience) {
@@ -100,7 +109,7 @@ public class JWTVerifier {
 
     void verifySignature(String[] pieces, String algorithm) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         Mac hmac = Mac.getInstance(algorithm);
-        hmac.init(new SecretKeySpec(decoder.decodeBase64(secret), algorithm));
+        hmac.init(new SecretKeySpec(secret, algorithm));
         byte[] sig = hmac.doFinal(new StringBuilder(pieces[0]).append(".").append(pieces[1]).toString().getBytes());
 
         if (!Arrays.equals(sig, decoder.decodeBase64(pieces[2]))) {

--- a/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -73,7 +73,8 @@ public class JWTVerifierTest {
                 "." +
                 "suchsignature_plzvalidate_zomgtokens";
         String secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow";
-        new JWTVerifier(secret, "audience").verifySignature(jws.split("\\."), "HmacSHA256");
+        new JWTVerifier(Base64.decodeBase64(secret), "audience")
+                .verifySignature(jws.split("\\."), "HmacSHA256");
     }
 
     @Test
@@ -85,7 +86,7 @@ public class JWTVerifierTest {
                 "." +
                 "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
         final String secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow";
-        new JWTVerifier(secret, "audience")
+        new JWTVerifier(Base64.decodeBase64(secret), "audience")
                 .verifySignature(jws.split("\\."), "HmacSHA256");
     }
 


### PR DESCRIPTION
The JOSE/JWT specs make no assumption that shared secrets are Base64 encoded. If a particular caller's secret needs to be decoded prior to verification, then it should be its responsibility to take care of that.
