### PR TITLE
Repackage maven dependencies to avoid conflicts with Jackson version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Maven Shaded Jar Artifact
+dependency-reduced-pom.xml
+
 node_modules
 
 # Ignore Eclipse stuff

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <java.version>1.6</java.version>
+    <repackage.base>com.auth0.jwt.internal</repackage.base>
   </properties>
 
   <licenses>
@@ -76,6 +77,33 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>2.2</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <shadedArtifactAttached>false</shadedArtifactAttached>
+                <createDependencyReducedPom>true</createDependencyReducedPom>
+                <relocations>
+                  <relocation>
+                    <pattern>com.fasterxml.jackson</pattern>
+                    <shadedPattern>${repackage.base}.com.fasterxml.jackson</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.apache.commons.codec</pattern>
+                    <shadedPattern>${repackage.base}.org.apache.commons.codec</shadedPattern>
+                  </relocation>
+                </relocations>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
The maven dependencies are now packaged along with the jar. That way it is possible that JWT uses a different version of Jackson than the application. I did this as I needed JWT to work with an older version of Jackson.
