### PR TITLE
Adding aud,oat,sub as part of the claimset

### DIFF
--- a/src/main/java/com/auth0/jwt/ClaimSet.java
+++ b/src/main/java/com/auth0/jwt/ClaimSet.java
@@ -1,14 +1,94 @@
 package com.auth0.jwt;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.List;
+
 public class ClaimSet {
 
-	private int exp;
+	private long exp;
+    protected String iss;
+    protected long iat;
+    protected String qsh;
+    protected String sub;
+    protected List<String> aud;
 	
-	public int getExp() {
+	public long getExp() {
 		return exp;
 	}
 
-	public void setExp(int exp) {
-		this.exp = (int)(System.currentTimeMillis() / 1000L) + exp;
+	public void setExp(long exp) {
+		this.exp = (long)(System.currentTimeMillis() / 1000L) + exp;
 	}
+
+    public String getIss() {
+        return iss;
+    }
+
+    public void setIss(String iss) {
+        this.iss = iss;
+    }
+
+    public long getIat() {
+        return iat;
+    }
+
+    public void setIat(long iat) {
+        this.iat = iat;
+    }
+
+    public String getQsh() {
+        return qsh;
+    }
+
+    public void setQsh(String qsh) {
+        this.qsh = qsh;
+    }
+
+    public String getSub() {
+        return sub;
+    }
+
+    public void setSub(String sub) {
+        this.sub = sub;
+    }
+
+    public List<String> getAud() {
+        return aud;
+    }
+
+    public void setAud(List<String> aud) {
+        this.aud = aud;
+    }
+
+    public ObjectNode build(){
+        ObjectNode localClaimSet = JsonNodeFactory.instance.objectNode();
+        ArrayNode localAudArray = JsonNodeFactory.instance.arrayNode();
+        if(this.getExp() > 0) {
+            localClaimSet.put("exp", this.getExp());
+        }
+        if (this.getAud()!=null && this.getAud().size() >0){
+            for (String str : this.getAud()){
+                localAudArray.add(str);
+            }
+            localClaimSet.put("aud", localAudArray);
+        }
+        if (this.getIss() != null && this.getIss().length() >0) {
+            localClaimSet.put("iss", this.getIss());
+        }
+        if(this.getIat() > 0) {
+            localClaimSet.put("iat", this.getIat());
+        }
+        if (this.getQsh() != null && this.getQsh().length() >0) {
+            localClaimSet.put("qsh", this.getQsh());
+        }
+        if (this.getSub() != null && this.getSub().length() >0) {
+            localClaimSet.put("sub", this.getSub());
+        }
+        return localClaimSet;
+    }
+
+
 }

--- a/src/main/java/com/auth0/jwt/JwtSigner.java
+++ b/src/main/java/com/auth0/jwt/JwtSigner.java
@@ -7,6 +7,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.naming.OperationNotSupportedException;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.commons.codec.binary.Base64;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -56,15 +57,13 @@ public class JwtSigner {
 	 */
 	private String encodedPayload(String payload, String payloadId, ClaimSet claimSet) throws Exception {
 		
-		ObjectNode localClaimSet = JsonNodeFactory.instance.objectNode();
+		ObjectNode localClaimSet = claimSet.build();
 		ObjectNode localPayload = JsonNodeFactory.instance.objectNode();
+
 		
 		localPayload.put(payloadId, payload);
 		
-		if(claimSet != null) {
-			if(claimSet.getExp() > 0) {
-				localClaimSet.put("exp", claimSet.getExp());
-			}
+		if(localClaimSet != null) {
 			localPayload.putAll(localClaimSet);
 		}
 		


### PR DESCRIPTION
Currently Claimset has exp only. There is no way to add audience  and
others as part of the claimset according to the standard.  I need
audience and others as part of the claimset.  So adding them to the
claimset
