### PR TITLE
Make project compatible with jdk 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <url>http://www.jwt.io</url>
 
   <properties>
-    <java.version>1.6</java.version>
+    <java.version>1.5</java.version>
     <repackage.base>com.auth0.jwt.internal</repackage.base>
   </properties>
 
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
For legacy purposes, the java-jwt project can now be used on 1.5+
