### PR TITLE
Update JWTSigner.java. Please merge if you think the same. A new release 1.0.1 would be great.

### DIFF
--- a/src/main/java/com/auth0/jwt/JWTSigner.java
+++ b/src/main/java/com/auth0/jwt/JWTSigner.java
@@ -91,7 +91,7 @@ public class JWTSigner {
 
         // create the header
         ObjectNode header = JsonNodeFactory.instance.objectNode();
-        header.put("type", "JWT");
+        header.put("typ", "JWT");
         header.put("alg", algorithm.name());
 
         return base64UrlEncode(header.toString().getBytes("UTF-8"));


### PR DESCRIPTION
Following the standard http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html the header has to contain a "typ" attribute. The current implementation uses "type". I think this is a bug.
There is no easy way to fix this in a 3rd party application because all relevant methods are private. encodedHeader cannot by overridden.

I propose to fix the issue by changing header.put("type", "JWT"); to header.put("typ", "JWT"); in JWTSigner.java.
