### PR TITLE
Allow arbitrary byte-array for secret

### DIFF
--- a/src/main/java/com/auth0/jwt/JWTSigner.java
+++ b/src/main/java/com/auth0/jwt/JWTSigner.java
@@ -26,9 +26,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * No support for RSA encryption at present
  */
 public class JWTSigner {
-    private final String secret;
+    private final byte[] secret;
 
     public JWTSigner(String secret) {
+        this(secret.getBytes());
+    }
+
+    public JWTSigner(byte[] secret) {
         this.secret = secret;
     }
 
@@ -216,7 +220,7 @@ public class JWTSigner {
     /**
      * Switch the signing algorithm based on input, RSA not supported
      */
-    private static byte[] sign(Algorithm algorithm, String msg, String secret) throws Exception {
+    private static byte[] sign(Algorithm algorithm, String msg, byte[] secret) throws Exception {
         switch (algorithm) {
         case HS256:
         case HS384:
@@ -233,9 +237,9 @@ public class JWTSigner {
     /**
      * Sign an input string using HMAC and return the encrypted bytes
      */
-    private static byte[] signHmac(Algorithm algorithm, String msg, String secret) throws Exception {
+    private static byte[] signHmac(Algorithm algorithm, String msg, byte[] secret) throws Exception {
         Mac mac = Mac.getInstance(algorithm.getValue());
-        mac.init(new SecretKeySpec(secret.getBytes(), algorithm.getValue()));
+        mac.init(new SecretKeySpec(secret, algorithm.getValue()));
         return mac.doFinal(msg.getBytes());
     }
 

--- a/src/test/java/com/auth0/jwt/JWTSignerTest_Bytes.java
+++ b/src/test/java/com/auth0/jwt/JWTSignerTest_Bytes.java
@@ -1,0 +1,200 @@
+package com.auth0.jwt;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+
+public class JWTSignerTest_Bytes {
+    private static JWTSigner signer = new JWTSigner(new byte[] { 109, 121, 32, 115, 101, 99, 114, 101, 116});
+    
+    @Test
+    public void shouldSignEmpty() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.86pkOAQxvnSDd91EThNNpOTbO-hbvxdssnFjQqT04NU", token);
+    }
+
+    @Test
+    public void shouldSignEmptyTwoParams() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.86pkOAQxvnSDd91EThNNpOTbO-hbvxdssnFjQqT04NU", token);
+    }
+
+    @Test
+    public void shouldSignStringOrURI1() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("iss", "foo");
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmb28ifQ.UbvkKJx4ubG9SQYs3Hpe6FJl1ix89jSLw0I9GNTnLgY", token);
+    }
+
+    @Test
+    public void shouldSignStringOrURI2() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("sub", "http://foo");
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJodHRwOi8vZm9vIn0.EaYoTXJWUNd_1tWfZo4EZoKUP8hVMJm1LHBQNo4Xfwg", token);
+    }
+    
+    @Test
+    public void shouldSignStringOrURI3() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("aud", "");
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIifQ.T2EKheH_WVVwybctic8Sqk89miYVKADW0AeXOicDbz8", token);
+    }
+    
+    @Test
+    public void shouldSignStringOrURICollection() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        LinkedList<String> aud = new LinkedList<String>();
+        aud.add("xyz");
+        aud.add("ftp://foo");
+        claims.put("aud", aud);
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsieHl6IiwiZnRwOi8vZm9vIl19.WGpsdOnLJ2k7Rr4WeEuabHO4wNQIhJfPMZot1DrTUgA", token);
+    }
+    
+    @Test
+    public void shouldSignIntDate1() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("exp", 123);
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjEyM30.FzAXEHf0LVQPOyRQFftA1VBAj8RmZGEfwQIPSfg_DUg", token);
+    }
+
+    @Test
+    public void bytes_shouldSignIntDate1() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("exp", 123);
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjEyM30.FzAXEHf0LVQPOyRQFftA1VBAj8RmZGEfwQIPSfg_DUg", token);
+    }
+
+    @Test
+    public void shouldSignIntDate2() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("nbf", 0);
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYmYiOjB9.ChHEHjtyr4qOUMu6KDsa2BjGXtkGurboD5ljr99gVzw", token);
+    }
+
+    @Test
+    public void shouldSignIntDate3() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("iat", Long.MAX_VALUE);
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjkyMjMzNzIwMzY4NTQ3NzU4MDd9.7yrsheXoAuqk5hDcbKmT3l6aDNNr7RMnbVe6kVkvv4M", token);
+    }
+
+    @Test
+    public void bytes_shouldSignIntDate2() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("nbf", 0);
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYmYiOjB9.ChHEHjtyr4qOUMu6KDsa2BjGXtkGurboD5ljr99gVzw", token);
+    }
+    
+    @Test
+    public void shouldSignString() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("jti", "foo");
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJmb28ifQ.CriA-W8LKO4bCxy3e2Nu7kx2MxgcHGyFu_GVLMX3bko", token);
+    }
+    
+    @Test
+    public void shouldSignNullEqualsMissing() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        for (String claimName : Arrays.asList("iss", "sub", "aud", "exp", "nbf", "iat", "jti")) {
+            claims.put(claimName, null);
+        }
+        String token = signer.sign(claims);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.86pkOAQxvnSDd91EThNNpOTbO-hbvxdssnFjQqT04NU", token);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectStringOrURI1() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("iss", 0);
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectStringOrURI2() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("sub", ":");
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectStringOrURICollection1() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("aud", 0);
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectStringOrURICollection2() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("aud", Arrays.asList(0));
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectStringOrURICollection3() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("aud", Arrays.asList(":"));
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectIntDate1() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("exp", -1);
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectIntDate2() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("nbf", "100");
+        signer.sign(claims);
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldFailExpectString() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        claims.put("jti", 100);
+        signer.sign(claims);
+    }
+    
+    @Test
+    public void shouldOptionsNone() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        String token = signer.sign(claims, new JWTSigner.Options());
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.86pkOAQxvnSDd91EThNNpOTbO-hbvxdssnFjQqT04NU", token);
+    }
+    
+    @Test
+    public void shouldOptionsAll() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        signer.sign(claims, new JWTSigner.Options()
+                .setExpirySeconds(1000).setNotValidBeforeLeeway(5)
+                .setIssuedAt(true).setJwtId(true));
+    }
+
+    @Test
+    public void shouldOptionsAlgorithm() throws Exception {
+        HashMap<String, Object> claims = new HashMap<String, Object>();
+        String token = signer.sign(claims,
+                new JWTSigner.Options().setAlgorithm(Algorithm.HS512));
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.e30.11MgCe-_uiheyy_kARCwhSZbeq3IkMn40GLQkczQ4Bjn_lkCYfSeqz0HeeYpitksiQ2bW47N0oGKCOYOlmQPyg", token);
+    }
+
+}


### PR DESCRIPTION
The current implementation does not allow using an arbitrary secret (such as a random generated secret that is base64-encoded).

The changes I have added allow using an arbitrary array of bytes as the secret.