### PR TITLE
Replace jackson-databind with jodd-json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
   <dependencies>
     <!-- For JWT parsing-->
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.0.1</version>
+      <groupId>org.jodd</groupId>
+      <artifactId>jodd-json</artifactId>
+      <version>3.6.5</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/src/main/java/com/auth0/jwt/JWTAudienceException.java
+++ b/src/main/java/com/auth0/jwt/JWTAudienceException.java
@@ -1,30 +1,29 @@
 package com.auth0.jwt;
 
-import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class JWTAudienceException extends JWTVerifyException {
-    private JsonNode audienceNode;
+    private Object audienceNode;
 
-    public JWTAudienceException(JsonNode audienceNode) {
+    public JWTAudienceException(Object audienceNode) {
         this.audienceNode = audienceNode;
     }
 
-    public JWTAudienceException(String message, JsonNode audienceNode) {
+    public JWTAudienceException(String message, Object audienceNode) {
         super(message);
         this.audienceNode = audienceNode;
     }
 
     public List<String> getAudience() {
         ArrayList<String> audience = new ArrayList<String>();
-        if (audienceNode.isArray()) {
-            for (JsonNode jsonNode : audienceNode) {
-                audience.add(jsonNode.textValue());
+        if (audienceNode instanceof List) {
+            for (Object jsonNode : (List)audienceNode) {
+                audience.add(jsonNode.toString());
             }
-        } else if (audienceNode.isTextual()) {
-            audience.add(audienceNode.textValue());
+        } else if (audienceNode instanceof String) {
+            audience.add((String)audienceNode);
         }
         return audience;
     }

--- a/src/main/java/com/auth0/jwt/JWTSigner.java
+++ b/src/main/java/com/auth0/jwt/JWTSigner.java
@@ -15,11 +15,8 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.naming.OperationNotSupportedException;
 
+import jodd.json.JsonSerializer;
 import org.apache.commons.codec.binary.Base64;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * JwtSigner implementation based on the Ruby implementation from http://jwt.io
@@ -89,11 +86,11 @@ public class JWTSigner {
         }
 
         // create the header
-        ObjectNode header = JsonNodeFactory.instance.objectNode();
+        Map<String, String> header = new HashMap<String, String>();
         header.put("typ", "JWT");
         header.put("alg", algorithm.name());
 
-        return base64UrlEncode(header.toString().getBytes("UTF-8"));
+        return base64UrlEncode(new JsonSerializer().serialize(header).getBytes("UTF-8"));
     }
 
     /**
@@ -113,7 +110,7 @@ public class JWTSigner {
         if (options != null)
             processPayloadOptions(claims, options);
 
-        String payload = new ObjectMapper().writeValueAsString(claims);
+        String payload = new JsonSerializer().deep(true).serialize(claims);
         return base64UrlEncode(payload.getBytes("UTF-8"));
     }
 

--- a/src/test/java/com/auth0/jwt/JWTSignerTest.java
+++ b/src/test/java/com/auth0/jwt/JWTSignerTest.java
@@ -39,7 +39,7 @@ public class JWTSignerTest {
         HashMap<String, Object> claims = new HashMap<String, Object>();
         claims.put("sub", "http://foo");
         String token = signer.sign(claims);
-        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJodHRwOi8vZm9vIn0.EaYoTXJWUNd_1tWfZo4EZoKUP8hVMJm1LHBQNo4Xfwg", token);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJodHRwOlwvXC9mb28ifQ.JC0PF0tuFXlPzZ2wPGDKLRwg6seFGyVJ-g4mbgNA6E4", token);
     }
     
     @Test
@@ -58,7 +58,7 @@ public class JWTSignerTest {
         aud.add("ftp://foo");
         claims.put("aud", aud);
         String token = signer.sign(claims);
-        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsieHl6IiwiZnRwOi8vZm9vIl19.WGpsdOnLJ2k7Rr4WeEuabHO4wNQIhJfPMZot1DrTUgA", token);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsieHl6IiwiZnRwOlwvXC9mb28iXX0.WcxlzyTdNxy2QH5cDejJIY2D5wzw8FRCHpN8kvCPo94", token);
     }
     
     @Test

--- a/src/test/java/com/auth0/jwt/JWTSignerTest_Bytes.java
+++ b/src/test/java/com/auth0/jwt/JWTSignerTest_Bytes.java
@@ -38,7 +38,7 @@ public class JWTSignerTest_Bytes {
         HashMap<String, Object> claims = new HashMap<String, Object>();
         claims.put("sub", "http://foo");
         String token = signer.sign(claims);
-        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJodHRwOi8vZm9vIn0.EaYoTXJWUNd_1tWfZo4EZoKUP8hVMJm1LHBQNo4Xfwg", token);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJodHRwOlwvXC9mb28ifQ.JC0PF0tuFXlPzZ2wPGDKLRwg6seFGyVJ-g4mbgNA6E4", token);
     }
     
     @Test
@@ -57,7 +57,7 @@ public class JWTSignerTest_Bytes {
         aud.add("ftp://foo");
         claims.put("aud", aud);
         String token = signer.sign(claims);
-        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsieHl6IiwiZnRwOi8vZm9vIl19.WGpsdOnLJ2k7Rr4WeEuabHO4wNQIhJfPMZot1DrTUgA", token);
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsieHl6IiwiZnRwOlwvXC9mb28iXX0.WcxlzyTdNxy2QH5cDejJIY2D5wzw8FRCHpN8kvCPo94", token);
     }
     
     @Test

--- a/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -1,15 +1,15 @@
 package com.auth0.jwt;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import jodd.json.JsonParser;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import java.security.SignatureException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -50,7 +50,7 @@ public class JWTVerifierTest {
 
     @Test(expected = IllegalStateException.class)
     public void shouldFailIfAlgorithmIsNotSetOnToken() throws Exception {
-        new JWTVerifier("such secret").getAlgorithm(JsonNodeFactory.instance.objectNode());
+        new JWTVerifier("such secret").getAlgorithm(Collections.<String, Object>emptyMap());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -115,7 +115,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldVerifyIssuerWhenNotFoundInClaimsSet() throws Exception {
         new JWTVerifier("such secret", "amaze audience", "very issuer")
-                .verifyIssuer(JsonNodeFactory.instance.objectNode());
+                .verifyIssuer(Collections.<String, Object>emptyMap());
     }
 
     @Test
@@ -133,7 +133,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldVerifyAudienceWhenNotFoundInClaimsSet() throws Exception {
         new JWTVerifier("such secret", "amaze audience")
-                .verifyAudience(JsonNodeFactory.instance.objectNode());
+                .verifyAudience(Collections.<String, Object>emptyMap());
     }
 
     @Test
@@ -146,14 +146,14 @@ public class JWTVerifierTest {
     public void shouldVerifyArrayAudience() throws Exception {
         new JWTVerifier("such secret", "amaze audience")
                 .verifyAudience(createSingletonJSONNode("aud",
-                        new ObjectMapper().readValue("[ \"foo\", \"amaze audience\" ]", ArrayNode.class)));
+                        new JsonParser().parse("[ \"foo\", \"amaze audience\" ]", List.class)));
     }
     
     @Test(expected = JWTAudienceException.class)
     public void shouldFailArrayAudience() throws Exception {
         new JWTVerifier("such secret", "amaze audience")
                 .verifyAudience(createSingletonJSONNode("aud",
-                        new ObjectMapper().readValue("[ \"foo\" ]", ArrayNode.class)));
+                        new JsonParser().parse("[ \"foo\" ]", List.class)));
     }
     
     @Test
@@ -162,22 +162,22 @@ public class JWTVerifierTest {
         final String encodedJSON = new String(encoder.encode("{\"some\": \"json\", \"number\": 123}".getBytes()));
         final JWTVerifier jwtVerifier = new JWTVerifier("secret", "audience");
 
-        final JsonNode decodedJSON = jwtVerifier.decodeAndParse(encodedJSON);
+        final Map<String, Object> decodedJSON = jwtVerifier.decodeAndParse(encodedJSON);
 
-        assertEquals("json", decodedJSON.get("some").asText());
+        assertEquals("json", decodedJSON.get("some").toString());
         assertEquals(null, decodedJSON.get("unexisting_property"));
-        assertEquals("123", decodedJSON.get("number").asText());
+        assertEquals("123", decodedJSON.get("number").toString());
     }
 
 
-    public static JsonNode createSingletonJSONNode(String key, String value) {
-        final ObjectNode jsonNodes = JsonNodeFactory.instance.objectNode();
-        jsonNodes.put(key, value);
-        return jsonNodes;
+    public static Map<String, Object> createSingletonJSONNode(String key, String value) {
+        Map<String, Object> node = new HashMap<String, Object>();
+        node.put(key, value);
+        return node;
     }
 
-    public static JsonNode createSingletonJSONNode(String key, JsonNode value) {
-        final ObjectNode jsonNodes = JsonNodeFactory.instance.objectNode();
+    public static Map<String, Object> createSingletonJSONNode(String key, Object value) {
+        final Map<String, Object> jsonNodes = new HashMap<String, Object>();
         jsonNodes.put(key, value);
         return jsonNodes;
     }


### PR DESCRIPTION
Replaces jackson-databind with [jodd-json].

The motivation behind this is to reduce the likeliness of
a version conflict in existing applications. Jackson is
one of the most common JSON libraries out there, but it has
some severe issues when multiple versions are available on the
classpath.

jodd-json is a small JSON parser/serializer library with a minimal
footprint. The resulting shaded jar of java-jwt is about half the size
compared to when its bundled with jackson-databind.

The patch has a bad side effect in that it created different tokens
than the jackson-bind implementation, since it escapes all the
characters defined in RFC4627, while jackson-databind only escapes
the MUST characters. This is visible in the test cases that include
"/" in the claim values.

Another "bad" effect is the use of Map<String, Object>, and Object
references. I've tried to add the needed type checks, but there
might dragons left to slay.

This commit should fix issue #18 and similar multiple jackson versions
issues that might be out there is the wild.

The pull request needs a fair bit a review, as I'm not that familiar with either JWT or this particular implementation of it. 

[jodd-json]: http://jodd.org/doc/json/