### PR TITLE
JWTVerifier was creating a URL safe base 64 decoder but wasn't using it ...

### DIFF
--- a/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -1,24 +1,21 @@
 package com.auth0.jwt;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.apache.commons.codec.binary.Base64;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * JWT Java Implementation
@@ -119,7 +116,7 @@ public class JWTVerifier {
         hmac.init(new SecretKeySpec(secret, algorithm));
         byte[] sig = hmac.doFinal(new StringBuilder(pieces[0]).append(".").append(pieces[1]).toString().getBytes());
 
-        if (!MessageDigest.isEqual(sig, decoder.decodeBase64(pieces[2]))) {
+        if (!MessageDigest.isEqual(sig, decoder.decode(pieces[2]))) {
             throw new SignatureException("signature verification failed");
         }
     }
@@ -173,7 +170,7 @@ public class JWTVerifier {
     }
 
     JsonNode decodeAndParse(String b64String) throws IOException {
-        String jsonString = new String(decoder.decodeBase64(b64String), "UTF-8");
+        String jsonString = new String(decoder.decode(b64String), "UTF-8");
         JsonNode jwtHeader = mapper.readValue(jsonString, JsonNode.class);
         return jwtHeader;
     }


### PR DESCRIPTION
...as it was using the non URL safe static methods on Base64.

I'm assuming here that these things are wanted to be decoded URL safe.