### PR TITLE
Remove dependency on commons-codec.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,6 @@
       <version>2.0.1</version>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.4</version>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/src/main/java/com/auth0/jwt/Base64.java
+++ b/src/main/java/com/auth0/jwt/Base64.java
@@ -1,0 +1,37 @@
+package com.auth0.jwt;
+
+import com.fasterxml.jackson.core.Base64Variants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Created by Chris Thielen on 4/21/15.
+ * MIT License
+ */
+public class Base64 {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static String encodeBase64URLSafe(byte[] binaryData) {
+        return Base64Variants.MODIFIED_FOR_URL.encode(binaryData);
+    }
+
+    public static byte[] decodeBase64(String base64String) {
+        int missingPadCount = base64String.length() % 4;
+        String pad;
+        switch (missingPadCount) {
+            case 1:
+                pad = "==="; break;
+            case 2:
+                pad = "=="; break;
+            case 3:
+                pad = "="; break;
+            default:
+                pad = "";
+        }
+        base64String = base64String.replaceAll("-", "+").replaceAll("_", "/");
+        if (missingPadCount > 0) {
+            base64String += pad;
+        }
+
+        return mapper.convertValue(base64String, byte[].class);
+    }
+}

--- a/src/main/java/com/auth0/jwt/JWTSigner.java
+++ b/src/main/java/com/auth0/jwt/JWTSigner.java
@@ -15,8 +15,6 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.naming.OperationNotSupportedException;
 
-import org.apache.commons.codec.binary.Base64;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -3,8 +3,6 @@ package com.auth0.jwt;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.codec.binary.Base64;
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -30,7 +28,7 @@ public class JWTVerifier {
     private final byte[] secret;
     private final String audience;
     private final String issuer;
-    private final Base64 decoder = new Base64(true);;
+    private final Base64 decoder = new Base64();;
 
     private final ObjectMapper mapper;
 

--- a/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import java.security.SignatureException;
@@ -14,10 +13,7 @@ import java.security.SignatureException;
 import static org.junit.Assert.assertEquals;
 
 public class JWTVerifierTest {
-	
-	private static final Base64 decoder = new Base64(true);;
 
-    
 	@Test(expected = IllegalArgumentException.class)
     public void constructorShouldFailOnEmptySecret() {
         new JWTVerifier("");
@@ -83,7 +79,7 @@ public class JWTVerifierTest {
                 "cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
                 "." +
                 "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-        byte[] secret = decoder.decodeBase64("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
+        byte[] secret = Base64.decodeBase64("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
         new JWTVerifier(secret, "audience")
                 .verifySignature(jws.split("\\."), "HmacSHA256");
     }
@@ -158,8 +154,7 @@ public class JWTVerifierTest {
     
     @Test
     public void decodeAndParse() throws Exception {
-        final Base64 encoder = new Base64(true);
-        final String encodedJSON = new String(encoder.encode("{\"some\": \"json\", \"number\": 123}".getBytes()));
+        final String encodedJSON = Base64.encodeBase64URLSafe("{\"some\": \"json\", \"number\": 123}".getBytes());
         final JWTVerifier jwtVerifier = new JWTVerifier("secret", "audience");
 
         final JsonNode decodedJSON = jwtVerifier.decodeAndParse(encodedJSON);

--- a/src/test/java/com/auth0/jwt/RoundtripTest.java
+++ b/src/test/java/com/auth0/jwt/RoundtripTest.java
@@ -7,7 +7,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 /**
@@ -105,7 +104,7 @@ public class RoundtripTest {
         assertTrue(iat >= System.currentTimeMillis() / 1000l);
         assertTrue(iat < System.currentTimeMillis() / 1000l + 10);
     }
-    
+
     @Test
     public void shouldOptionsTimestamps() throws Exception {
         HashMap<String, Object> claims = new HashMap<String, Object>();


### PR DESCRIPTION
I see there's already some discussion regarding whether or not it's a good idea to keep Jackson as a dependency.  Considering it currently is a dependency, however, it's worth noting that Jackson also provides Base64 en/decoding.  This PR removes the commons-codec dependency and replaces the en/decode calls with a small Base64 class that delegates to Jackson.

All current tests pass.  

I'm packaging and deploying original-java-jwt.jar (no dependencies rolled in via shade) into my app.  I don't really want a dependency on commons-codec, thus the motivation for this.  It's just a thought :+1: 