### PR TITLE
Return the decoded value directly

### DIFF
--- a/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -171,7 +171,6 @@ public class JWTVerifier {
 
     JsonNode decodeAndParse(String b64String) throws IOException {
         String jsonString = new String(decoder.decode(b64String), "UTF-8");
-        JsonNode jwtHeader = mapper.readValue(jsonString, JsonNode.class);
-        return jwtHeader;
+        return mapper.readValue(jsonString, JsonNode.class);
     }
 }


### PR DESCRIPTION
This is just a nit, but since decodeAndParse is used to parse both the header and the payload it makes sense to have a more generic result name.  Even better, the local variable is not required and can be omitted.