### PR TITLE
Change group name for commons-io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
     </dependency>


### PR DESCRIPTION
The ```commons-io``` dependency changed the group id, so I updated the dependency to the new one.

Background is, that we ran into some problems with Gradle and Eclipse, because of these relocation section in the original `pom.xml`.