### PR TITLE
Upgrade commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
+      <version>2.5</version>
     </dependency>
 
     <!-- test -->


### PR DESCRIPTION
Your commons-io version is very old and is conflicting with other libraries we have.  Any chance for an upgrade?
