### PR TITLE
Update Shade to use commons-io instead of org.apache.commons.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
                   <shadedPattern>${repackage.base}.org.apache.commons.codec</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.commons.io</pattern>
-                  <shadedPattern>${repackage.base}.org.apache.commons.io</shadedPattern>
+                  <pattern>commons-io</pattern>
+                  <shadedPattern>${repackage.base}.commons-io</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons.lang3</pattern>


### PR DESCRIPTION
commons-io appears to have had it's groupId changed from `org.apache.commons.io` to `commons-io`, but shade was not updated.