### PR TITLE
Pass caught Exception directly to RuntimeException

### DIFF
--- a/src/main/java/com/auth0/jwt/JWTSigner.java
+++ b/src/main/java/com/auth0/jwt/JWTSigner.java
@@ -77,7 +77,7 @@ public class JWTSigner {
             segments.add(encodedSignature(join(segments, "."), algorithm));
             return join(segments, ".");
         } catch (Exception e) {
-            throw new RuntimeException(e.getCause());
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
The Exception that has been caught should be wrapped by RuntimeException. By calling 'getCause', you're looking further up the chain for a cause, and the resulting value could be `null`.
