### PR TITLE
Add Custom Claims support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,31 @@ String id = jwt.getId();
 
 ### Private Claims
 
-Additional Claims defined in the token can be obtained by calling `getClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found.
+Additional Claims defined in the token can be obtained by calling `getClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You should always check for null values.
 
 ```java
 Claim claim = jwt.getClaim("isAdmin");
 ```
+
+When creating a Token with the `JWT.create()` you can specify a custom Claim by calling `withClaim()` and passing both the name and the value.
+
+```java
+JWT.create()
+    .withClaim("name", 123)
+    .sign(Algorithm.HMAC256("secret"));
+```
+
+You can also verify custom Claims on the `JWT.require()` by calling `withClaim()` and passing both the name and the required value.
+
+```java
+JWT.require(Algorithm.HMAC256("secret"))
+    .withClaim("name", 123)
+    .build()
+    .verify("my.jwt.token");
+```
+
+> The value of the custom Claim in all the cases must be of a `Integer`, `Double`, `Date`, `String`, or `Boolean` class.
+
 
 ### Claim Class
 The Claim class is a wrapper for the Claim values. It allows you to get the Claim as different class types. The available helpers are:
@@ -222,7 +242,7 @@ The Claim class is a wrapper for the Claim values. It allows you to get the Clai
 * **asInt()**: Returns the Integer value or null if it can't be converted.
 * **asDouble()**: Returns the Double value or null if it can't be converted.
 * **asString()**: Returns the String value or null if it can't be converted.
-* **asDate()**: Returns the Date value or null if it can't be converted. Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
+* **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
 
 #### Collections
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -141,6 +141,28 @@ class JWTCreator {
         }
 
         /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name
+         * @param value the Claim's value. Must be an instance of Integer, Double, Boolean, Date or String class.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null or the value class is not allowed.
+         */
+        public Builder withClaim(String name, Object value) throws IllegalArgumentException {
+            final boolean validValue = value instanceof Integer || value instanceof Double ||
+                    value instanceof Boolean || value instanceof Date || value instanceof String;
+            if (name == null) {
+                throw new IllegalArgumentException("The Custom Claim's name can't be null.");
+            }
+            if (!validValue) {
+                throw new IllegalArgumentException("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
+            }
+
+            addClaim(name, value);
+            return this;
+        }
+
+        /**
          * Creates a new instance of the JWT with the specified payloadClaims.
          *
          * @param algorithm the Algorithm to use on the JWT signing.

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -3,9 +3,12 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
+import com.auth0.jwt.impl.ClaimsHolder;
+import com.auth0.jwt.impl.PayloadSerializer;
 import com.auth0.jwt.impl.PublicClaims;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.codec.binary.Base64;
 
 import java.util.Date;
@@ -24,8 +27,12 @@ class JWTCreator {
     private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims) throws JWTCreationException {
         this.algorithm = algorithm;
         try {
-            headerJson = toSafeJson(headerClaims);
-            payloadJson = toSafeJson(payloadClaims);
+            ObjectMapper mapper = new ObjectMapper();
+            SimpleModule module = new SimpleModule();
+            module.addSerializer(ClaimsHolder.class, new PayloadSerializer());
+            mapper.registerModule(module);
+            headerJson = mapper.writeValueAsString(headerClaims);
+            payloadJson = mapper.writeValueAsString(new ClaimsHolder(payloadClaims));
         } catch (JsonProcessingException e) {
             throw new JWTCreationException("Some of the Claims couldn't be converted to a valid JSON format.", e);
         }
@@ -89,12 +96,7 @@ class JWTCreator {
          * @return this same Builder instance.
          */
         public Builder withAudience(String[] audience) {
-            //FIXME: Use a custom Serializer
-            if (audience.length == 1) {
-                addClaim(PublicClaims.AUDIENCE, audience[0]);
-            } else if (audience.length > 1) {
-                addClaim(PublicClaims.AUDIENCE, audience);
-            }
+            addClaim(PublicClaims.AUDIENCE, audience);
             return this;
         }
 
@@ -104,7 +106,7 @@ class JWTCreator {
          * @return this same Builder instance.
          */
         public Builder withExpiresAt(Date expiresAt) {
-            addClaim(PublicClaims.EXPIRES_AT, dateToSeconds(expiresAt));
+            addClaim(PublicClaims.EXPIRES_AT, expiresAt);
             return this;
         }
 
@@ -114,7 +116,7 @@ class JWTCreator {
          * @return this same Builder instance.
          */
         public Builder withNotBefore(Date notBefore) {
-            addClaim(PublicClaims.NOT_BEFORE, dateToSeconds(notBefore));
+            addClaim(PublicClaims.NOT_BEFORE, notBefore);
             return this;
         }
 
@@ -124,7 +126,7 @@ class JWTCreator {
          * @return this same Builder instance.
          */
         public Builder withIssuedAt(Date issuedAt) {
-            addClaim(PublicClaims.ISSUED_AT, dateToSeconds(issuedAt));
+            addClaim(PublicClaims.ISSUED_AT, issuedAt);
             return this;
         }
 
@@ -154,11 +156,6 @@ class JWTCreator {
             return new JWTCreator(algorithm, headerClaims, payloadClaims).sign();
         }
 
-        private int dateToSeconds(Date date) {
-            //FIXME: Use a custom Serializer
-            return (int) (date.getTime() / 1000);
-        }
-
         private void addClaim(String name, Object value) {
             if (value == null) {
                 payloadClaims.remove(name);
@@ -166,11 +163,6 @@ class JWTCreator {
             }
             payloadClaims.put(name, value);
         }
-    }
-
-    private String toSafeJson(Map<String, Object> claims) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(claims);
     }
 
     private String sign() throws SignatureGenerationException {

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -16,7 +16,7 @@ final class JWTVerifier {
     final Map<String, Object> claims;
     private final Clock clock;
 
-    private JWTVerifier(Algorithm algorithm, Map<String, Object> claims, Clock clock) {
+    JWTVerifier(Algorithm algorithm, Map<String, Object> claims, Clock clock) {
         this.algorithm = algorithm;
         this.claims = Collections.unmodifiableMap(claims);
         this.clock = clock;

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -3,6 +3,7 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.*;
 import com.auth0.jwt.impl.PublicClaims;
+import com.auth0.jwt.interfaces.Claim;
 import org.apache.commons.codec.binary.Base64;
 
 import java.util.*;
@@ -53,6 +54,7 @@ final class JWTVerifier {
         /**
          * Require a specific Issuer ("iss") claim.
          *
+         * @param issuer the required Issuer value
          * @return this same Verification instance.
          */
         public Verification withIssuer(String issuer) {
@@ -63,6 +65,7 @@ final class JWTVerifier {
         /**
          * Require a specific Subject ("sub") claim.
          *
+         * @param subject the required Subject value
          * @return this same Verification instance.
          */
         public Verification withSubject(String subject) {
@@ -73,6 +76,7 @@ final class JWTVerifier {
         /**
          * Require a specific Audience ("aud") claim.
          *
+         * @param audience the required Audience value
          * @return this same Verification instance.
          */
         public Verification withAudience(String[] audience) {
@@ -147,10 +151,33 @@ final class JWTVerifier {
         /**
          * Require a specific JWT Id ("jti") claim.
          *
+         * @param jwtId the required Id value
          * @return this same Verification instance.
          */
         public Verification withJWTId(String jwtId) {
             requireClaim(PublicClaims.JWT_ID, jwtId);
+            return this;
+        }
+
+        /**
+         * Require a specific Claim value.
+         *
+         * @param name the Claim's name
+         * @param value the Claim's value. Must be an instance of Integer, Double, Boolean, Date or String class.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null or the value class is not allowed.
+         */
+        public Verification withClaim(String name, Object value) throws IllegalArgumentException {
+            final boolean validValue = value instanceof Integer || value instanceof Double ||
+                    value instanceof Boolean || value instanceof Date || value instanceof String;
+            if (name == null) {
+                throw new IllegalArgumentException("The Custom Claim's name can't be null.");
+            }
+            if (!validValue) {
+                throw new IllegalArgumentException("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
+            }
+
+            requireClaim(name, value);
             return this;
         }
 
@@ -227,35 +254,81 @@ final class JWTVerifier {
 
     private void verifyClaims(JWT jwt, Map<String, Object> claims) {
         for (Map.Entry<String, Object> entry : claims.entrySet()) {
-            assertValidClaim(jwt, entry.getKey(), entry.getValue());
+            switch (entry.getKey()) {
+                case PublicClaims.AUDIENCE:
+                    assertValidAudienceClaim(jwt.getAudience(), (String[]) entry.getValue());
+                    break;
+                case PublicClaims.EXPIRES_AT:
+                    assertValidDateClaim(jwt.getExpiresAt(), (Long) entry.getValue(), true);
+                    break;
+                case PublicClaims.ISSUED_AT:
+                    assertValidDateClaim(jwt.getIssuedAt(), (Long) entry.getValue(), false);
+                    break;
+                case PublicClaims.NOT_BEFORE:
+                    assertValidDateClaim(jwt.getNotBefore(), (Long) entry.getValue(), false);
+                    break;
+                case PublicClaims.ISSUER:
+                    assertValidStringClaim(entry.getKey(), jwt.getIssuer(), (String) entry.getValue());
+                    break;
+                case PublicClaims.JWT_ID:
+                    assertValidStringClaim(entry.getKey(), jwt.getId(), (String) entry.getValue());
+                    break;
+                case PublicClaims.SUBJECT:
+                    assertValidStringClaim(entry.getKey(), jwt.getSubject(), (String) entry.getValue());
+                    break;
+                default:
+                    assertValidClaim(jwt.getClaim(entry.getKey()), entry.getKey(), entry.getValue());
+                    break;
+            }
         }
     }
 
-    private void assertValidClaim(JWT jwt, String claimName, Object expectedValue) throws InvalidClaimException {
-        String errMessage = String.format("The Claim '%s' value doesn't match the required one.", claimName);
-        boolean isValid;
-        if (PublicClaims.AUDIENCE.equals(claimName)) {
-            isValid = Arrays.equals(jwt.getAudience(), (String[]) expectedValue);
-        } else if (PublicClaims.NOT_BEFORE.equals(claimName) || PublicClaims.EXPIRES_AT.equals(claimName) || PublicClaims.ISSUED_AT.equals(claimName)) {
-            long deltaValue = (long) expectedValue;
-            Date today = clock.getToday();
-            Date date = jwt.getClaim(claimName).asDate();
-            if (PublicClaims.EXPIRES_AT.equals(claimName)) {
-                today.setTime(today.getTime() - deltaValue);
-                isValid = date == null || !today.after(date);
-                errMessage = String.format("The Token has expired on %s.", date);
-            } else {
-                today.setTime(today.getTime() + deltaValue);
-                isValid = date == null || !today.before(date);
-                errMessage = String.format("The Token can't be used before %s.", date);
-            }
-        } else {
-            String stringValue = (String) expectedValue;
-            isValid = stringValue.equals(jwt.getClaim(claimName).asString());
+    private void assertValidClaim(Claim claim, String claimName, Object value) {
+        boolean isValid = false;
+        if (value instanceof String) {
+            isValid = value.equals(claim.asString());
+        } else if (value instanceof Integer) {
+            isValid = value.equals(claim.asInt());
+        } else if (value instanceof Boolean) {
+            isValid = value.equals(claim.asBoolean());
+        } else if (value instanceof Double) {
+            isValid = value.equals(claim.asDouble());
+        } else if (value instanceof Date) {
+            isValid = value.equals(claim.asDate());
         }
 
         if (!isValid) {
+            throw new InvalidClaimException(String.format("The Claim '%s' value doesn't match the required one.", claimName));
+        }
+    }
+
+    private void assertValidStringClaim(String claimName, String value, String expectedValue) {
+        if (!expectedValue.equals(value)) {
+            throw new InvalidClaimException(String.format("The Claim '%s' value doesn't match the required one.", claimName));
+        }
+    }
+
+    private void assertValidDateClaim(Date date, long delta, boolean shouldBeFuture) {
+        Date today = clock.getToday();
+        boolean isValid;
+        String errMessage;
+        if (shouldBeFuture) {
+            today.setTime(today.getTime() - delta);
+            isValid = date == null || !today.after(date);
+            errMessage = String.format("The Token has expired on %s.", date);
+        } else {
+            today.setTime(today.getTime() + delta);
+            isValid = date == null || !today.before(date);
+            errMessage = String.format("The Token can't be used before %s.", date);
+        }
+        if (!isValid) {
             throw new InvalidClaimException(errMessage);
+        }
+    }
+
+    private void assertValidAudienceClaim(String[] audience, String[] value) {
+        if (!Arrays.equals(audience, value)) {
+            throw new InvalidClaimException("The Claim 'aud' value doesn't match the required one.");
         }
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/ClaimsHolder.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/ClaimsHolder.java
@@ -1,0 +1,19 @@
+package com.auth0.jwt.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The ClaimsHolder class is just a wrapper for the Map of Claims.
+ */
+public final class ClaimsHolder {
+    private Map<String, Object> claims;
+
+    public ClaimsHolder(Map<String, Object> claims) {
+        this.claims = claims == null ? new HashMap<String, Object>() : claims;
+    }
+
+    Map<String, Object> getClaims() {
+        return claims;
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -35,16 +35,16 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         String issuer = getString(tree, PublicClaims.ISSUER);
         String subject = getString(tree, PublicClaims.SUBJECT);
         String[] audience = getStringOrArray(tree, PublicClaims.AUDIENCE);
-        Date expiresAt = getDate(tree, PublicClaims.EXPIRES_AT);
-        Date notBefore = getDate(tree, PublicClaims.NOT_BEFORE);
-        Date issuedAt = getDate(tree, PublicClaims.ISSUED_AT);
+        Date expiresAt = getDateFromSeconds(tree, PublicClaims.EXPIRES_AT);
+        Date notBefore = getDateFromSeconds(tree, PublicClaims.NOT_BEFORE);
+        Date issuedAt = getDateFromSeconds(tree, PublicClaims.ISSUED_AT);
         String jwtId = getString(tree, PublicClaims.JWT_ID);
 
         return new PayloadImpl(issuer, subject, audience, expiresAt, notBefore, issuedAt, jwtId, tree);
     }
 
     String[] getStringOrArray(Map<String, JsonNode> tree, String claimName) throws JWTDecodeException {
-        JsonNode node = tree.get(claimName);
+        JsonNode node = tree.remove(claimName);
         if (node == null || node.isNull() || !(node.isArray() || node.isTextual())) {
             return null;
         }
@@ -64,8 +64,8 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         return arr;
     }
 
-    Date getDate(Map<String, JsonNode> tree, String claimName) {
-        JsonNode node = tree.get(claimName);
+    Date getDateFromSeconds(Map<String, JsonNode> tree, String claimName) {
+        JsonNode node = tree.remove(claimName);
         if (node == null || node.isNull() || !node.canConvertToLong()) {
             return null;
         }
@@ -74,7 +74,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {
-        JsonNode node = tree.get(claimName);
+        JsonNode node = tree.remove(claimName);
         if (node == null || node.isNull()) {
             return null;
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -39,16 +39,22 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
                 case PublicClaims.EXPIRES_AT:
                 case PublicClaims.ISSUED_AT:
                 case PublicClaims.NOT_BEFORE:
-                    Date date = (Date) e.getValue();
-                    int seconds = (int) (date.getTime() / 1000);
-                    safePayload.put(e.getKey(), seconds);
+                    safePayload.put(e.getKey(), dateToSeconds((Date) e.getValue()));
                     break;
                 default:
-                    safePayload.put(e.getKey(), e.getValue());
+                    if (e.getValue() instanceof Date) {
+                        safePayload.put(e.getKey(), dateToSeconds((Date) e.getValue()));
+                    } else {
+                        safePayload.put(e.getKey(), e.getValue());
+                    }
                     break;
             }
         }
 
         gen.writeObject(safePayload);
+    }
+
+    private int dateToSeconds(Date date) {
+        return (int) (date.getTime() / 1000);
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -1,0 +1,54 @@
+package com.auth0.jwt.impl;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
+
+    public PayloadSerializer() {
+        this(null);
+    }
+
+    private PayloadSerializer(Class<ClaimsHolder> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(ClaimsHolder holder, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        HashMap<Object, Object> safePayload = new HashMap<>();
+        for (Map.Entry<String, Object> e : holder.getClaims().entrySet()) {
+            switch (e.getKey()) {
+                case PublicClaims.AUDIENCE:
+                    if (e.getValue() instanceof String) {
+                        safePayload.put(e.getKey(), e.getValue());
+                        break;
+                    }
+                    String[] audArray = (String[]) e.getValue();
+                    if (audArray.length == 1) {
+                        safePayload.put(e.getKey(), audArray[0]);
+                    } else if (audArray.length > 1) {
+                        safePayload.put(e.getKey(), audArray);
+                    }
+                    break;
+                case PublicClaims.EXPIRES_AT:
+                case PublicClaims.ISSUED_AT:
+                case PublicClaims.NOT_BEFORE:
+                    Date date = (Date) e.getValue();
+                    int seconds = (int) (date.getTime() / 1000);
+                    safePayload.put(e.getKey(), seconds);
+                    break;
+                default:
+                    safePayload.put(e.getKey(), e.getValue());
+                    break;
+            }
+        }
+
+        gen.writeObject(safePayload);
+    }
+}

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -117,7 +117,6 @@ public class JWTCreatorTest {
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJqdGkiOiJqd3RfaWRfMTIzIn0"));
     }
 
-
     @Test
     public void shouldRemoveClaimWhenPassingNull() throws Exception {
         String signed = JWTCreator.init()
@@ -144,6 +143,78 @@ public class JWTCreatorTest {
                 .sign(Algorithm.none());
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[2], is(""));
+    }
+
+    @Test
+    public void shouldThrowOnNullCustomClaimName() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Custom Claim's name can't be null.");
+        JWTCreator.init()
+                .withClaim(null, "value");
+    }
+
+    @Test
+    public void shouldThrowOnIllegalCustomClaimValueClass() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
+        JWTCreator.init()
+                .withClaim("name", new Object());
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeString() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", "value")
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoidmFsdWUifQ.4qDWJcNQHDVDW1iAcIgZNiu-qqJQ0RIq8X3ETijBx5k";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeInteger() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", 123)
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoxMjN9.5i6ga8YMteicIeZrFZgJyW4OnI_2jpMaUXcDt-_jme4";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeDouble() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", 23.45)
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoyMy40NX0.aFNlMk3WiikukJq1jo4Tf8ztR180wjTfSpqec0xKKqU";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeBoolean() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", true)
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp0cnVlfQ.jseAYuhVmT1boYrHQfn9wXmomWq_tdGfphLtG_2tj_M";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
+        Date date = new Date(1478891521000L);
+        String jwt = JWTCreator.init()
+                .withClaim("name", date)
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.ZU1B1pDLYoJZhWD8h3_QsK5dViolxvL5Q43Yz9QIxL4";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
     }
 
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -110,6 +110,134 @@ public class JWTVerifierTest {
                 .verify(token);
     }
 
+    @Test
+    public void shouldThrowOnNullCustomClaimName() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Custom Claim's name can't be null.");
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim(null, "value");
+    }
+
+    @Test
+    public void shouldThrowOnIllegalCustomClaimValueClass() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", new Object());
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeString() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", "value")
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeInteger() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", 123)
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeDouble() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", 23.45)
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeBoolean() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", true)
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", new Date())
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeString() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidmFsdWUifQ.Jki8pvw6KGbxpMinufrgo6RDL1cu7AtNMJYVh6t-_cE";
+        JWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", "value")
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeInteger() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxMjN9.XZAudnA7h3_Al5kJydzLjw6RzZC3Q6OvnLEYlhNW7HA";
+        JWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", 123)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeDouble() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoyMy40NX0.7pyX2OmEGaU9q15T8bGFqRm-d3RVTYnqmZNZtxMKSlA";
+        JWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", 23.45)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeBoolean() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjp0cnVlfQ.FwQ8VfsZNRqBa9PXMinSIQplfLU4-rkCLfIlTLg_MV0";
+        JWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", true)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeDate() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
+        Date date = new Date(1478891521000L);
+        JWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", date)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+
     // Generic Delta
     @Test
     public void shouldAddDefaultTimeDeltaToDateClaims() throws Exception {

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -170,6 +172,7 @@ public class JWTVerifierTest {
                 .verify(token);
     }
 
+
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() throws Exception {
         exception.expect(InvalidClaimException.class);
@@ -179,6 +182,17 @@ public class JWTVerifierTest {
                 .withClaim("name", new Date())
                 .build()
                 .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValue() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", new Object());
+        JWTVerifier verifier = new JWTVerifier(Algorithm.HMAC256("secret"), map, new Clock());
+        verifier.verify(token);
     }
 
     @Test
@@ -239,6 +253,7 @@ public class JWTVerifierTest {
 
 
     // Generic Delta
+    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldAddDefaultTimeDeltaToDateClaims() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
@@ -251,6 +266,7 @@ public class JWTVerifierTest {
         assertThat(verifier.claims, hasEntry("nbf", (Object) 0L));
     }
 
+    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldAddCustomTimeDeltaToDateClaims() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
@@ -264,6 +280,7 @@ public class JWTVerifierTest {
         assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
     }
 
+    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldOverrideDefaultIssuedAtTimeDelta() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
@@ -278,6 +295,7 @@ public class JWTVerifierTest {
         assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
     }
 
+    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldOverrideDefaultExpiresAtTimeDelta() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
@@ -292,6 +310,7 @@ public class JWTVerifierTest {
         assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
     }
 
+    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldOverrideDefaultNotBeforeTimeDelta() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);

--- a/lib/src/test/java/com/auth0/jwt/impl/ClaimImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/ClaimImplTest.java
@@ -5,6 +5,8 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -200,6 +202,26 @@ public class ClaimImplTest {
 
         exception.expect(JWTDecodeException.class);
         claim.asList(UserPojo.class);
+    }
+
+    @Test
+    public void shouldReturnBaseClaimWhenParsingMissingNode() throws Exception {
+        JsonNode value = MissingNode.getInstance();
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim, is(notNullValue()));
+        assertThat(claim, is(instanceOf(BaseClaim.class)));
+        assertThat(claim.isNull(), is(true));
+    }
+
+    @Test
+    public void shouldReturnBaseClaimWhenParsingNullNode() throws Exception {
+        JsonNode value = NullNode.getInstance();
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim, is(notNullValue()));
+        assertThat(claim, is(instanceOf(BaseClaim.class)));
+        assertThat(claim.isNull(), is(true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/ClaimsHolderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/ClaimsHolderTest.java
@@ -1,0 +1,33 @@
+package com.auth0.jwt.impl;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class ClaimsHolderTest {
+
+    @SuppressWarnings("RedundantCast")
+    @Test
+    public void shouldGetClaims() throws Exception {
+        HashMap<String, Object> claims = new HashMap<>();
+        claims.put("iss", "auth0");
+        ClaimsHolder holder = new ClaimsHolder(claims);
+        assertThat(holder, is(notNullValue()));
+        assertThat(holder.getClaims(), is(notNullValue()));
+        assertThat(holder.getClaims(), is(instanceOf(Map.class)));
+        assertThat(holder.getClaims(), is(IsMapContaining.hasEntry("iss", (Object) "auth0")));
+    }
+
+    @Test
+    public void shouldGetNotNullClaims() throws Exception {
+        ClaimsHolder holder = new ClaimsHolder(null);
+        assertThat(holder, is(notNullValue()));
+        assertThat(holder.getClaims(), is(notNullValue()));
+        assertThat(holder.getClaims(), is(instanceOf(Map.class)));
+    }
+}

--- a/lib/src/test/java/com/auth0/jwt/impl/HeaderImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/HeaderImplTest.java
@@ -1,7 +1,9 @@
 package com.auth0.jwt.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -18,10 +20,28 @@ public class HeaderImplTest {
 
     @SuppressWarnings("Convert2Diamond")
     @Test
-    public void shouldHaveUnmodifiableTree() throws Exception {
+    public void shouldHaveUnmodifiableTreeWhenInstantiatedWithNonNullTree() throws Exception {
         exception.expect(UnsupportedOperationException.class);
         HeaderImpl header = new HeaderImpl(new HashMap<String, JsonNode>());
         header.getTree().put("something", null);
+    }
+
+    @Test
+    public void shouldHaveUnmodifiableTreeWhenInstantiatedWithNullTree() throws Exception {
+        exception.expect(UnsupportedOperationException.class);
+        HeaderImpl header = new HeaderImpl(null);
+        header.getTree().put("something", null);
+    }
+
+    @Test
+    public void shouldHaveTree() throws Exception {
+        HashMap<String, JsonNode> map = new HashMap<>();
+        JsonNode node = NullNode.getInstance();
+        map.put("key", node);
+        HeaderImpl header = new HeaderImpl(map);
+
+        assertThat(header.getTree(), is(notNullValue()));
+        assertThat(header.getTree(), is(IsMapContaining.hasEntry("key", node)));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -138,6 +138,17 @@ public class PayloadDeserializerTest {
     }
 
     @Test
+    public void shouldGetEmptyStringArrayWhenParsingEmptyTextNode() throws Exception {
+        Map<String, JsonNode> tree = new HashMap<>();
+        TextNode textNode = new TextNode("");
+        tree.put("key", textNode);
+
+        String[] values = deserializer.getStringOrArray(tree, "key");
+        assertThat(values, is(notNullValue()));
+        assertThat(values, is(arrayWithSize(0)));
+    }
+
+    @Test
     public void shouldGetNullArrayWhenParsingNullNode() throws Exception {
         Map<String, JsonNode> tree = new HashMap<>();
         NullNode node = NullNode.getInstance();

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -35,9 +35,10 @@ public class PayloadSerializerTest {
         serializerProvider = mapper.getSerializerProvider();
     }
 
+    @SuppressWarnings("Convert2Diamond")
     @Test
     public void shouldSerializeEmptyMap() throws Exception {
-        ClaimsHolder holder = new ClaimsHolder(new HashMap<>());
+        ClaimsHolder holder = new ClaimsHolder(new HashMap<String, Object>());
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -99,12 +100,12 @@ public class PayloadSerializerTest {
     }
 
     @Test
-    public void shouldSerializeCustomDateInMillis() throws Exception {
+    public void shouldSerializeCustomDateInSeconds() throws Exception {
         ClaimsHolder holder = holderFor("birthdate", new Date(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
-        assertThat(writer.toString(), is(equalTo("{\"birthdate\":1478874000}")));
+        assertThat(writer.toString(), is(equalTo("{\"birthdate\":1478874}")));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -1,0 +1,194 @@
+package com.auth0.jwt.impl;
+
+import com.auth0.jwt.UserPojo;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PayloadSerializerTest {
+
+    private StringWriter writer;
+    private PayloadSerializer serializer;
+    private JsonGenerator jsonGenerator;
+    private SerializerProvider serializerProvider;
+
+    @Before
+    public void setUp() throws Exception {
+        writer = new StringWriter();
+        serializer = new PayloadSerializer();
+        jsonGenerator = new JsonFactory().createGenerator(writer);
+        ObjectMapper mapper = new ObjectMapper();
+        jsonGenerator.setCodec(mapper);
+        serializerProvider = mapper.getSerializerProvider();
+    }
+
+    @Test
+    public void shouldSerializeEmptyMap() throws Exception {
+        ClaimsHolder holder = new ClaimsHolder(new HashMap<>());
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{}")));
+    }
+
+    @Test
+    public void shouldSerializeStringAudienceAsString() throws Exception {
+        ClaimsHolder holder = holderFor("aud", "auth0");
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"aud\":\"auth0\"}")));
+    }
+
+    @Test
+    public void shouldSerializeSingleItemAudienceAsArray() throws Exception {
+        ClaimsHolder holder = holderFor("aud", new String[]{"auth0"});
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"aud\":\"auth0\"}")));
+    }
+
+    @Test
+    public void shouldSerializeMultipleItemsAudienceAsArray() throws Exception {
+        ClaimsHolder holder = holderFor("aud", new String[]{"auth0", "auth10"});
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"aud\":[\"auth0\",\"auth10\"]}")));
+    }
+
+    @Test
+    public void shouldSerializeNotBeforeDateInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("nbf", new Date(1478874000));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"nbf\":1478874}")));
+    }
+
+    @Test
+    public void shouldSerializeIssuedAtDateInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("iat", new Date(1478874000));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"iat\":1478874}")));
+    }
+
+    @Test
+    public void shouldSerializeExpiresAtDateInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("exp", new Date(1478874000));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"exp\":1478874}")));
+    }
+
+    @Test
+    public void shouldSerializeCustomDateInMillis() throws Exception {
+        ClaimsHolder holder = holderFor("birthdate", new Date(1478874000));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"birthdate\":1478874000}")));
+    }
+
+    @Test
+    public void shouldSerializeStrings() throws Exception {
+        ClaimsHolder holder = holderFor("name", "Auth0 Inc");
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"name\":\"Auth0 Inc\"}")));
+    }
+
+    @Test
+    public void shouldSerializeIntegers() throws Exception {
+        ClaimsHolder holder = holderFor("number", 12345);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"number\":12345}")));
+    }
+
+    @Test
+    public void shouldSerializeDoubles() throws Exception {
+        ClaimsHolder holder = holderFor("fraction", 23.45);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"fraction\":23.45}")));
+    }
+
+    @Test
+    public void shouldSerializeBooleans() throws Exception {
+        ClaimsHolder holder = holderFor("pro", true);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"pro\":true}")));
+    }
+
+    @Test
+    public void shouldSerializeNulls() throws Exception {
+        ClaimsHolder holder = holderFor("id", null);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"id\":null}")));
+    }
+
+    @Test
+    public void shouldSerializeCustomArrayOfObject() throws Exception {
+        UserPojo user1 = new UserPojo("Michael", 1);
+        UserPojo user2 = new UserPojo("Lucas", 2);
+        ClaimsHolder holder = holderFor("users", new UserPojo[]{user1, user2});
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"users\":[{\"name\":\"Michael\",\"id\":1},{\"name\":\"Lucas\",\"id\":2}]}")));
+    }
+
+    @Test
+    public void shouldSerializeCustomListOfObject() throws Exception {
+        UserPojo user1 = new UserPojo("Michael", 1);
+        UserPojo user2 = new UserPojo("Lucas", 2);
+        ClaimsHolder holder = holderFor("users", Arrays.asList(user1, user2));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"users\":[{\"name\":\"Michael\",\"id\":1},{\"name\":\"Lucas\",\"id\":2}]}")));
+    }
+
+    @Test
+    public void shouldSerializeCustomObject() throws Exception {
+        UserPojo user = new UserPojo("Michael", 1);
+        ClaimsHolder holder = holderFor("users", user);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"users\":{\"name\":\"Michael\",\"id\":1}}")));
+    }
+
+    @SuppressWarnings("Convert2Diamond")
+    private ClaimsHolder holderFor(String key, Object value) {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put(key, value);
+        return new ClaimsHolder(map);
+    }
+
+}

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -73,6 +73,15 @@ public class PayloadSerializerTest {
     }
 
     @Test
+    public void shouldSkipSerializationOnEmptyAudience() throws Exception {
+        ClaimsHolder holder = holderFor("aud", new String[0]);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{}")));
+    }
+
+    @Test
     public void shouldSerializeNotBeforeDateInSeconds() throws Exception {
         ClaimsHolder holder = holderFor("nbf", new Date(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);


### PR DESCRIPTION
Allow to specify custom claims for decoding/verifying and creating/signing a JWT.

When creating a Token with the `JWT.create()` you can specify a custom Claim by calling `withClaim()` and passing both the name and the value.

**The claim value MUST BE an `Integer`, `Double`, `Date`, `String`, or `Boolean` class.**

```java
JWT.create()
        .withClaim("name", 123)
        .sign(Algorithm.HMAC256("secret"));
```

You can also verify custom Claims on the `JWT.require()` by calling `withClaim()` and passing both the name and the required value.

```java
JWT.verify(Algorithm.HMAC256("secret"))
        .withClaim("name", 123)
        .build();
```