### PR TITLE
Allow to obtain the string representation of the token

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/jwt/JWT.java
@@ -117,4 +117,9 @@ public final class JWT implements com.auth0.jwt.interfaces.JWT {
     public String getKeyId() {
         return jwt.getKeyId();
     }
+
+    @Override
+    public String toString() {
+        return jwt.toString();
+    }
 }

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -18,11 +18,13 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 final class JWTDecoder implements JWT {
 
+    private final String token;
     private Header header;
     private Payload payload;
     private String signature;
 
     private JWTDecoder(String jwt) throws JWTDecodeException {
+        this.token = jwt;
         parseToken(jwt);
     }
 
@@ -124,4 +126,8 @@ final class JWTDecoder implements JWT {
         return signature;
     }
 
+    @Override
+    public String toString() {
+        return token;
+    }
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/JWT.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/JWT.java
@@ -4,4 +4,11 @@ package com.auth0.jwt.interfaces;
  * The JWT class represents a Json Web Token.
  */
 public interface JWT extends Payload, Header, Signature {
+
+    /**
+     * Returns the String representation of the token.
+     *
+     * @return the String representation of the token.
+     */
+    String toString();
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -7,7 +7,6 @@ import com.auth0.jwt.interfaces.JWT;
 import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -63,7 +62,6 @@ public class JWTDecoderTest {
 
     // toString
     @Test
-    @Ignore("Pending implementation")
     public void shouldGetStringToken() throws Exception {
         JWT jwt = JWTDecoder.decode("eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ");
         assertThat(jwt, is(notNullValue()));

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -42,6 +42,15 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
     }
 
+    // toString
+    @Test
+    public void shouldGetStringToken() throws Exception {
+        JWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ");
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.toString(), is(notNullValue()));
+        assertThat(jwt.toString(), is("eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ"));
+    }
+
 
     // Verify
 


### PR DESCRIPTION
```java
JWT jwt = JWT.decode("a.b.c");
String token = jwt.toString(); //returns "a.b.c"
```