### PR TITLE
Keep public claims on the tree

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    patch:
+      default:
+        if_no_uploads: error
+    changes: true
+    project:
+      default:
+        target: auto
+        if_no_uploads: error
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+sudo: false
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ String keyId = jwt.getKeyId();
 
 #### Private Claims
 
-Additional Claims defined in the token's Header can be obtained by calling `getHeaderClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You should always check for null values.
+Additional Claims defined in the token's Header can be obtained by calling `getHeaderClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You can check if a Claim's value is null by calling `claim.isNull()`.
 
 ```java
 Claim claim = jwt.getHeaderClaim("owner");
@@ -256,7 +256,7 @@ String id = jwt.getId();
 
 #### Private Claims
 
-Additional Claims defined in the token's Payload can be obtained by calling `getClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You should always check for null values.
+Additional Claims defined in the token's Payload can be obtained by calling `getClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You can check if a Claim's value is null by calling `claim.isNull()`.
 
 ```java
 Claim claim = jwt.getClaim("isAdmin");

--- a/lib/src/main/java/com/auth0/jwt/impl/HeaderDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/HeaderDeserializer.java
@@ -36,7 +36,7 @@ class HeaderDeserializer extends StdDeserializer<BasicHeader> {
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {
-        JsonNode node = tree.remove(claimName);
+        JsonNode node = tree.get(claimName);
         if (node == null || node.isNull()) {
             return null;
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -43,7 +43,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
     }
 
     List<String> getStringOrArray(Map<String, JsonNode> tree, String claimName) throws JWTDecodeException {
-        JsonNode node = tree.remove(claimName);
+        JsonNode node = tree.get(claimName);
         if (node == null || node.isNull() || !(node.isArray() || node.isTextual())) {
             return null;
         }
@@ -64,7 +64,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
     }
 
     Date getDateFromSeconds(Map<String, JsonNode> tree, String claimName) {
-        JsonNode node = tree.remove(claimName);
+        JsonNode node = tree.get(claimName);
         if (node == null || node.isNull() || !node.canConvertToLong()) {
             return null;
         }
@@ -73,7 +73,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {
-        JsonNode node = tree.remove(claimName);
+        JsonNode node = tree.get(claimName);
         if (node == null || node.isNull()) {
             return null;
         }

--- a/lib/src/test/java/com/auth0/jwt/impl/HeaderDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/HeaderDeserializerTest.java
@@ -58,7 +58,7 @@ public class HeaderDeserializerTest {
 
 
     @Test
-    public void shouldRemoveKnownPublicClaimsFromTree() throws Exception {
+    public void shouldNotRemoveKnownPublicClaimsFromTree() throws Exception {
         String headerJSON = "{\n" +
                 "  \"alg\": \"HS256\",\n" +
                 "  \"typ\": \"jws\",\n" +
@@ -80,10 +80,10 @@ public class HeaderDeserializerTest {
         assertThat(header.getKeyId(), is("key"));
 
         assertThat(header.getHeaderClaim("roles").asString(), is("admin"));
-        assertThat(header.getHeaderClaim("alg").isNull(), is(true));
-        assertThat(header.getHeaderClaim("typ").isNull(), is(true));
-        assertThat(header.getHeaderClaim("cty").isNull(), is(true));
-        assertThat(header.getHeaderClaim("kid").isNull(), is(true));
+        assertThat(header.getHeaderClaim("alg").asString(), is("HS256"));
+        assertThat(header.getHeaderClaim("typ").asString(), is("jws"));
+        assertThat(header.getHeaderClaim("cty").asString(), is("content"));
+        assertThat(header.getHeaderClaim("kid").asString(), is("key"));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -71,7 +71,7 @@ public class PayloadDeserializerTest {
     }
 
     @Test
-    public void shouldRemoveKnownPublicClaimsFromTree() throws Exception {
+    public void shouldNotRemoveKnownPublicClaimsFromTree() throws Exception {
         String payloadJSON = "{\n" +
                 "  \"iss\": \"auth0\",\n" +
                 "  \"sub\": \"emails\",\n" +
@@ -99,14 +99,13 @@ public class PayloadDeserializerTest {
         assertThat(payload.getId(), is("idid"));
 
         assertThat(payload.getClaim("roles").asString(), is("admin"));
-        assertThat(payload.getClaim("iss").isNull(), is(true));
-        assertThat(payload.getClaim("sub").isNull(), is(true));
-        assertThat(payload.getClaim("aud").isNull(), is(true));
-        assertThat(payload.getClaim("iat").isNull(), is(true));
-        assertThat(payload.getClaim("exp").isNull(), is(true));
-        assertThat(payload.getClaim("nbf").isNull(), is(true));
-        assertThat(payload.getClaim("jti").isNull(), is(true));
-
+        assertThat(payload.getClaim("iss").asString(), is("auth0"));
+        assertThat(payload.getClaim("sub").asString(), is("emails"));
+        assertThat(payload.getClaim("aud").asString(), is("users"));
+        assertThat(payload.getClaim("iat").asDouble(), is(10101010D));
+        assertThat(payload.getClaim("exp").asDouble(), is(11111111D));
+        assertThat(payload.getClaim("nbf").asDouble(), is(10101011D));
+        assertThat(payload.getClaim("jti").asString(), is("idid"));
     }
 
     @Test


### PR DESCRIPTION
Keep the public claims on the claims tree instead of removing them.