### PR TITLE
Accept Array type on verification and creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,6 @@ JWT.require(Algorithm.HMAC256("secret"))
     .verify("my.jwt.token");
 ```
 
-> The value of the custom Claim in all the cases must be of a `Integer`, `Double`, `Date`, `String`, or `Boolean` class.
-
 
 ### Claim Class
 The Claim class is a wrapper for the Claim values. It allows you to get the Claim as different class types. The available helpers are:
@@ -299,13 +297,14 @@ The Claim class is a wrapper for the Claim values. It allows you to get the Clai
 * **asString()**: Returns the String value or null if it can't be converted.
 * **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
 
-#### Collections
+#### Custom Class and Collections
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.
 
+* **as(class)**: Returns the value parsed as **Class Type**.
 * **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
 * **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
 
-If the values inside the JSON Array can't be converted to the given **Class Type**, a `JWTDecodeException` will raise.
+If the values can't be converted to the given **Class Type** a `JWTDecodeException` will raise.
 
 
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ When creating a Token with the `JWT.create()` you can specify a custom Claim by 
 ```java
 JWT.create()
     .withClaim("name", 123)
+    .withArrayClaim("array", new Integer[]{1, 2, 3})
     .sign(Algorithm.HMAC256("secret"));
 ```
 
@@ -282,11 +283,12 @@ You can also verify custom Claims on the `JWT.require()` by calling `withClaim()
 ```java
 JWT.require(Algorithm.HMAC256("secret"))
     .withClaim("name", 123)
+    .withArrayClaim("array", 1, 2, 3)
     .build()
     .verify("my.jwt.token");
 ```
 
-> Currently supported classes for custom Claim verification are: Boolean, Integer, Double, String, Date and Array of types String and Integer.
+> Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Date and Arrays of type String and Integer.
 
 
 ### Claim Class
@@ -299,7 +301,7 @@ The Claim class is a wrapper for the Claim values. It allows you to get the Clai
 * **asString()**: Returns the String value or null if it can't be converted.
 * **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
 
-#### Custom Class and Collections
+#### Custom Classes and Collections
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.
 
 * **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The Claim class is a wrapper for the Claim values. It allows you to get the Clai
 #### Custom Class and Collections
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.
 
-* **as(class)**: Returns the value parsed as **Class Type**.
+* **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.
 * **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
 * **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ JWT.require(Algorithm.HMAC256("secret"))
     .verify("my.jwt.token");
 ```
 
+> Currently supported classes for custom Claim verification are: Boolean, Integer, Double, String, Date and Array of types String and Integer.
+
 
 ### Claim Class
 The Claim class is a wrapper for the Claim values. It allows you to get the Claim as different class types. The available helpers are:

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -158,12 +158,93 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Object value) throws IllegalArgumentException {
-            if (name == null) {
-                throw new IllegalArgumentException("The Custom Claim's name can't be null.");
-            }
-
+        public Builder withClaim(String name, Boolean value) throws IllegalArgumentException {
+            assertNonNull(name);
             addClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, Integer value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, Double value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, String value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, Date value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Add a custom Array Claim with the given items.
+         *
+         * @param name  the Claim's name.
+         * @param items the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withArrayClaim(String name, String[] items) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, items);
+            return this;
+        }
+
+        /**
+         * Add a custom Array Claim with the given items.
+         *
+         * @param name  the Claim's name.
+         * @param items the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withArrayClaim(String name, Integer[] items) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, items);
             return this;
         }
 
@@ -181,6 +262,12 @@ public final class JWTCreator {
             }
             headerClaims.put(PublicClaims.ALGORITHM, algorithm.getName());
             return new JWTCreator(algorithm, headerClaims, payloadClaims).sign();
+        }
+
+        private void assertNonNull(String name) {
+            if (name == null) {
+                throw new IllegalArgumentException("The Custom Claim's name can't be null.");
+            }
         }
 
         private void addClaim(String name, Object value) {

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -153,19 +153,14 @@ public final class JWTCreator {
         /**
          * Add a custom Claim value.
          *
-         * @param name  the Claim's name
-         * @param value the Claim's value. Must be an instance of Integer, Double, Boolean, Date or String class.
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
          * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null or the value class is not allowed.
+         * @throws IllegalArgumentException if the name is null.
          */
         public Builder withClaim(String name, Object value) throws IllegalArgumentException {
-            final boolean validValue = value instanceof Integer || value instanceof Double ||
-                    value instanceof Boolean || value instanceof Date || value instanceof String;
             if (name == null) {
                 throw new IllegalArgumentException("The Custom Claim's name can't be null.");
-            }
-            if (!validValue) {
-                throw new IllegalArgumentException("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
             }
 
             addClaim(name, value);

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -99,9 +99,7 @@ public final class JWTVerifier {
          * @throws IllegalArgumentException if leeway is negative.
          */
         public Verification acceptLeeway(long leeway) throws IllegalArgumentException {
-            if (leeway < 0) {
-                throw new IllegalArgumentException("Leeway value can't be negative.");
-            }
+            assertPositive(leeway);
             this.defaultLeeway = leeway;
             return this;
         }
@@ -115,9 +113,7 @@ public final class JWTVerifier {
          * @throws IllegalArgumentException if leeway is negative.
          */
         public Verification acceptExpiresAt(long leeway) throws IllegalArgumentException {
-            if (leeway < 0) {
-                throw new IllegalArgumentException("Leeway value can't be negative.");
-            }
+            assertPositive(leeway);
             requireClaim(PublicClaims.EXPIRES_AT, leeway);
             return this;
         }
@@ -131,9 +127,7 @@ public final class JWTVerifier {
          * @throws IllegalArgumentException if leeway is negative.
          */
         public Verification acceptNotBefore(long leeway) throws IllegalArgumentException {
-            if (leeway < 0) {
-                throw new IllegalArgumentException("Leeway value can't be negative.");
-            }
+            assertPositive(leeway);
             requireClaim(PublicClaims.NOT_BEFORE, leeway);
             return this;
         }
@@ -147,9 +141,7 @@ public final class JWTVerifier {
          * @throws IllegalArgumentException if leeway is negative.
          */
         public Verification acceptIssuedAt(long leeway) throws IllegalArgumentException {
-            if (leeway < 0) {
-                throw new IllegalArgumentException("Leeway value can't be negative.");
-            }
+            assertPositive(leeway);
             requireClaim(PublicClaims.ISSUED_AT, leeway);
             return this;
         }
@@ -173,12 +165,93 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Verification withClaim(String name, Object value) throws IllegalArgumentException {
-            if (name == null) {
-                throw new IllegalArgumentException("The Custom Claim's name can't be null.");
-            }
-
+        public Verification withClaim(String name, Boolean value) throws IllegalArgumentException {
+            assertNonNull(name);
             requireClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Require a specific Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Verification withClaim(String name, Integer value) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Require a specific Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Verification withClaim(String name, Double value) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Require a specific Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Verification withClaim(String name, String value) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Require a specific Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Verification withClaim(String name, Date value) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, value);
+            return this;
+        }
+
+        /**
+         * Require a specific Array Claim to contain at least the given items.
+         *
+         * @param name  the Claim's name.
+         * @param items the items the Claim must contain.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Verification withArrayClaim(String name, String... items) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, items);
+            return this;
+        }
+
+        /**
+         * Require a specific Array Claim to contain at least the given items.
+         *
+         * @param name  the Claim's name.
+         * @param items the items the Claim must contain.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, items);
             return this;
         }
 
@@ -201,6 +274,18 @@ public final class JWTVerifier {
         JWTVerifier build(Clock clock) {
             addLeewayToDateClaims();
             return new JWTVerifier(algorithm, claims, clock);
+        }
+
+        private void assertPositive(long leeway) {
+            if (leeway < 0) {
+                throw new IllegalArgumentException("Leeway value can't be negative.");
+            }
+        }
+
+        private void assertNonNull(String name) {
+            if (name == null) {
+                throw new IllegalArgumentException("The Custom Claim's name can't be null.");
+            }
         }
 
         private void addLeewayToDateClaims() {
@@ -296,8 +381,10 @@ public final class JWTVerifier {
             isValid = value.equals(claim.asDouble());
         } else if (value instanceof Date) {
             isValid = value.equals(claim.asDate());
-        } else {
-            isValid = Objects.deepEquals(value, claim.as(value.getClass()));
+        } else if (value instanceof Object[]) {
+            List<Object> claimArr = Arrays.asList(claim.as(Object[].class));
+            List<Object> valueArr = Arrays.asList((Object[]) value);
+            isValid = claimArr.containsAll(valueArr);
         }
 
         if (!isValid) {

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -168,19 +168,14 @@ public final class JWTVerifier {
         /**
          * Require a specific Claim value.
          *
-         * @param name  the Claim's name
-         * @param value the Claim's value. Must be an instance of Integer, Double, Boolean, Date or String class.
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
          * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null or the value class is not allowed.
+         * @throws IllegalArgumentException if the name is null.
          */
         public Verification withClaim(String name, Object value) throws IllegalArgumentException {
-            final boolean validValue = value instanceof Integer || value instanceof Double ||
-                    value instanceof Boolean || value instanceof Date || value instanceof String;
             if (name == null) {
                 throw new IllegalArgumentException("The Custom Claim's name can't be null.");
-            }
-            if (!validValue) {
-                throw new IllegalArgumentException("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
             }
 
             requireClaim(name, value);
@@ -301,6 +296,8 @@ public final class JWTVerifier {
             isValid = value.equals(claim.asDouble());
         } else if (value instanceof Date) {
             isValid = value.equals(claim.asDate());
+        } else {
+            isValid = Objects.deepEquals(value, claim.as(value.getClass()));
         }
 
         if (!isValid) {

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -90,6 +90,16 @@ class JsonNodeClaim implements Claim {
     }
 
     @Override
+    public <T> T as(Class<T> tClazz) throws JWTDecodeException {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.treeToValue(data, tClazz);
+        } catch (JsonProcessingException e) {
+            throw new JWTDecodeException("Couldn't map the Claim value to " + tClazz.getSimpleName(), e);
+        }
+    }
+
+    @Override
     public boolean isNull() {
         return !(data.isArray() || data.canConvertToLong() || data.isTextual() || data.isNumber() || data.isBoolean());
     }

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Date;
@@ -93,8 +94,8 @@ class JsonNodeClaim implements Claim {
     public <T> T as(Class<T> tClazz) throws JWTDecodeException {
         ObjectMapper mapper = new ObjectMapper();
         try {
-            return mapper.treeToValue(data, tClazz);
-        } catch (JsonProcessingException e) {
+            return mapper.treeAsTokens(data).readValueAs(tClazz);
+        } catch (IOException e) {
             throw new JWTDecodeException("Couldn't map the Claim value to " + tClazz.getSimpleName(), e);
         }
     }

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -49,4 +49,9 @@ public class NullClaim implements Claim {
     public <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException {
         return null;
     }
+
+    @Override
+    public <T> T as(Class<T> tClazz) throws JWTDecodeException {
+        return null;
+    }
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -69,4 +69,12 @@ public interface Claim {
      * @throws JWTDecodeException if the values inside the List can't be converted to a class T.
      */
     <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException;
+
+    /**
+     * Get this Claim as a custom type T.
+     *
+     * @return the value as instance of T.
+     * @throws JWTDecodeException if the value can't be converted to a class T.
+     */
+    <T> T as(Class<T> tClazz) throws JWTDecodeException;
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -54,18 +54,18 @@ public interface Claim {
 
     /**
      * Get this Claim as an Array of type T.
-     * If the value isn't an Array, an empty Array will be returned.
+     * If the value isn't an Array, null will be returned.
      *
-     * @return the value as an Array or an empty Array.
+     * @return the value as an Array or null.
      * @throws JWTDecodeException if the values inside the Array can't be converted to a class T.
      */
     <T> T[] asArray(Class<T> tClazz) throws JWTDecodeException;
 
     /**
      * Get this Claim as a List of type T.
-     * If the value isn't an Array, an empty List will be returned.
+     * If the value isn't an Array, null will be returned.
      *
-     * @return the value as a List or an empty List.
+     * @return the value as a List or null.
      * @throws JWTDecodeException if the values inside the List can't be converted to a class T.
      */
     <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException;

--- a/lib/src/main/java/com/auth0/jwt/interfaces/DecodedJWT.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/DecodedJWT.java
@@ -4,5 +4,10 @@ package com.auth0.jwt.interfaces;
  * Class that represents a Json Web Token that was decoded from it's string representation.
  */
 public interface DecodedJWT extends Payload, Header, Signature {
+    /**
+     * Getter for the String Token used to create this JWT instance.
+     *
+     * @return the String Token.
+     */
     String getToken();
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -5,9 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -154,14 +152,6 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldThrowOnIllegalCustomClaimValueClass() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
-        JWTCreator.init()
-                .withClaim("name", new Object());
-    }
-
-    @Test
     public void shouldAcceptCustomClaimOfTypeString() throws Exception {
         String jwt = JWTCreator.init()
                 .withClaim("name", "value")
@@ -217,4 +207,47 @@ public class JWTCreatorTest {
         assertThat(jwt, is(token));
     }
 
+    @Test
+    public void shouldAcceptCustomClaimOfTypeArray() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", new Object[]{"text", 123, true})
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeList() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", Arrays.asList("text", 123, true))
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeMap() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", Collections.singletonMap("value", new Object[]{"text", 123, true}))
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InZhbHVlIjpbInRleHQiLDEyMyx0cnVlXX19.CtZqZMoG__8yJQisT__pcv3NlynrkDl6qvq4sERx6D0";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
+
+    @Test
+    public void shouldAcceptCustomClaimOfTypeObject() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("name", new UserPojo("john", 123))
+                .sign(Algorithm.HMAC256("secret"));
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7Im5hbWUiOiJqb2huIiwiaWQiOjEyM319.4ar5Q2vy8h7mw-FjFp1XRoiiKQrrPqdrSqEfATCGmNM";
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(token));
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -5,7 +5,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -208,44 +210,22 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomClaimOfTypeArray() throws Exception {
+    public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
         String jwt = JWTCreator.init()
-                .withClaim("name", new Object[]{"text", 123, true})
+                .withArrayClaim("name", new String[]{"text", "123", "true"})
                 .sign(Algorithm.HMAC256("secret"));
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
 
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt, is(token));
     }
 
     @Test
-    public void shouldAcceptCustomClaimOfTypeList() throws Exception {
+    public void shouldAcceptCustomArrayClaimOfTypeInteger() throws Exception {
         String jwt = JWTCreator.init()
-                .withClaim("name", Arrays.asList("text", 123, true))
+                .withArrayClaim("name", new Integer[]{1, 2, 3})
                 .sign(Algorithm.HMAC256("secret"));
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
-
-        assertThat(jwt, is(notNullValue()));
-        assertThat(jwt, is(token));
-    }
-
-    @Test
-    public void shouldAcceptCustomClaimOfTypeMap() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", Collections.singletonMap("value", new Object[]{"text", 123, true}))
-                .sign(Algorithm.HMAC256("secret"));
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InZhbHVlIjpbInRleHQiLDEyMyx0cnVlXX19.CtZqZMoG__8yJQisT__pcv3NlynrkDl6qvq4sERx6D0";
-
-        assertThat(jwt, is(notNullValue()));
-        assertThat(jwt, is(token));
-    }
-
-    @Test
-    public void shouldAcceptCustomClaimOfTypeObject() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", new UserPojo("john", 123))
-                .sign(Algorithm.HMAC256("secret"));
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7Im5hbWUiOiJqb2huIiwiaWQiOjEyM319.4ar5Q2vy8h7mw-FjFp1XRoiiKQrrPqdrSqEfATCGmNM";
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
 
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt, is(token));

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -8,9 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -130,14 +128,6 @@ public class JWTVerifierTest {
         exception.expectMessage("The Custom Claim's name can't be null.");
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim(null, "value");
-    }
-
-    @Test
-    public void shouldThrowOnIllegalCustomClaimValueClass() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The Custom Claim's value class must be an instance of Integer, Double, Boolean, Date or String.");
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", new Object());
     }
 
     @Test
@@ -263,6 +253,38 @@ public class JWTVerifierTest {
         assertThat(jwt, is(notNullValue()));
     }
 
+    @Test
+    public void shouldValidateCustomClaimOfCustomType() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7Im5hbWUiOiJqb2huIiwiaWQiOjEyM319.j3e7IfnEchQEwgDs1icOyufhzAyNOYfX9fjJwV6uyZk";
+        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("user", new UserPojo("john", 123))
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeArray() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
+        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", new Object[]{"text", 123, true})
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomClaimOfTypeList() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
+        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", new ArrayList<>(Arrays.asList("text", 123, true)))
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
 
     // Generic Delta
     @SuppressWarnings("RedundantCast")

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -8,7 +8,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -254,10 +256,10 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateCustomClaimOfCustomType() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7Im5hbWUiOiJqb2huIiwiaWQiOjEyM319.j3e7IfnEchQEwgDs1icOyufhzAyNOYfX9fjJwV6uyZk";
+    public void shouldValidateCustomArrayClaimOfTypeString() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
         DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("user", new UserPojo("john", 123))
+                .withArrayClaim("name", "text", "123", "true")
                 .build()
                 .verify(token);
 
@@ -265,21 +267,10 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateCustomClaimOfTypeArray() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
+    public void shouldValidateCustomArrayClaimOfTypeInteger() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
         DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", new Object[]{"text", 123, true})
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeList() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLDEyMyx0cnVlXX0.uSulPFzLSbgfG8Lpr0jq0JDMhDlGGeQrx09PHEymu1E";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", new ArrayList<>(Arrays.asList("text", 123, true)))
+                .withArrayClaim("name", 1, 2, 3)
                 .build()
                 .verify(token);
 

--- a/lib/src/test/java/com/auth0/jwt/impl/BasicHeaderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/BasicHeaderTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-public class HeaderImplTest {
+public class BasicHeaderTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -7,13 +7,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
 
 import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
 import static com.auth0.jwt.impl.JsonNodeClaim.claimFromNode;
@@ -223,7 +225,7 @@ public class JsonNodeClaimTest {
         claim.as(String.class);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "RedundantCast"})
     @Test
     public void shouldGetAsMapValue() throws Exception {
         JsonNode value = mapper.valueToTree(Collections.singletonMap("key", new UserPojo("john", 123)));
@@ -231,8 +233,8 @@ public class JsonNodeClaimTest {
 
         assertThat(claim, is(notNullValue()));
         Map map = claim.as(Map.class);
-        assertThat(((HashMap<String, Object>) map.get("key")), IsMapContaining.hasEntry("name", "john"));
-        assertThat(((HashMap<String, Object>) map.get("key")), IsMapContaining.hasEntry("id", 123));
+        assertThat(((Map<String, Object>) map.get("key")), hasEntry("name", (Object) "john"));
+        assertThat(((Map<String, Object>) map.get("key")), hasEntry("id", (Object) 123));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-public class BaseClaimTest {
+public class NullClaimTest {
     private NullClaim claim;
 
     @Before
@@ -54,6 +54,11 @@ public class BaseClaimTest {
     @Test
     public void shouldGetAsList() throws Exception {
         assertThat(claim.asList(Object.class), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsCustomClass() throws Exception {
+        assertThat(claim.as(Object.class), is(nullValue()));
     }
 
 }


### PR DESCRIPTION
Now we can specify Arrays of type String or Integer for creation/verification of JWTs.

1. Get a Claim as a custom class:

```java
Claim claim = jwt.getClaim("user");
UserProfile user = claim.as(UserProfile.class);
```

2. Create a token with an Array Claim:

```java
String jwt = JWTCreator.init()
                .withArrayClaim("name", new String[]{"a", "b", "c"})
                .sign(Algorithm.HMAC256("secret"));
```

3. Verify that a token contains an Array Claim with at least specific items:

```java
DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
                .withArrayClaim("name", "a", "b")
                .build()
                .verify(token);
```

Note that in this example, `UserProfile` class must have a no-args public constructor for deserialization to work.