### PR TITLE
Add getter for all the Payload's Claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,14 @@ String id = jwt.getId();
 
 #### Private Claims
 
-Additional Claims defined in the token's Payload can be obtained by calling `getClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You can check if a Claim's value is null by calling `claim.isNull()`.
+Additional Claims defined in the token's Payload can be obtained by calling `getClaims()` or `getClaim()` and passing the Claim name. A Claim will always be returned, even if it can't be found. You can check if a Claim's value is null by calling `claim.isNull()`.
+
+```java
+Map<String, Claim> claims = jwt.getClaims();    //Key is the Claim name
+Claim claim = claims.get("isAdmin");
+```
+al
+or
 
 ```java
 Claim claim = jwt.getClaim("isAdmin");

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -11,6 +11,7 @@ import org.apache.commons.codec.binary.StringUtils;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The JWTDecoder class holds the decode method to parse a given JWT token into it's JWT representation.
@@ -107,6 +108,11 @@ final class JWTDecoder extends JWT {
     @Override
     public Claim getClaim(String name) {
         return payload.getClaim(name);
+    }
+
+    @Override
+    public Map<String, Claim> getClaims() {
+        return payload.getClaims();
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
@@ -76,4 +76,12 @@ class PayloadImpl implements Payload {
         return extractClaim(name, tree);
     }
 
+    @Override
+    public Map<String, Claim> getClaims() {
+        Map<String, Claim> claims = new HashMap<>();
+        for (String name : tree.keySet()) {
+            claims.put(name, extractClaim(name, tree));
+        }
+        return Collections.unmodifiableMap(claims);
+    }
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -2,6 +2,7 @@ package com.auth0.jwt.interfaces;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The Payload class represents the 2nd part of the JWT, where the Payload value is hold.
@@ -58,10 +59,17 @@ public interface Payload {
     String getId();
 
     /**
-     * Get a Private Claim given it's name. If the Claim wasn't specified in the Payload, a NullClaim will be returned.
+     * Get a Claim given it's name. If the Claim wasn't specified in the Payload, a NullClaim will be returned.
      *
      * @param name the name of the Claim to retrieve.
      * @return a non-null Claim.
      */
     Claim getClaim(String name);
+
+    /**
+     * Get the Claims defined in the Token.
+     *
+     * @return a non-null Map containing the Claims defined in the Token.
+     */
+    Map<String, Claim> getClaims();
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -13,6 +13,7 @@ import org.junit.rules.ExpectedException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -196,6 +197,22 @@ public class JWTDecoderTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getClaim("object"), is(notNullValue()));
         assertThat(jwt.getClaim("object").isNull(), is(true));
+    }
+
+    @Test
+    public void shouldGetAvailableClaims() throws Exception {
+        DecodedJWT jwt = JWTDecoder.decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjM0NTY3ODkwIiwiaWF0IjoiMTIzNDU2Nzg5MCIsIm5iZiI6IjEyMzQ1Njc4OTAiLCJqdGkiOiJodHRwczovL2p3dC5pby8iLCJhdWQiOiJodHRwczovL2RvbWFpbi5hdXRoMC5jb20iLCJzdWIiOiJsb2dpbiIsImlzcyI6ImF1dGgwIiwiZXh0cmFDbGFpbSI6IkpvaG4gRG9lIn0.TX9Ct4feGp9YyeGK9Zl91tO0YBOrguJ4As9jeqgHdZQ");
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaims(), is(notNullValue()));
+        assertThat(jwt.getClaims(), is(instanceOf(Map.class)));
+        assertThat(jwt.getClaims().get("exp"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("iat"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("nbf"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("jti"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("aud"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("sub"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("iss"), is(notNullValue()));
+        assertThat(jwt.getClaims().get("extraClaim"), is(notNullValue()));
     }
 
     //Helper Methods

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -1,5 +1,6 @@
 package com.auth0.jwt.impl;
 
+import com.auth0.jwt.interfaces.Claim;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.hamcrest.collection.IsCollectionWithSize;
@@ -152,5 +153,28 @@ public class PayloadImplTest {
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getClaim("missing"), is(notNullValue()));
         assertThat(payload.getClaim("missing"), is(instanceOf(NullClaim.class)));
+    }
+
+    @Test
+    public void shouldGetClaims() throws Exception {
+        Map<String, JsonNode> tree = new HashMap<>();
+        tree.put("extraClaim", new TextNode("extraValue"));
+        tree.put("sub", new TextNode("auth0"));
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, tree);
+        assertThat(payload, is(notNullValue()));
+        Map<String, Claim> claims = payload.getClaims();
+        assertThat(claims, is(notNullValue()));
+
+        assertThat(claims.get("extraClaim"), is(notNullValue()));
+        assertThat(claims.get("sub"), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldNotAllowToModifyClaimsMap() throws Exception {
+        assertThat(payload, is(notNullValue()));
+        Map<String, Claim> claims = payload.getClaims();
+        assertThat(claims, is(notNullValue()));
+        exception.expect(UnsupportedOperationException.class);
+        claims.put("name", null);
     }
 }


### PR DESCRIPTION
Add getter for the Claims defined in the JWT's Payload.

```java
Map<String, Claim> claims = jwt.getClaims();
Claims claim = claims.get("user");
```
Fixes: https://github.com/auth0/java-jwt/issues/116