### PR TITLE
Make Clock customization accessible for verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If you need to test this behaviour in your lib/app cast the `Verification` insta
 BaseVerification verification = (BaseVerification) JWT.require(Algorithm.RSA256(key))
     .acceptLeeway(1)
     .acceptExpiresAt(5);
-Clock clock = new Clock();
+Clock clock = new CustomClock(); //Must implement Clock interface
 JWTVerifier verifier = verification.build(clock);
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ JWTVerifier verifier = JWT.require(Algorithm.RSA256(key))
     .build();
 ```
 
+If you need to test this behaviour in your lib/app cast the `Verification` instance to a `BaseVerification` to gain visibility of the `verification.build()` method that accepts a custom `Clock`. e.g.:
+
+```java
+BaseVerification verification = (BaseVerification) JWT.require(Algorithm.RSA256(key))
+    .acceptLeeway(1)
+    .acceptExpiresAt(5);
+Clock clock = new Clock();
+JWTVerifier verifier = verification.build(clock);
+```
 
 ### Header Claims
 

--- a/lib/src/main/java/com/auth0/jwt/Clock.java
+++ b/lib/src/main/java/com/auth0/jwt/Clock.java
@@ -5,9 +5,9 @@ import java.util.Date;
 /**
  * The Clock class is used to wrap calls to Date class.
  */
-class Clock {
+public class Clock {
 
-    Clock() {
+    public Clock() {
     }
 
     /**
@@ -15,7 +15,7 @@ class Clock {
      *
      * @return a new Date representing Today's time.
      */
-    Date getToday() {
+    public Date getToday() {
         return new Date();
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/ClockImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/ClockImpl.java
@@ -1,0 +1,16 @@
+package com.auth0.jwt;
+
+import com.auth0.jwt.interfaces.Clock;
+
+import java.util.Date;
+
+final class ClockImpl implements Clock {
+
+    ClockImpl() {
+    }
+
+    @Override
+    public Date getToday() {
+        return new Date();
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/jwt/JWT.java
@@ -2,18 +2,15 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
-import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
-
-import java.util.Date;
-import java.util.List;
+import com.auth0.jwt.interfaces.Verification;
 
 @SuppressWarnings("WeakerAccess")
 public abstract class JWT implements DecodedJWT {
 
     /**
      * Decode a given JWT token.
-     *
+     * <p>
      * Note that this method <b>doesn't verify the token's signature!</b> Use it only if you trust the token or you already verified it.
      *
      * @param token with jwt format as string.
@@ -31,7 +28,7 @@ public abstract class JWT implements DecodedJWT {
      * @return {@link JWTVerifier} builder
      * @throws IllegalArgumentException if the provided algorithm is null.
      */
-    public static JWTVerifier.Verification require(Algorithm algorithm) {
+    public static Verification require(Algorithm algorithm) {
         return JWTVerifier.init(algorithm);
     }
 

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
 import org.apache.commons.codec.binary.Base64;
@@ -278,7 +279,7 @@ public final class JWTVerifier {
          */
         @Override
         public JWTVerifier build() {
-            return this.build(new Clock());
+            return this.build(new ClockImpl());
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -8,6 +8,7 @@ import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.Verification;
 import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
@@ -35,19 +36,19 @@ public final class JWTVerifier {
      * @return a JWTVerifier.Verification instance to configure.
      * @throws IllegalArgumentException if the provided algorithm is null.
      */
-    static JWTVerifier.Verification init(Algorithm algorithm) throws IllegalArgumentException {
-        return new Verification(algorithm);
+    static Verification init(Algorithm algorithm) throws IllegalArgumentException {
+        return new BaseVerification(algorithm);
     }
 
     /**
      * The Verification class holds the Claims required by a JWT to be valid.
      */
-    public static class Verification {
+    public static class BaseVerification implements Verification {
         private final Algorithm algorithm;
         private final Map<String, Object> claims;
         private long defaultLeeway;
 
-        Verification(Algorithm algorithm) throws IllegalArgumentException {
+        BaseVerification(Algorithm algorithm) throws IllegalArgumentException {
             if (algorithm == null) {
                 throw new IllegalArgumentException("The Algorithm cannot be null.");
             }
@@ -63,6 +64,7 @@ public final class JWTVerifier {
          * @param issuer the required Issuer value
          * @return this same Verification instance.
          */
+        @Override
         public Verification withIssuer(String issuer) {
             requireClaim(PublicClaims.ISSUER, issuer);
             return this;
@@ -74,6 +76,7 @@ public final class JWTVerifier {
          * @param subject the required Subject value
          * @return this same Verification instance.
          */
+        @Override
         public Verification withSubject(String subject) {
             requireClaim(PublicClaims.SUBJECT, subject);
             return this;
@@ -85,6 +88,7 @@ public final class JWTVerifier {
          * @param audience the required Audience value
          * @return this same Verification instance.
          */
+        @Override
         public Verification withAudience(String... audience) {
             requireClaim(PublicClaims.AUDIENCE, Arrays.asList(audience));
             return this;
@@ -98,6 +102,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if leeway is negative.
          */
+        @Override
         public Verification acceptLeeway(long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             this.defaultLeeway = leeway;
@@ -112,6 +117,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if leeway is negative.
          */
+        @Override
         public Verification acceptExpiresAt(long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             requireClaim(PublicClaims.EXPIRES_AT, leeway);
@@ -126,6 +132,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if leeway is negative.
          */
+        @Override
         public Verification acceptNotBefore(long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             requireClaim(PublicClaims.NOT_BEFORE, leeway);
@@ -140,6 +147,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if leeway is negative.
          */
+        @Override
         public Verification acceptIssuedAt(long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             requireClaim(PublicClaims.ISSUED_AT, leeway);
@@ -152,6 +160,7 @@ public final class JWTVerifier {
          * @param jwtId the required Id value
          * @return this same Verification instance.
          */
+        @Override
         public Verification withJWTId(String jwtId) {
             requireClaim(PublicClaims.JWT_ID, jwtId);
             return this;
@@ -165,6 +174,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withClaim(String name, Boolean value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
@@ -179,6 +189,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withClaim(String name, Integer value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
@@ -193,6 +204,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withClaim(String name, Double value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
@@ -207,6 +219,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withClaim(String name, String value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
@@ -221,6 +234,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withClaim(String name, Date value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
@@ -235,6 +249,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withArrayClaim(String name, String... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
@@ -249,6 +264,7 @@ public final class JWTVerifier {
          * @return this same Verification instance.
          * @throws IllegalArgumentException if the name is null.
          */
+        @Override
         public Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
@@ -260,6 +276,7 @@ public final class JWTVerifier {
          *
          * @return a new JWTVerifier instance.
          */
+        @Override
         public JWTVerifier build() {
             return this.build(new Clock());
         }
@@ -271,7 +288,7 @@ public final class JWTVerifier {
          * @param clock the instance that will handle the current time.
          * @return a new JWTVerifier instance with a custom Clock.
          */
-        JWTVerifier build(Clock clock) {
+        public JWTVerifier build(Clock clock) {
             addLeewayToDateClaims();
             return new JWTVerifier(algorithm, claims, clock);
         }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
@@ -1,21 +1,16 @@
-package com.auth0.jwt;
+package com.auth0.jwt.interfaces;
 
 import java.util.Date;
 
 /**
  * The Clock class is used to wrap calls to Date class.
  */
-public class Clock {
-
-    public Clock() {
-    }
+public interface Clock {
 
     /**
      * Returns a new Date representing Today's time.
      *
      * @return a new Date representing Today's time.
      */
-    public Date getToday() {
-        return new Date();
-    }
+    Date getToday();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -1,0 +1,39 @@
+package com.auth0.jwt.interfaces;
+
+import com.auth0.jwt.JWTVerifier;
+
+import java.util.Date;
+
+public interface Verification {
+    Verification withIssuer(String issuer);
+
+    Verification withSubject(String subject);
+
+    Verification withAudience(String... audience);
+
+    Verification acceptLeeway(long leeway) throws IllegalArgumentException;
+
+    Verification acceptExpiresAt(long leeway) throws IllegalArgumentException;
+
+    Verification acceptNotBefore(long leeway) throws IllegalArgumentException;
+
+    Verification acceptIssuedAt(long leeway) throws IllegalArgumentException;
+
+    Verification withJWTId(String jwtId);
+
+    Verification withClaim(String name, Boolean value) throws IllegalArgumentException;
+
+    Verification withClaim(String name, Integer value) throws IllegalArgumentException;
+
+    Verification withClaim(String name, Double value) throws IllegalArgumentException;
+
+    Verification withClaim(String name, String value) throws IllegalArgumentException;
+
+    Verification withClaim(String name, Date value) throws IllegalArgumentException;
+
+    Verification withArrayClaim(String name, String... items) throws IllegalArgumentException;
+
+    Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
+
+    JWTVerifier build();
+}

--- a/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
@@ -1,19 +1,19 @@
 package com.auth0.jwt;
 
+import com.auth0.jwt.interfaces.Clock;
 import org.junit.Test;
 
 import java.util.Date;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
 
-public class ClockTest {
+public class ClockImplTest {
 
     @Test
     public void shouldGetToday() throws Exception{
-        Clock clock = new Clock();
+        Clock clock = new ClockImpl();
         Date clockToday = clock.getToday();
         assertThat(clockToday, is(notNullValue()));
     }

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -242,7 +242,8 @@ public class JWTTest {
         when(clock.getToday()).thenReturn(expectedDate);
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTJ9.x_ZjkPkKYUV5tdvc0l8go6D_z2kez1MQcOxokXrDc3k";
-        DecodedJWT jwt = JWT.require(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -259,7 +260,8 @@ public class JWTTest {
         when(clock.getToday()).thenReturn(expectedDate);
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0Nzc1OTJ9.mWYSOPoNXstjKbZkKrqgkwPOQWEx3F3gMm6PMcfuJd8";
-        DecodedJWT jwt = JWT.require(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -276,7 +278,8 @@ public class JWTTest {
         when(clock.getToday()).thenReturn(expectedDate);
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.5o1CKlLFjKKcddZzoarQ37pq7qZqNPav3sdZ_bsZaD4";
-        DecodedJWT jwt = JWT.require(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -289,7 +292,8 @@ public class JWTTest {
     @Test
     public void shouldGetId() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMjM0NTY3ODkwIn0.m3zgEfVUFOd-CvL3xG5BuOWLzb0zMQZCqiVNQQOPOvA";
-        DecodedJWT jwt = JWT.require(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build()
                 .verify(token);
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -3,6 +3,7 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.AlgorithmMismatchException;
 import com.auth0.jwt.exceptions.InvalidClaimException;
+import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.junit.Rule;
 import org.junit.Test;
@@ -195,7 +196,7 @@ public class JWTVerifierTest {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         Map<String, Object> map = new HashMap<>();
         map.put("name", new Object());
-        JWTVerifier verifier = new JWTVerifier(Algorithm.HMAC256("secret"), map, new Clock());
+        JWTVerifier verifier = new JWTVerifier(Algorithm.HMAC256("secret"), map, new ClockImpl());
         verifier.verify(token);
     }
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -366,8 +366,9 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .acceptExpiresAt(2)
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .acceptExpiresAt(2);
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -380,7 +381,8 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -395,7 +397,8 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification
                 .build(clock)
                 .verify(token);
     }
@@ -416,8 +419,9 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .acceptNotBefore(2)
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .acceptNotBefore(2);
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -432,7 +436,8 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification
                 .build(clock)
                 .verify(token);
     }
@@ -443,7 +448,8 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -466,8 +472,9 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .acceptIssuedAt(2)
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .acceptIssuedAt(2);
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 
@@ -482,7 +489,8 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification
                 .build(clock)
                 .verify(token);
     }
@@ -493,7 +501,8 @@ public class JWTVerifierTest {
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
                 .build(clock)
                 .verify(token);
 


### PR DESCRIPTION
Now when working with time related claims, the JWTVerifier allows to specify the custom `Clock` instance used on the verification. We want this to be as hidden as possible for the normal user. Devs can access it by performing a cast.

```java
BaseVerification verification = (BaseVerification) JWT.require(Algorithm.RSA256(key))
    .acceptLeeway(1)
    .acceptExpiresAt(5);
Clock clock = new CustomClock(); //Must implement Clock interface
JWTVerifier verifier = verification.build(clock);
```

Related to: https://github.com/auth0/java-jwt/issues/50 https://github.com/auth0/java-jwt/issues/118