### PR TITLE
Enable parsing JSON with newline postfix

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
@@ -50,8 +50,12 @@ public class JWTParser implements JWTPartsParser {
     @SuppressWarnings("WeakerAccess")
     <T> T convertFromJSON(String json, Class<T> tClazz) throws JWTDecodeException {
         JWTDecodeException exception = new JWTDecodeException(String.format("The string '%s' doesn't have a valid JSON format.", json));
-        if (json == null || !json.startsWith("{") || !json.endsWith("}")) {
+        if (json == null) {
             throw exception;
+        }
+        String trimmedJson = json.trim();
+        if(!trimmedJson.startsWith("{") || !trimmedJson.endsWith("}")) {
+            throw  exception;
         }
         try {
             return mapper.readValue(json, tClazz);

--- a/lib/src/test/java/com/auth0/jwt/impl/JWTParserTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JWTParserTest.java
@@ -102,6 +102,13 @@ public class JWTParserTest {
     }
 
     @Test
+    public void shouldConvertFromValidJSONWithWhiteSpace() {
+        String json = " {}\r\n ";
+        Object object = parser.convertFromJSON(json, Object.class);
+        assertThat(object, is(notNullValue()));
+    }
+
+    @Test
     public void shouldThrowWhenConvertingIfNullJson() throws Exception {
         exception.expect(JWTDecodeException.class);
         exception.expectMessage("The string 'null' doesn't have a valid JSON format.");


### PR DESCRIPTION
Couldn't we say JSON with leading/trailing whitespace is valid too? It solves my issues with trailing newlines.. 