### PR TITLE
Instantiate RSA/EC Algorithm with both keys

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -4,12 +4,14 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 
 import java.io.UnsupportedEncodingException;
-import java.security.interfaces.ECKey;
-import java.security.interfaces.RSAKey;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.*;
 
 /**
  * The Algorithm class represents an algorithm to be used in the Signing or Verification process of a Token.
  */
+@SuppressWarnings("WeakerAccess")
 public abstract class Algorithm {
 
     private final String name;
@@ -21,9 +23,13 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA256 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #RSA256(RSAPublicKey, RSAPrivateKey)}
      */
+    @Deprecated
     public static Algorithm RSA256(RSAKey key) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS256", "SHA256withRSA", key);
+        RSAPublicKey publicKey = key instanceof PublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof PrivateKey ? (RSAPrivateKey) key : null;
+        return RSA256(publicKey, privateKey);
     }
 
     /**
@@ -32,9 +38,13 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA384 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #RSA384(RSAPublicKey, RSAPrivateKey)}
      */
+    @Deprecated
     public static Algorithm RSA384(RSAKey key) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS384", "SHA384withRSA", key);
+        RSAPublicKey publicKey = key instanceof PublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof PrivateKey ? (RSAPrivateKey) key : null;
+        return RSA384(publicKey, privateKey);
     }
 
     /**
@@ -43,9 +53,49 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA512 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #RSA512(RSAPublicKey, RSAPrivateKey)}
      */
+    @Deprecated
     public static Algorithm RSA512(RSAKey key) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS512", "SHA512withRSA", key);
+        RSAPublicKey publicKey = key instanceof PublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof PrivateKey ? (RSAPrivateKey) key : null;
+        return RSA512(publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid RSA256 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA256(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS256", "SHA256withRSA", publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid RSA384 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA384(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS384", "SHA384withRSA", publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA512withRSA. Tokens specify this as "RS512".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid RSA512 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA512(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS512", "SHA512withRSA", publicKey, privateKey);
     }
 
     /**
@@ -123,9 +173,13 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA256 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #ECDSA256(ECPublicKey, ECPrivateKey)}
      */
+    @Deprecated
     public static Algorithm ECDSA256(ECKey key) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, key);
+        ECPublicKey publicKey = key instanceof PublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof PrivateKey ? (ECPrivateKey) key : null;
+        return ECDSA256(publicKey, privateKey);
     }
 
     /**
@@ -134,9 +188,13 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA384 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #ECDSA384(ECPublicKey, ECPrivateKey)}
      */
+    @Deprecated
     public static Algorithm ECDSA384(ECKey key) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, key);
+        ECPublicKey publicKey = key instanceof PublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof PrivateKey ? (ECPrivateKey) key : null;
+        return ECDSA384(publicKey, privateKey);
     }
 
     /**
@@ -145,9 +203,49 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA512 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #ECDSA512(ECPublicKey, ECPrivateKey)}
      */
+    @Deprecated
     public static Algorithm ECDSA512(ECKey key) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, key);
+        ECPublicKey publicKey = key instanceof PublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof PrivateKey ? (ECPrivateKey) key : null;
+        return ECDSA512(publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid ECDSA256 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA256(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid ECDSA384 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA384(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA512withECDSA. Tokens specify this as "ES512".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid ECDSA512 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA512(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, publicKey, privateKey);
     }
 
     public static Algorithm none() {

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -4,8 +4,6 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 
 import java.io.UnsupportedEncodingException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.security.interfaces.*;
 
 /**
@@ -27,8 +25,8 @@ public abstract class Algorithm {
      */
     @Deprecated
     public static Algorithm RSA256(RSAKey key) throws IllegalArgumentException {
-        RSAPublicKey publicKey = key instanceof PublicKey ? (RSAPublicKey) key : null;
-        RSAPrivateKey privateKey = key instanceof PrivateKey ? (RSAPrivateKey) key : null;
+        RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
         return RSA256(publicKey, privateKey);
     }
 
@@ -42,8 +40,8 @@ public abstract class Algorithm {
      */
     @Deprecated
     public static Algorithm RSA384(RSAKey key) throws IllegalArgumentException {
-        RSAPublicKey publicKey = key instanceof PublicKey ? (RSAPublicKey) key : null;
-        RSAPrivateKey privateKey = key instanceof PrivateKey ? (RSAPrivateKey) key : null;
+        RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
         return RSA384(publicKey, privateKey);
     }
 
@@ -57,8 +55,8 @@ public abstract class Algorithm {
      */
     @Deprecated
     public static Algorithm RSA512(RSAKey key) throws IllegalArgumentException {
-        RSAPublicKey publicKey = key instanceof PublicKey ? (RSAPublicKey) key : null;
-        RSAPrivateKey privateKey = key instanceof PrivateKey ? (RSAPrivateKey) key : null;
+        RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
         return RSA512(publicKey, privateKey);
     }
 
@@ -177,8 +175,8 @@ public abstract class Algorithm {
      */
     @Deprecated
     public static Algorithm ECDSA256(ECKey key) throws IllegalArgumentException {
-        ECPublicKey publicKey = key instanceof PublicKey ? (ECPublicKey) key : null;
-        ECPrivateKey privateKey = key instanceof PrivateKey ? (ECPrivateKey) key : null;
+        ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
         return ECDSA256(publicKey, privateKey);
     }
 
@@ -192,8 +190,8 @@ public abstract class Algorithm {
      */
     @Deprecated
     public static Algorithm ECDSA384(ECKey key) throws IllegalArgumentException {
-        ECPublicKey publicKey = key instanceof PublicKey ? (ECPublicKey) key : null;
-        ECPrivateKey privateKey = key instanceof PrivateKey ? (ECPrivateKey) key : null;
+        ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
         return ECDSA384(publicKey, privateKey);
     }
 
@@ -207,8 +205,8 @@ public abstract class Algorithm {
      */
     @Deprecated
     public static Algorithm ECDSA512(ECKey key) throws IllegalArgumentException {
-        ECPublicKey publicKey = key instanceof PublicKey ? (ECPublicKey) key : null;
-        ECPrivateKey privateKey = key instanceof PrivateKey ? (ECPrivateKey) key : null;
+        ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
         return ECDSA512(publicKey, privateKey);
     }
 

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -44,7 +44,7 @@ class ECDSAAlgorithm extends Algorithm {
     public void verify(byte[] contentBytes, byte[] signatureBytes) throws SignatureVerificationException {
         try {
             if (publicKey == null) {
-                throw new IllegalArgumentException("The given Public Key is null.");
+                throw new IllegalStateException("The given Public Key is null.");
             }
             if (!isDERSignature(signatureBytes)) {
                 signatureBytes = JOSEToDER(signatureBytes);
@@ -54,7 +54,7 @@ class ECDSAAlgorithm extends Algorithm {
             if (!valid) {
                 throw new SignatureVerificationException(this);
             }
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalArgumentException e) {
+        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
             throw new SignatureVerificationException(this, e);
         }
     }
@@ -63,10 +63,10 @@ class ECDSAAlgorithm extends Algorithm {
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
             if (privateKey == null) {
-                throw new IllegalArgumentException("The given Private Key is null.");
+                throw new IllegalStateException("The given Private Key is null.");
             }
             return crypto.createSignatureFor(getDescription(), privateKey, contentBytes);
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalArgumentException e) {
+        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
             throw new SignatureGenerationException(this, e);
         }
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -3,40 +3,48 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 
-import java.security.*;
-import java.security.interfaces.RSAKey;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 
 class RSAAlgorithm extends Algorithm {
 
-    private final RSAKey key;
+    private final RSAPublicKey publicKey;
+    private final RSAPrivateKey privateKey;
     private final CryptoHelper crypto;
 
-    RSAAlgorithm(CryptoHelper crypto, String id, String algorithm, RSAKey key) throws IllegalArgumentException {
+    //Visible for testing
+    RSAAlgorithm(CryptoHelper crypto, String id, String algorithm, RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
         super(id, algorithm);
-        if (key == null) {
-            throw new IllegalArgumentException("The RSAKey cannot be null");
+        if (publicKey == null && privateKey == null) {
+            throw new IllegalArgumentException("Both provided Keys cannot be null.");
         }
-        this.key = key;
+        this.publicKey = publicKey;
+        this.privateKey = privateKey;
         this.crypto = crypto;
     }
 
-    RSAAlgorithm(String id, String algorithm, RSAKey key) throws IllegalArgumentException {
-        this(new CryptoHelper(), id, algorithm, key);
+    RSAAlgorithm(String id, String algorithm, RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
+        this(new CryptoHelper(), id, algorithm, publicKey, privateKey);
     }
 
-    RSAKey getKey() {
-        return key;
+    RSAPublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    RSAPrivateKey getPrivateKey() {
+        return privateKey;
     }
 
     @Override
     public void verify(byte[] contentBytes, byte[] signatureBytes) throws SignatureVerificationException {
         try {
-            if (!(key instanceof PublicKey)) {
-                throw new IllegalArgumentException("The given RSAKey is not a RSAPublicKey.");
+            if (publicKey == null) {
+                throw new IllegalArgumentException("The given Public Key is null.");
             }
-            boolean valid = crypto.verifySignatureFor(getDescription(), (RSAPublicKey) key, contentBytes, signatureBytes);
+            boolean valid = crypto.verifySignatureFor(getDescription(), publicKey, contentBytes, signatureBytes);
             if (!valid) {
                 throw new SignatureVerificationException(this);
             }
@@ -48,10 +56,10 @@ class RSAAlgorithm extends Algorithm {
     @Override
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
-            if (!(key instanceof PrivateKey)) {
-                throw new IllegalArgumentException("The given RSAKey is not a RSAPrivateKey.");
+            if (privateKey == null) {
+                throw new IllegalArgumentException("The given Private Key is null.");
             }
-            return crypto.createSignatureFor(getDescription(), (RSAPrivateKey) key, contentBytes);
+            return crypto.createSignatureFor(getDescription(), privateKey, contentBytes);
         } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalArgumentException e) {
             throw new SignatureGenerationException(this, e);
         }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -42,13 +42,13 @@ class RSAAlgorithm extends Algorithm {
     public void verify(byte[] contentBytes, byte[] signatureBytes) throws SignatureVerificationException {
         try {
             if (publicKey == null) {
-                throw new IllegalArgumentException("The given Public Key is null.");
+                throw new IllegalStateException("The given Public Key is null.");
             }
             boolean valid = crypto.verifySignatureFor(getDescription(), publicKey, contentBytes, signatureBytes);
             if (!valid) {
                 throw new SignatureVerificationException(this);
             }
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalArgumentException e) {
+        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
             throw new SignatureVerificationException(this, e);
         }
     }
@@ -57,10 +57,10 @@ class RSAAlgorithm extends Algorithm {
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
             if (privateKey == null) {
-                throw new IllegalArgumentException("The given Private Key is null.");
+                throw new IllegalStateException("The given Private Key is null.");
             }
             return crypto.createSignatureFor(getDescription(), privateKey, contentBytes);
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalArgumentException e) {
+        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
             throw new SignatureGenerationException(this, e);
         }
     }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
@@ -5,12 +5,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.nio.charset.StandardCharsets;
-import java.security.interfaces.ECKey;
-import java.security.interfaces.RSAKey;
+import java.security.interfaces.*;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 public class AlgorithmTest {
 
@@ -19,7 +19,7 @@ public class AlgorithmTest {
 
 
     @Test
-    public void shouldThrowHMAC256VerificationWithNullSecretBytes() throws Exception {
+    public void shouldThrowHMAC256InstanceWithNullSecretBytes() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Secret cannot be null");
         byte[] secret = null;
@@ -27,7 +27,7 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldThrowHMAC384VerificationWithNullSecretBytes() throws Exception {
+    public void shouldThrowHMAC384InstanceWithNullSecretBytes() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Secret cannot be null");
         byte[] secret = null;
@@ -35,7 +35,7 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldThrowHMAC512VerificationWithNullSecretBytes() throws Exception {
+    public void shouldThrowHMAC512InstanceWithNullSecretBytes() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Secret cannot be null");
         byte[] secret = null;
@@ -43,7 +43,7 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldThrowHMAC256VerificationWithNullSecret() throws Exception {
+    public void shouldThrowHMAC256InstanceWithNullSecret() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Secret cannot be null");
         String secret = null;
@@ -51,7 +51,7 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldThrowHMAC384VerificationWithNullSecret() throws Exception {
+    public void shouldThrowHMAC384InstanceWithNullSecret() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Secret cannot be null");
         String secret = null;
@@ -59,7 +59,7 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldThrowHMAC512VerificationWithNullSecret() throws Exception {
+    public void shouldThrowHMAC512InstanceWithNullSecret() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Secret cannot be null");
         String secret = null;
@@ -67,45 +67,87 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldThrowRSA256VerificationWithNullPublicKey() throws Exception {
+    public void shouldThrowRSA256InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The RSAKey cannot be null");
+        exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.RSA256(null);
     }
 
     @Test
-    public void shouldThrowRSA384VerificationWithNullPublicKey() throws Exception {
+    public void shouldThrowRSA256InstanceWithNullKeys() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The RSAKey cannot be null");
+        exception.expectMessage("Both provided Keys cannot be null.");
+        Algorithm.RSA256(null, null);
+    }
+
+    @Test
+    public void shouldThrowRSA384InstanceWithNullKey() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.RSA384(null);
     }
 
     @Test
-    public void shouldThrowRSA512VerificationWithNullPublicKey() throws Exception {
+    public void shouldThrowRSA384InstanceWithNullKeys() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The RSAKey cannot be null");
+        exception.expectMessage("Both provided Keys cannot be null.");
+        Algorithm.RSA384(null, null);
+    }
+
+    @Test
+    public void shouldThrowRSA512InstanceWithNullKey() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.RSA512(null);
     }
 
     @Test
-    public void shouldThrowECDSA256VerificationWithNullPublicKey() throws Exception {
+    public void shouldThrowRSA512InstanceWithNullKeys() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The ECKey cannot be null");
+        exception.expectMessage("Both provided Keys cannot be null.");
+        Algorithm.RSA512(null, null);
+    }
+
+    @Test
+    public void shouldThrowECDSA256InstanceWithNullKey() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.ECDSA256(null);
     }
 
     @Test
-    public void shouldThrowECDSA384VerificationWithNullPublicKey() throws Exception {
+    public void shouldThrowECDSA256InstanceWithNullKeys() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The ECKey cannot be null");
+        exception.expectMessage("Both provided Keys cannot be null.");
+        Algorithm.ECDSA256(null, null);
+    }
+
+    @Test
+    public void shouldThrowECDSA384InstanceWithNullKey() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.ECDSA384(null);
     }
 
     @Test
-    public void shouldThrowECDSA512VerificationWithNullPublicKey() throws Exception {
+    public void shouldThrowECDSA384InstanceWithNullKeys() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The ECKey cannot be null");
+        exception.expectMessage("Both provided Keys cannot be null.");
+        Algorithm.ECDSA384(null, null);
+    }
+
+    @Test
+    public void shouldThrowECDSA512InstanceWithNullKey() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.ECDSA512(null);
+    }
+
+    @Test
+    public void shouldThrowECDSA512InstanceWithNullKeys() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Both provided Keys cannot be null.");
+        Algorithm.ECDSA512(null, null);
     }
 
     @Test
@@ -175,75 +217,231 @@ public class AlgorithmTest {
     }
 
     @Test
-    public void shouldCreateRSA256Algorithm() throws Exception {
-        RSAKey key = mock(RSAKey.class);
+    public void shouldCreateRSA256AlgorithmWithPublicKey() throws Exception {
+        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
         Algorithm algorithm = Algorithm.RSA256(key);
 
         assertThat(algorithm, is(notNullValue()));
         assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
         assertThat(algorithm.getDescription(), is("SHA256withRSA"));
         assertThat(algorithm.getName(), is("RS256"));
-        assertThat(((RSAAlgorithm) algorithm).getKey(), is(key));
+        assertThat(((RSAAlgorithm) algorithm).getPublicKey(), is(key));
     }
 
     @Test
-    public void shouldCreateRSA384Algorithm() throws Exception {
-        RSAKey key = mock(RSAKey.class);
+    public void shouldCreateRSA256AlgorithmWithPrivateKey() throws Exception {
+        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPrivateKey.class));
+        Algorithm algorithm = Algorithm.RSA256(key);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA256withRSA"));
+        assertThat(algorithm.getName(), is("RS256"));
+        assertThat(((RSAAlgorithm) algorithm).getPrivateKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateRSA256Algorithm() throws Exception {
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = Algorithm.RSA256(publicKey, privateKey);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA256withRSA"));
+        assertThat(algorithm.getName(), is("RS256"));
+        assertThat(((RSAAlgorithm) algorithm).getPublicKey(), is(publicKey));
+        assertThat(((RSAAlgorithm) algorithm).getPrivateKey(), is(privateKey));
+    }
+
+    @Test
+    public void shouldCreateRSA384AlgorithmWithPublicKey() throws Exception {
+        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
         Algorithm algorithm = Algorithm.RSA384(key);
 
         assertThat(algorithm, is(notNullValue()));
         assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
         assertThat(algorithm.getDescription(), is("SHA384withRSA"));
         assertThat(algorithm.getName(), is("RS384"));
-        assertThat(((RSAAlgorithm) algorithm).getKey(), is(key));
+        assertThat(((RSAAlgorithm) algorithm).getPublicKey(), is(key));
     }
 
     @Test
-    public void shouldCreateRSA512Algorithm() throws Exception {
-        RSAKey key = mock(RSAKey.class);
+    public void shouldCreateRSA384AlgorithmWithPrivateKey() throws Exception {
+        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPrivateKey.class));
+        Algorithm algorithm = Algorithm.RSA384(key);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA384withRSA"));
+        assertThat(algorithm.getName(), is("RS384"));
+        assertThat(((RSAAlgorithm) algorithm).getPrivateKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateRSA384Algorithm() throws Exception {
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = Algorithm.RSA384(publicKey, privateKey);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA384withRSA"));
+        assertThat(algorithm.getName(), is("RS384"));
+        assertThat(((RSAAlgorithm) algorithm).getPublicKey(), is(publicKey));
+        assertThat(((RSAAlgorithm) algorithm).getPrivateKey(), is(privateKey));
+    }
+
+    @Test
+    public void shouldCreateRSA512AlgorithmWithPublicKey() throws Exception {
+        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
         Algorithm algorithm = Algorithm.RSA512(key);
 
         assertThat(algorithm, is(notNullValue()));
         assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
         assertThat(algorithm.getDescription(), is("SHA512withRSA"));
         assertThat(algorithm.getName(), is("RS512"));
-        assertThat(((RSAAlgorithm) algorithm).getKey(), is(key));
+        assertThat(((RSAAlgorithm) algorithm).getPublicKey(), is(key));
     }
 
     @Test
-    public void shouldCreateECDSA256Algorithm() throws Exception {
-        ECKey key = mock(ECKey.class);
+    public void shouldCreateRSA512AlgorithmWithPrivateKey() throws Exception {
+        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPrivateKey.class));
+        Algorithm algorithm = Algorithm.RSA512(key);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA512withRSA"));
+        assertThat(algorithm.getName(), is("RS512"));
+        assertThat(((RSAAlgorithm) algorithm).getPrivateKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateRSA512Algorithm() throws Exception {
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = Algorithm.RSA512(publicKey, privateKey);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(RSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA512withRSA"));
+        assertThat(algorithm.getName(), is("RS512"));
+        assertThat(((RSAAlgorithm) algorithm).getPublicKey(), is(publicKey));
+        assertThat(((RSAAlgorithm) algorithm).getPrivateKey(), is(privateKey));
+    }
+
+    @Test
+    public void shouldCreateECDSA256AlgorithmWithPublicKey() throws Exception {
+        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
         Algorithm algorithm = Algorithm.ECDSA256(key);
 
         assertThat(algorithm, is(notNullValue()));
         assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
         assertThat(algorithm.getDescription(), is("SHA256withECDSA"));
         assertThat(algorithm.getName(), is("ES256"));
-        assertThat(((ECDSAAlgorithm) algorithm).getKey(), is(key));
+        assertThat(((ECDSAAlgorithm) algorithm).getPublicKey(), is(key));
     }
 
     @Test
-    public void shouldCreateECDSA384Algorithm() throws Exception {
-        ECKey key = mock(ECKey.class);
+    public void shouldCreateECDSA256AlgorithmWithPrivateKey() throws Exception {
+        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPrivateKey.class));
+        Algorithm algorithm = Algorithm.ECDSA256(key);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA256withECDSA"));
+        assertThat(algorithm.getName(), is("ES256"));
+        assertThat(((ECDSAAlgorithm) algorithm).getPrivateKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateECDSA256Algorithm() throws Exception {
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = Algorithm.ECDSA256(publicKey, privateKey);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA256withECDSA"));
+        assertThat(algorithm.getName(), is("ES256"));
+        assertThat(((ECDSAAlgorithm) algorithm).getPublicKey(), is(publicKey));
+        assertThat(((ECDSAAlgorithm) algorithm).getPrivateKey(), is(privateKey));
+    }
+
+    @Test
+    public void shouldCreateECDSA384AlgorithmWithPublicKey() throws Exception {
+        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
         Algorithm algorithm = Algorithm.ECDSA384(key);
 
         assertThat(algorithm, is(notNullValue()));
         assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
         assertThat(algorithm.getDescription(), is("SHA384withECDSA"));
         assertThat(algorithm.getName(), is("ES384"));
-        assertThat(((ECDSAAlgorithm) algorithm).getKey(), is(key));
+        assertThat(((ECDSAAlgorithm) algorithm).getPublicKey(), is(key));
     }
 
     @Test
-    public void shouldCreateECDSA512Algorithm() throws Exception {
-        ECKey key = mock(ECKey.class);
+    public void shouldCreateECDSA384AlgorithmWithPrivateKey() throws Exception {
+        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPrivateKey.class));
+        Algorithm algorithm = Algorithm.ECDSA384(key);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA384withECDSA"));
+        assertThat(algorithm.getName(), is("ES384"));
+        assertThat(((ECDSAAlgorithm) algorithm).getPrivateKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateECDSA384Algorithm() throws Exception {
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = Algorithm.ECDSA384(publicKey, privateKey);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA384withECDSA"));
+        assertThat(algorithm.getName(), is("ES384"));
+        assertThat(((ECDSAAlgorithm) algorithm).getPublicKey(), is(publicKey));
+        assertThat(((ECDSAAlgorithm) algorithm).getPrivateKey(), is(privateKey));
+    }
+
+    @Test
+    public void shouldCreateECDSA512AlgorithmWithPublicKey() throws Exception {
+        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
         Algorithm algorithm = Algorithm.ECDSA512(key);
 
         assertThat(algorithm, is(notNullValue()));
         assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
         assertThat(algorithm.getDescription(), is("SHA512withECDSA"));
         assertThat(algorithm.getName(), is("ES512"));
-        assertThat(((ECDSAAlgorithm) algorithm).getKey(), is(key));
+        assertThat(((ECDSAAlgorithm) algorithm).getPublicKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateECDSA512AlgorithmWithPrivateKey() throws Exception {
+        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPrivateKey.class));
+        Algorithm algorithm = Algorithm.ECDSA512(key);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA512withECDSA"));
+        assertThat(algorithm.getName(), is("ES512"));
+        assertThat(((ECDSAAlgorithm) algorithm).getPrivateKey(), is(key));
+    }
+
+    @Test
+    public void shouldCreateECDSA512Algorithm() throws Exception {
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = Algorithm.ECDSA512(publicKey, privateKey);
+
+        assertThat(algorithm, is(notNullValue()));
+        assertThat(algorithm, is(instanceOf(ECDSAAlgorithm.class)));
+        assertThat(algorithm.getDescription(), is("SHA512withECDSA"));
+        assertThat(algorithm.getName(), is("ES512"));
+        assertThat(((ECDSAAlgorithm) algorithm).getPublicKey(), is(publicKey));
+        assertThat(((ECDSAAlgorithm) algorithm).getPrivateKey(), is(privateKey));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -16,12 +16,12 @@ import java.security.interfaces.ECPublicKey;
 import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
 import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ECDSAAlgorithmTest {
 
@@ -62,6 +62,20 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
+    public void shouldPassECDSA256VerificationWithJOSESignatureWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
+        Algorithm algorithm = Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
+    public void shouldPassECDSA256VerificationWithDERSignatureWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.MEYCIQDiJWTf5jS/hFPj/0hpCWn7x1n/h+xPMjKWCs9MMusS9AIhAMcFPJVLe2A9uvb8hl8sRO2IpGoKDRpDmyH14ixNPAHW";
+        Algorithm algorithm = Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
     public void shouldFailECDSA256VerificationWithInvalidPublicKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA256withECDSA");
@@ -75,7 +89,7 @@ public class ECDSAAlgorithmTest {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA256withECDSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not an ECPublicKey.")));
+        exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.W9qfN1b80B9hnMo49WL8THrOsf1vEjOhapeFemPMGySzxTcgfyudS5esgeBTO908X5SLdAr5jMwPUPBs9b6nNg";
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
         AlgorithmUtils.verify(algorithm, jwt);
@@ -140,6 +154,20 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
+    public void shouldPassECDSA384VerificationWithJOSESignatureWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.50UU5VKNdF1wfykY8jQBKpvuHZoe6IZBJm5NvoB8bR-hnRg6ti-CHbmvoRtlLfnHfwITa_8cJMy6TenMC2g63GQHytc8rYoXqbwtS4R0Ko_AXbLFUmfxnGnMC6v4MS_z";
+        Algorithm algorithm = Algorithm.ECDSA384((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
+    public void shouldPassECDSA384VerificationWithDERSignatureWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.MGUCMQDnRRTlUo10XXB/KRjyNAEqm+4dmh7ohkEmbk2+gHxtH6GdGDq2L4Idua+hG2Ut+ccCMH8CE2v/HCTMuk3pzAtoOtxkB8rXPK2KF6m8LUuEdCqPwF2yxVJn8ZxpzAur+DEv8w==";
+        Algorithm algorithm = Algorithm.ECDSA384((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
     public void shouldFailECDSA384VerificationWithInvalidPublicKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA384withECDSA");
@@ -153,7 +181,7 @@ public class ECDSAAlgorithmTest {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA384withECDSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not an ECPublicKey.")));
+        exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9._k5h1KyO-NE0R2_HAw0-XEc0bGT5atv29SxHhOGC9JDqUHeUdptfCK_ljQ01nLVt2OQWT2SwGs-TuyHDFmhPmPGFZ9wboxvq_ieopmYqhQilNAu-WF-frioiRz9733fU";
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC"));
         AlgorithmUtils.verify(algorithm, jwt);
@@ -218,6 +246,20 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
+    public void shouldPassECDSA512VerificationWithJOSESignatureWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.AeCJPDIsSHhwRSGZCY6rspi8zekOw0K9qYMNridP1Fu9uhrA1QrG-EUxXlE06yvmh2R7Rz0aE7kxBwrnq8L8aOBCAYAsqhzPeUvyp8fXjjgs0Eto5I0mndE2QHlgcMSFASyjHbU8wD2Rq7ZNzGQ5b2MZfpv030WGUajT-aZYWFUJHVg2";
+        Algorithm algorithm = Algorithm.ECDSA512((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
+    public void shouldPassECDSA512VerificationWithDERSignatureWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0/UW726GsDVCsb4RTFeUTTrK+aHZHtHPRoTuTEHCuerwvxo4EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0/mmWFhVCR1YNg==";
+        Algorithm algorithm = Algorithm.ECDSA512((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
     public void shouldFailECDSA512VerificationWithInvalidPublicKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA512withECDSA");
@@ -231,7 +273,7 @@ public class ECDSAAlgorithmTest {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA512withECDSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not an ECPublicKey.")));
+        exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.AZgdopFFsN0amCSs2kOucXdpylD31DEm5ChK1PG0_gq5Mf47MrvVph8zHSVuvcrXzcE1U3VxeCg89mYW1H33Y-8iAF0QFkdfTUQIWKNObH543WNMYYssv3OtOj0znPv8atDbaF8DMYAtcT1qdmaSJRhx-egRE9HGZkinPh9CfLLLt58X";
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC"));
         AlgorithmUtils.verify(algorithm, jwt);
@@ -291,7 +333,9 @@ public class ECDSAAlgorithmTest {
         String signature = Base64.encodeBase64URLSafeString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
 
-        Algorithm algorithm = new ECDSAAlgorithm("ES256", "SHA256withECDSA", 128, (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"));
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm("ES256", "SHA256withECDSA", 128, publicKey, privateKey);
         AlgorithmUtils.verify(algorithm, jwt);
     }
 
@@ -305,8 +349,9 @@ public class ECDSAAlgorithmTest {
         when(crypto.verifySignatureFor(anyString(), any(PublicKey.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -321,8 +366,9 @@ public class ECDSAAlgorithmTest {
         when(crypto.verifySignatureFor(anyString(), any(PublicKey.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -337,8 +383,9 @@ public class ECDSAAlgorithmTest {
         when(crypto.verifySignatureFor(anyString(), any(PublicKey.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -361,11 +408,21 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
+    public void shouldDoECDSA256SigningWithBothKeys() throws Exception {
+        Algorithm algorithm = Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
+        byte[] contentBytes = String.format("%s.%s", ES256Header, auth0IssPayload).getBytes(StandardCharsets.UTF_8);
+        byte[] signatureBytes = algorithm.sign(contentBytes);
+
+        assertThat(signatureBytes, is(notNullValue()));
+        algorithm.verify(contentBytes, signatureBytes);
+    }
+
+    @Test
     public void shouldFailOnECDSA256SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA256withECDSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not a ECPrivateKey.")));
+        exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"));
         algorithm.sign(new byte[0]);
@@ -383,11 +440,21 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
+    public void shouldDoECDSA384SigningWithBothKeys() throws Exception {
+        Algorithm algorithm = Algorithm.ECDSA384((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC"));
+        byte[] contentBytes = String.format("%s.%s", ES384Header, auth0IssPayload).getBytes(StandardCharsets.UTF_8);
+        byte[] signatureBytes = algorithm.sign(contentBytes);
+
+        assertThat(signatureBytes, is(notNullValue()));
+        algorithm.verify(contentBytes, signatureBytes);
+    }
+
+    @Test
     public void shouldFailOnECDSA384SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA384withECDSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not a ECPrivateKey.")));
+        exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC"));
         algorithm.sign(new byte[0]);
@@ -405,11 +472,21 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
+    public void shouldDoECDSA512SigningWithBothKeys() throws Exception {
+        Algorithm algorithm = Algorithm.ECDSA512((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC"));
+        byte[] contentBytes = String.format("%s.%s", ES512Header, auth0IssPayload).getBytes(StandardCharsets.UTF_8);
+        byte[] signatureBytes = algorithm.sign(contentBytes);
+
+        assertThat(signatureBytes, is(notNullValue()));
+        algorithm.verify(contentBytes, signatureBytes);
+    }
+
+    @Test
     public void shouldFailOnECDSA512SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA512withECDSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not a ECPrivateKey.")));
+        exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC"));
         algorithm.sign(new byte[0]);
@@ -425,8 +502,9 @@ public class ECDSAAlgorithmTest {
         when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPrivateKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -440,24 +518,9 @@ public class ECDSAAlgorithmTest {
         when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPrivateKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
-        algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
-    }
-
-    @Test
-    public void shouldThrowOnSignWhenUsingPublicKey() throws Exception {
-        exception.expect(SignatureGenerationException.class);
-        exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: some-algorithm");
-        exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given ECKey is not a ECPrivateKey.")));
-
-        CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
-                .thenThrow(InvalidKeyException.class);
-
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPublicKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -471,8 +534,9 @@ public class ECDSAAlgorithmTest {
         when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
-        ECKey key = mock(ECKey.class, withSettings().extraInterfaces(ECPrivateKey.class));
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, key);
+        ECPublicKey publicKey = mock(ECPublicKey.class);
+        ECPrivateKey privateKey = mock(ECPrivateKey.class);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -88,7 +88,7 @@ public class ECDSAAlgorithmTest {
     public void shouldFailECDSA256VerificationWhenUsingPrivateKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA256withECDSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.W9qfN1b80B9hnMo49WL8THrOsf1vEjOhapeFemPMGySzxTcgfyudS5esgeBTO908X5SLdAr5jMwPUPBs9b6nNg";
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
@@ -180,7 +180,7 @@ public class ECDSAAlgorithmTest {
     public void shouldFailECDSA384VerificationWhenUsingPrivateKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA384withECDSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9._k5h1KyO-NE0R2_HAw0-XEc0bGT5atv29SxHhOGC9JDqUHeUdptfCK_ljQ01nLVt2OQWT2SwGs-TuyHDFmhPmPGFZ9wboxvq_ieopmYqhQilNAu-WF-frioiRz9733fU";
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC"));
@@ -272,7 +272,7 @@ public class ECDSAAlgorithmTest {
     public void shouldFailECDSA512VerificationWhenUsingPrivateKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA512withECDSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.AZgdopFFsN0amCSs2kOucXdpylD31DEm5ChK1PG0_gq5Mf47MrvVph8zHSVuvcrXzcE1U3VxeCg89mYW1H33Y-8iAF0QFkdfTUQIWKNObH543WNMYYssv3OtOj0znPv8atDbaF8DMYAtcT1qdmaSJRhx-egRE9HGZkinPh9CfLLLt58X";
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC"));
@@ -421,7 +421,7 @@ public class ECDSAAlgorithmTest {
     public void shouldFailOnECDSA256SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA256withECDSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"));
@@ -453,7 +453,7 @@ public class ECDSAAlgorithmTest {
     public void shouldFailOnECDSA384SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA384withECDSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC"));
@@ -485,7 +485,7 @@ public class ECDSAAlgorithmTest {
     public void shouldFailOnECDSA512SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA512withECDSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC"));

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -61,7 +61,7 @@ public class RSAAlgorithmTest {
     public void shouldFailRSA256VerificationWhenUsingPrivateKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA256withRSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         Algorithm algorithm = Algorithm.RSA256((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
@@ -95,7 +95,7 @@ public class RSAAlgorithmTest {
     public void shouldFailRSA384VerificationWhenUsingPrivateKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA384withRSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.TZlWjXObwGSQOiu2oMq8kiKz0_BR7bbBddNL6G8eZ_GoR82BXOZDqNrQr7lb_M-78XGBguWLWNIdYhzgxOUL9EoCJlrqVm9s9vo6G8T1sj1op-4TbjXZ61TwIvrJee9BvPLdKUJ9_fp1Js5kl6yXkst40Th8Auc5as4n49MLkipjpEhKDKaENKHpSubs1ripSz8SCQZSofeTM_EWVwSw7cpiM8Fy8jOPvWG8Xz4-e3ODFowvHVsDcONX_4FTMNbeRqDuHq2ZhCJnEfzcSJdrve_5VD5fM1LperBVslTrOxIgClOJ3RmM7-WnaizJrWP3D6Z9OLxPxLhM6-jx6tcxEw";
         Algorithm algorithm = Algorithm.RSA384((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
@@ -129,7 +129,7 @@ public class RSAAlgorithmTest {
     public void shouldFailRSA512VerificationWhenUsingPrivateKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA512withRSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mvL5LoMyIrWYjk5umEXZTmbyIrkbbcVPUkvdGZbu0qFBxGOf0nXP5PZBvPcOu084lvpwVox5n3VaD4iqzW-PsJyvKFgi5TnwmsbKchAp7JexQEsQOnTSGcfRqeUUiBZqRQdYsho71oAB3T4FnalDdFEpM-fztcZY9XqKyayqZLreTeBjqJm4jfOWH7KfGBHgZExQhe96NLq1UA9eUyQwdOA1Z0SgXe4Ja5PxZ6Fm37KnVDtDlNnY4JAAGFo6y74aGNnp_BKgpaVJCGFu1f1S5xCQ1HSvs8ZSdVWs5NgawW3wRd0kRt_GJ_Y3mIwiF4qUyHWGtsSHu_qjVdCTtbFyow";
         Algorithm algorithm = Algorithm.RSA512((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
@@ -227,7 +227,7 @@ public class RSAAlgorithmTest {
     public void shouldFailOnRSA256SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA256withRSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.RSA256((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
@@ -267,7 +267,7 @@ public class RSAAlgorithmTest {
     public void shouldFailOnRSA384SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA384withRSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.RSA384((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
@@ -307,7 +307,7 @@ public class RSAAlgorithmTest {
     public void shouldFailOnRSA512SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA512withRSA");
-        exception.expectCause(isA(IllegalArgumentException.class));
+        exception.expectCause(isA(IllegalStateException.class));
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.RSA512((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -16,12 +16,12 @@ import java.security.interfaces.RSAPublicKey;
 import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
 import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RSAAlgorithmTest {
 
@@ -42,6 +42,13 @@ public class RSAAlgorithmTest {
     }
 
     @Test
+    public void shouldPassRSA256VerificationWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
+        Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"), (RSAPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
     public void shouldFailRSA256VerificationWithInvalidPublicKey() throws Exception {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA256withRSA");
@@ -55,7 +62,7 @@ public class RSAAlgorithmTest {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA256withRSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPublicKey.")));
+        exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         Algorithm algorithm = Algorithm.RSA256((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
         AlgorithmUtils.verify(algorithm, jwt);
@@ -65,6 +72,13 @@ public class RSAAlgorithmTest {
     public void shouldPassRSA384Verification() throws Exception {
         String jwt = "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.TZlWjXObwGSQOiu2oMq8kiKz0_BR7bbBddNL6G8eZ_GoR82BXOZDqNrQr7lb_M-78XGBguWLWNIdYhzgxOUL9EoCJlrqVm9s9vo6G8T1sj1op-4TbjXZ61TwIvrJee9BvPLdKUJ9_fp1Js5kl6yXkst40Th8Auc5as4n49MLkipjpEhKDKaENKHpSubs1ripSz8SCQZSofeTM_EWVwSw7cpiM8Fy8jOPvWG8Xz4-e3ODFowvHVsDcONX_4FTMNbeRqDuHq2ZhCJnEfzcSJdrve_5VD5fM1LperBVslTrOxIgClOJ3RmM7-WnaizJrWP3D6Z9OLxPxLhM6-jx6tcxEw";
         Algorithm algorithm = Algorithm.RSA384((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
+    public void shouldPassRSA384VerificationWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.TZlWjXObwGSQOiu2oMq8kiKz0_BR7bbBddNL6G8eZ_GoR82BXOZDqNrQr7lb_M-78XGBguWLWNIdYhzgxOUL9EoCJlrqVm9s9vo6G8T1sj1op-4TbjXZ61TwIvrJee9BvPLdKUJ9_fp1Js5kl6yXkst40Th8Auc5as4n49MLkipjpEhKDKaENKHpSubs1ripSz8SCQZSofeTM_EWVwSw7cpiM8Fy8jOPvWG8Xz4-e3ODFowvHVsDcONX_4FTMNbeRqDuHq2ZhCJnEfzcSJdrve_5VD5fM1LperBVslTrOxIgClOJ3RmM7-WnaizJrWP3D6Z9OLxPxLhM6-jx6tcxEw";
+        Algorithm algorithm = Algorithm.RSA384((RSAPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"), (RSAPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
         AlgorithmUtils.verify(algorithm, jwt);
     }
 
@@ -82,7 +96,7 @@ public class RSAAlgorithmTest {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA384withRSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPublicKey.")));
+        exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.TZlWjXObwGSQOiu2oMq8kiKz0_BR7bbBddNL6G8eZ_GoR82BXOZDqNrQr7lb_M-78XGBguWLWNIdYhzgxOUL9EoCJlrqVm9s9vo6G8T1sj1op-4TbjXZ61TwIvrJee9BvPLdKUJ9_fp1Js5kl6yXkst40Th8Auc5as4n49MLkipjpEhKDKaENKHpSubs1ripSz8SCQZSofeTM_EWVwSw7cpiM8Fy8jOPvWG8Xz4-e3ODFowvHVsDcONX_4FTMNbeRqDuHq2ZhCJnEfzcSJdrve_5VD5fM1LperBVslTrOxIgClOJ3RmM7-WnaizJrWP3D6Z9OLxPxLhM6-jx6tcxEw";
         Algorithm algorithm = Algorithm.RSA384((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
         AlgorithmUtils.verify(algorithm, jwt);
@@ -92,6 +106,13 @@ public class RSAAlgorithmTest {
     public void shouldPassRSA512Verification() throws Exception {
         String jwt = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mvL5LoMyIrWYjk5umEXZTmbyIrkbbcVPUkvdGZbu0qFBxGOf0nXP5PZBvPcOu084lvpwVox5n3VaD4iqzW-PsJyvKFgi5TnwmsbKchAp7JexQEsQOnTSGcfRqeUUiBZqRQdYsho71oAB3T4FnalDdFEpM-fztcZY9XqKyayqZLreTeBjqJm4jfOWH7KfGBHgZExQhe96NLq1UA9eUyQwdOA1Z0SgXe4Ja5PxZ6Fm37KnVDtDlNnY4JAAGFo6y74aGNnp_BKgpaVJCGFu1f1S5xCQ1HSvs8ZSdVWs5NgawW3wRd0kRt_GJ_Y3mIwiF4qUyHWGtsSHu_qjVdCTtbFyow";
         Algorithm algorithm = Algorithm.RSA512((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
+        AlgorithmUtils.verify(algorithm, jwt);
+    }
+
+    @Test
+    public void shouldPassRSA512VerificationWithBothKeys() throws Exception {
+        String jwt = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mvL5LoMyIrWYjk5umEXZTmbyIrkbbcVPUkvdGZbu0qFBxGOf0nXP5PZBvPcOu084lvpwVox5n3VaD4iqzW-PsJyvKFgi5TnwmsbKchAp7JexQEsQOnTSGcfRqeUUiBZqRQdYsho71oAB3T4FnalDdFEpM-fztcZY9XqKyayqZLreTeBjqJm4jfOWH7KfGBHgZExQhe96NLq1UA9eUyQwdOA1Z0SgXe4Ja5PxZ6Fm37KnVDtDlNnY4JAAGFo6y74aGNnp_BKgpaVJCGFu1f1S5xCQ1HSvs8ZSdVWs5NgawW3wRd0kRt_GJ_Y3mIwiF4qUyHWGtsSHu_qjVdCTtbFyow";
+        Algorithm algorithm = Algorithm.RSA512((RSAPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"), (RSAPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
         AlgorithmUtils.verify(algorithm, jwt);
     }
 
@@ -109,7 +130,7 @@ public class RSAAlgorithmTest {
         exception.expect(SignatureVerificationException.class);
         exception.expectMessage("The Token's Signature resulted invalid when verified using the Algorithm: SHA512withRSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPublicKey.")));
+        exception.expectCause(hasMessage(is("The given Public Key is null.")));
         String jwt = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mvL5LoMyIrWYjk5umEXZTmbyIrkbbcVPUkvdGZbu0qFBxGOf0nXP5PZBvPcOu084lvpwVox5n3VaD4iqzW-PsJyvKFgi5TnwmsbKchAp7JexQEsQOnTSGcfRqeUUiBZqRQdYsho71oAB3T4FnalDdFEpM-fztcZY9XqKyayqZLreTeBjqJm4jfOWH7KfGBHgZExQhe96NLq1UA9eUyQwdOA1Z0SgXe4Ja5PxZ6Fm37KnVDtDlNnY4JAAGFo6y74aGNnp_BKgpaVJCGFu1f1S5xCQ1HSvs8ZSdVWs5NgawW3wRd0kRt_GJ_Y3mIwiF4qUyHWGtsSHu_qjVdCTtbFyow";
         Algorithm algorithm = Algorithm.RSA512((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
         AlgorithmUtils.verify(algorithm, jwt);
@@ -125,8 +146,9 @@ public class RSAAlgorithmTest {
         when(crypto.verifySignatureFor(anyString(), any(PublicKey.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -141,8 +163,9 @@ public class RSAAlgorithmTest {
         when(crypto.verifySignatureFor(anyString(), any(PublicKey.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -157,8 +180,9 @@ public class RSAAlgorithmTest {
         when(crypto.verifySignatureFor(anyString(), any(PublicKey.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -186,11 +210,25 @@ public class RSAAlgorithmTest {
     }
 
     @Test
+    public void shouldDoRSA256SigningWithBothKeys() throws Exception {
+        Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"), (RSAPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
+
+        byte[] contentBytes = String.format("%s.%s", RS256Header, auth0IssPayload).getBytes(StandardCharsets.UTF_8);
+        byte[] signatureBytes = algorithm.sign(contentBytes);
+        String signature = Base64.encodeBase64URLSafeString(signatureBytes);
+        String expectedSignature = "ZB-Tr0vLtnf8I9fhSdSjU6HZei5xLYZQ6nZqM5O6Va0W9PgAqgRT7ShI9CjeYulRXPHvVmSl5EQuYuXdBzM0-H_3p_Nsl6tSMy4EyX2kkhEm6T0HhvarTh8CG0PCjn5p6FP5ZxWwhLcmRN70ItP6Z5MMO4CcJh1JrNxR4Fi4xQgt-CK2aVDMFXd-Br5yQiLVx1CX83w28OD9wssW3Rdltl5e66vCef0Ql6Q5I5e5F0nqGYT989a9fkNgLIx2F8k_az5x07BY59FV2SZg59nSiY7TZNjP8ot11Ew7HKRfPXOdh9eKRUVdhcxzqDePhyzKabU8TG5FP0SiWH5qVPfAgw";
+
+        assertThat(signature, is(notNullValue()));
+        assertThat(signature, is(expectedSignature));
+        algorithm.verify(contentBytes, signatureBytes);
+    }
+
+    @Test
     public void shouldFailOnRSA256SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA256withRSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPrivateKey.")));
+        exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.RSA256((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
         algorithm.sign(new byte[0]);
@@ -212,11 +250,25 @@ public class RSAAlgorithmTest {
     }
 
     @Test
+    public void shouldDoRSA384SigningWithBothKeys() throws Exception {
+        Algorithm algorithm = Algorithm.RSA384((RSAPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"), (RSAPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
+
+        byte[] contentBytes = String.format("%s.%s", RS384Header, auth0IssPayload).getBytes(StandardCharsets.UTF_8);
+        byte[] signatureBytes = algorithm.sign(contentBytes);
+        String signature = Base64.encodeBase64URLSafeString(signatureBytes);
+        String expectedSignature = "Jx1PaTBnjd_U56MNjifFcY7w9ImDbseg0y8Ijr2pSiA1_wzQb_wy9undaWfzR5YqdIAXvjS8AGuZUAzIoTG4KMgOgdVyYDz3l2jzj6wI-lgqfR5hTy1w1ruMUQ4_wobpdxAiJ4fEbg8Mi_GljOiCO-P1HilxKnpiOJZidR8MQGwTInsf71tOUkK4x5UsdmUueuZbaU-CL5kPnRfXmJj9CcdxZbD9oMlbo23dwkP5BNMrS2LwGGzc9C_-ypxrBIOVilG3WZxcSmuG86LjcZbnL6LBEfph5NmKBgQav147uipb_7umBEr1m2dYiB_9u606n3bcoo3rnsYYK_Xfi1GAEQ";
+
+        assertThat(signature, is(notNullValue()));
+        assertThat(signature, is(expectedSignature));
+        algorithm.verify(contentBytes, signatureBytes);
+    }
+
+    @Test
     public void shouldFailOnRSA384SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA384withRSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPrivateKey.")));
+        exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.RSA384((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
         algorithm.sign(new byte[0]);
@@ -238,11 +290,25 @@ public class RSAAlgorithmTest {
     }
 
     @Test
+    public void shouldDoRSA512SigningWithBothKeys() throws Exception {
+        Algorithm algorithm = Algorithm.RSA512((RSAPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"), (RSAPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
+
+        byte[] contentBytes = String.format("%s.%s", RS512Header, auth0IssPayload).getBytes(StandardCharsets.UTF_8);
+        byte[] signatureBytes = algorithm.sign(contentBytes);
+        String signature = Base64.encodeBase64URLSafeString(signatureBytes);
+        String expectedSignature = "THIPVYzNZ1Yo_dm0k1UELqV0txs3SzyMopCyHcLXOOdgYXF4MlGvBqu0CFvgSga72Sp5LpuC1Oesj40v_QDsp2GTGDeWnvvcv_eo-b0LPSpmT2h1Ibrmu-z70u2rKf28pkN-AJiMFqi8sit2kMIp1bwIVOovPvMTQKGFmova4Xwb3G526y_PeLlflW1h69hQTIVcI67ACEkAC-byjDnnYIklA-B4GWcggEoFwQRTdRjAUpifA6HOlvnBbZZlUd6KXwEydxVS-eh1odwPjB2_sfbyy5HnLsvNdaniiZQwX7QbwLNT4F72LctYdHHM1QCrID6bgfgYp9Ij9CRX__XDEA";
+
+        assertThat(signature, is(notNullValue()));
+        assertThat(signature, is(expectedSignature));
+        algorithm.verify(contentBytes, signatureBytes);
+    }
+
+    @Test
     public void shouldFailOnRSA512SigningWhenUsingPublicKey() throws Exception {
         exception.expect(SignatureGenerationException.class);
         exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: SHA512withRSA");
         exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPrivateKey.")));
+        exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         Algorithm algorithm = Algorithm.RSA512((RSAKey) readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA"));
         algorithm.sign(new byte[0]);
@@ -258,8 +324,9 @@ public class RSAAlgorithmTest {
         when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPrivateKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
         algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -273,24 +340,9 @@ public class RSAAlgorithmTest {
         when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPrivateKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
-        algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
-    }
-
-    @Test
-    public void shouldThrowOnSignWhenUsingPublicKey() throws Exception {
-        exception.expect(SignatureGenerationException.class);
-        exception.expectMessage("The Token's Signature couldn't be generated when signing using the Algorithm: some-algorithm");
-        exception.expectCause(isA(IllegalArgumentException.class));
-        exception.expectCause(hasMessage(is("The given RSAKey is not a RSAPrivateKey.")));
-
-        CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
-                .thenThrow(InvalidKeyException.class);
-
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPublicKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
         algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -304,8 +356,9 @@ public class RSAAlgorithmTest {
         when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
-        RSAKey key = mock(RSAKey.class, withSettings().extraInterfaces(RSAPrivateKey.class));
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", key);
+        RSAPublicKey publicKey = mock(RSAPublicKey.class);
+        RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
         algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
Before this PR, the `Algorithm` instance received one key (public or private). With the introduced changes, the `Algorithm` is now instantiated with both keys at the same time. So the user can define the instance once and reuse it as needed for both signing and verifying purposes.

* If both keys are null, `IllegalArgumentException` is thrown upon instantiation.
* If the public key is null when the user calls `verify`, `IllegalStateException` is thrown.
* If the private key is null when the user calls `sign`, `IllegalStateException` is thrown.