### PR TITLE
Add Algorithm KeyProvider interface

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -2,6 +2,8 @@ package com.auth0.jwt.algorithms;
 
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.ECKeyProvider;
+import com.auth0.jwt.interfaces.RSAKeyProvider;
 
 import java.io.UnsupportedEncodingException;
 import java.security.interfaces.*;
@@ -18,9 +20,20 @@ public abstract class Algorithm {
     /**
      * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
      *
-     * @param key the key to use in the verify or signing instance.
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
      * @return a valid RSA256 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm RSA256(RSAKeyProvider keyProvider) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS256", "SHA256withRSA", keyProvider);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
+     *
+     * @param key the key to use in the verify or signing instance.
+     * @return a valid RSA256 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
      * @deprecated use {@link #RSA256(RSAPublicKey, RSAPrivateKey)}
      */
     @Deprecated
@@ -43,6 +56,17 @@ public abstract class Algorithm {
         RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
         RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
         return RSA384(publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
+     *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid RSA384 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm RSA384(RSAKeyProvider keyProvider) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS384", "SHA384withRSA", keyProvider);
     }
 
     /**
@@ -94,6 +118,17 @@ public abstract class Algorithm {
      */
     public static Algorithm RSA512(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
         return new RSAAlgorithm("RS512", "SHA512withRSA", publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA512withRSA. Tokens specify this as "RS512".
+     *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid RSA512 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm RSA512(RSAKeyProvider keyProvider) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS512", "SHA512withRSA", keyProvider);
     }
 
     /**
@@ -181,6 +216,17 @@ public abstract class Algorithm {
     }
 
     /**
+     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
+     *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid ECDSA256 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm ECDSA256(ECKeyProvider keyProvider) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, keyProvider);
+    }
+
+    /**
      * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
      *
      * @param key the key to use in the verify or signing instance.
@@ -193,6 +239,17 @@ public abstract class Algorithm {
         ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
         ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
         return ECDSA384(publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
+     *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid ECDSA384 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm ECDSA384(ECKeyProvider keyProvider) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, keyProvider);
     }
 
     /**
@@ -244,6 +301,17 @@ public abstract class Algorithm {
      */
     public static Algorithm ECDSA512(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
         return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA512withECDSA. Tokens specify this as "ES512".
+     *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid ECDSA512 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm ECDSA512(ECKeyProvider keyProvider) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, keyProvider);
     }
 
     public static Algorithm none() {

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -31,6 +31,18 @@ public abstract class Algorithm {
     /**
      * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
      *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid RSA256 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA256(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS256", "SHA256withRSA", publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
+     *
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA256 Algorithm.
      * @throws IllegalArgumentException if the Key Provider is null.
@@ -41,6 +53,29 @@ public abstract class Algorithm {
         RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
         RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
         return RSA256(publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
+     *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid RSA384 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm RSA384(RSAKeyProvider keyProvider) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS384", "SHA384withRSA", keyProvider);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid RSA384 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA384(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS384", "SHA384withRSA", publicKey, privateKey);
     }
 
     /**
@@ -59,53 +94,14 @@ public abstract class Algorithm {
     }
 
     /**
-     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
-     *
-     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
-     * @return a valid RSA384 Algorithm.
-     * @throws IllegalArgumentException if the Key Provider is null.
-     */
-    public static Algorithm RSA384(RSAKeyProvider keyProvider) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS384", "SHA384withRSA", keyProvider);
-    }
-
-    /**
      * Creates a new Algorithm instance using SHA512withRSA. Tokens specify this as "RS512".
      *
-     * @param key the key to use in the verify or signing instance.
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
      * @return a valid RSA512 Algorithm.
-     * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #RSA512(RSAPublicKey, RSAPrivateKey)}
+     * @throws IllegalArgumentException if the Key Provider is null.
      */
-    @Deprecated
-    public static Algorithm RSA512(RSAKey key) throws IllegalArgumentException {
-        RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
-        RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
-        return RSA512(publicKey, privateKey);
-    }
-
-    /**
-     * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
-     *
-     * @param publicKey  the key to use in the verify instance.
-     * @param privateKey the key to use in the signing instance.
-     * @return a valid RSA256 Algorithm.
-     * @throws IllegalArgumentException if both provided Keys are null.
-     */
-    public static Algorithm RSA256(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS256", "SHA256withRSA", publicKey, privateKey);
-    }
-
-    /**
-     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
-     *
-     * @param publicKey  the key to use in the verify instance.
-     * @param privateKey the key to use in the signing instance.
-     * @return a valid RSA384 Algorithm.
-     * @throws IllegalArgumentException if both provided Keys are null.
-     */
-    public static Algorithm RSA384(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS384", "SHA384withRSA", publicKey, privateKey);
+    public static Algorithm RSA512(RSAKeyProvider keyProvider) throws IllegalArgumentException {
+        return new RSAAlgorithm("RS512", "SHA512withRSA", keyProvider);
     }
 
     /**
@@ -123,12 +119,16 @@ public abstract class Algorithm {
     /**
      * Creates a new Algorithm instance using SHA512withRSA. Tokens specify this as "RS512".
      *
-     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @param key the key to use in the verify or signing instance.
      * @return a valid RSA512 Algorithm.
-     * @throws IllegalArgumentException if the Key Provider is null.
+     * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #RSA512(RSAPublicKey, RSAPrivateKey)}
      */
-    public static Algorithm RSA512(RSAKeyProvider keyProvider) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS512", "SHA512withRSA", keyProvider);
+    @Deprecated
+    public static Algorithm RSA512(RSAKey key) throws IllegalArgumentException {
+        RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
+        RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
+        return RSA512(publicKey, privateKey);
     }
 
     /**
@@ -203,6 +203,29 @@ public abstract class Algorithm {
     /**
      * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
      *
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @return a valid ECDSA256 Algorithm.
+     * @throws IllegalArgumentException if the Key Provider is null.
+     */
+    public static Algorithm ECDSA256(ECKeyProvider keyProvider) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, keyProvider);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid ECDSA256 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA256(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, publicKey, privateKey);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
+     *
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA256 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
@@ -216,14 +239,26 @@ public abstract class Algorithm {
     }
 
     /**
-     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
+     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
      *
      * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
-     * @return a valid ECDSA256 Algorithm.
+     * @return a valid ECDSA384 Algorithm.
      * @throws IllegalArgumentException if the Key Provider is null.
      */
-    public static Algorithm ECDSA256(ECKeyProvider keyProvider) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, keyProvider);
+    public static Algorithm ECDSA384(ECKeyProvider keyProvider) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, keyProvider);
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @return a valid ECDSA384 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA384(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, publicKey, privateKey);
     }
 
     /**
@@ -242,53 +277,14 @@ public abstract class Algorithm {
     }
 
     /**
-     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
-     *
-     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
-     * @return a valid ECDSA384 Algorithm.
-     * @throws IllegalArgumentException if the Key Provider is null.
-     */
-    public static Algorithm ECDSA384(ECKeyProvider keyProvider) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, keyProvider);
-    }
-
-    /**
      * Creates a new Algorithm instance using SHA512withECDSA. Tokens specify this as "ES512".
      *
-     * @param key the key to use in the verify or signing instance.
+     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
      * @return a valid ECDSA512 Algorithm.
-     * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA512(ECPublicKey, ECPrivateKey)}
+     * @throws IllegalArgumentException if the Key Provider is null.
      */
-    @Deprecated
-    public static Algorithm ECDSA512(ECKey key) throws IllegalArgumentException {
-        ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
-        ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
-        return ECDSA512(publicKey, privateKey);
-    }
-
-    /**
-     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
-     *
-     * @param publicKey  the key to use in the verify instance.
-     * @param privateKey the key to use in the signing instance.
-     * @return a valid ECDSA256 Algorithm.
-     * @throws IllegalArgumentException if the provided Key is null.
-     */
-    public static Algorithm ECDSA256(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, publicKey, privateKey);
-    }
-
-    /**
-     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
-     *
-     * @param publicKey  the key to use in the verify instance.
-     * @param privateKey the key to use in the signing instance.
-     * @return a valid ECDSA384 Algorithm.
-     * @throws IllegalArgumentException if the provided Key is null.
-     */
-    public static Algorithm ECDSA384(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, publicKey, privateKey);
+    public static Algorithm ECDSA512(ECKeyProvider keyProvider) throws IllegalArgumentException {
+        return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, keyProvider);
     }
 
     /**
@@ -306,13 +302,18 @@ public abstract class Algorithm {
     /**
      * Creates a new Algorithm instance using SHA512withECDSA. Tokens specify this as "ES512".
      *
-     * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
+     * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA512 Algorithm.
-     * @throws IllegalArgumentException if the Key Provider is null.
+     * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated use {@link #ECDSA512(ECPublicKey, ECPrivateKey)}
      */
-    public static Algorithm ECDSA512(ECKeyProvider keyProvider) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, keyProvider);
+    @Deprecated
+    public static Algorithm ECDSA512(ECKey key) throws IllegalArgumentException {
+        ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
+        ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
+        return ECDSA512(publicKey, privateKey);
     }
+
 
     public static Algorithm none() {
         return new NoneAlgorithm();

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -37,7 +37,7 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if both provided Keys are null.
      */
     public static Algorithm RSA256(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS256", "SHA256withRSA", publicKey, privateKey);
+        return RSA256(RSAAlgorithm.providerForKeys(publicKey, privateKey));
     }
 
     /**
@@ -46,7 +46,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA256 Algorithm.
      * @throws IllegalArgumentException if the Key Provider is null.
-     * @deprecated use {@link #RSA256(RSAPublicKey, RSAPrivateKey)}
+     * @deprecated use {@link #RSA256(RSAPublicKey, RSAPrivateKey)} or {@link #RSA256(RSAKeyProvider)}
      */
     @Deprecated
     public static Algorithm RSA256(RSAKey key) throws IllegalArgumentException {
@@ -75,7 +75,7 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if both provided Keys are null.
      */
     public static Algorithm RSA384(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS384", "SHA384withRSA", publicKey, privateKey);
+        return RSA384(RSAAlgorithm.providerForKeys(publicKey, privateKey));
     }
 
     /**
@@ -84,7 +84,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA384 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #RSA384(RSAPublicKey, RSAPrivateKey)}
+     * @deprecated use {@link #RSA384(RSAPublicKey, RSAPrivateKey)} or {@link #RSA384(RSAKeyProvider)}
      */
     @Deprecated
     public static Algorithm RSA384(RSAKey key) throws IllegalArgumentException {
@@ -113,7 +113,7 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if both provided Keys are null.
      */
     public static Algorithm RSA512(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return new RSAAlgorithm("RS512", "SHA512withRSA", publicKey, privateKey);
+        return RSA512(RSAAlgorithm.providerForKeys(publicKey, privateKey));
     }
 
     /**
@@ -122,7 +122,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA512 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #RSA512(RSAPublicKey, RSAPrivateKey)}
+     * @deprecated use {@link #RSA512(RSAPublicKey, RSAPrivateKey)} or {@link #RSA512(RSAKeyProvider)}
      */
     @Deprecated
     public static Algorithm RSA512(RSAKey key) throws IllegalArgumentException {
@@ -220,7 +220,7 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if the provided Key is null.
      */
     public static Algorithm ECDSA256(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES256", "SHA256withECDSA", 32, publicKey, privateKey);
+        return ECDSA256(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
     }
 
     /**
@@ -229,7 +229,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA256 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA256(ECPublicKey, ECPrivateKey)}
+     * @deprecated use {@link #ECDSA256(ECPublicKey, ECPrivateKey)} or {@link #ECDSA256(ECKeyProvider)}
      */
     @Deprecated
     public static Algorithm ECDSA256(ECKey key) throws IllegalArgumentException {
@@ -258,7 +258,7 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if the provided Key is null.
      */
     public static Algorithm ECDSA384(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES384", "SHA384withECDSA", 48, publicKey, privateKey);
+        return ECDSA384(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
     }
 
     /**
@@ -267,7 +267,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA384 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA384(ECPublicKey, ECPrivateKey)}
+     * @deprecated use {@link #ECDSA384(ECPublicKey, ECPrivateKey)} or {@link #ECDSA384(ECKeyProvider)}
      */
     @Deprecated
     public static Algorithm ECDSA384(ECKey key) throws IllegalArgumentException {
@@ -296,7 +296,7 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if the provided Key is null.
      */
     public static Algorithm ECDSA512(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return new ECDSAAlgorithm("ES512", "SHA512withECDSA", 66, publicKey, privateKey);
+        return ECDSA512(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
     }
 
     /**
@@ -305,7 +305,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA512 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA512(ECPublicKey, ECPrivateKey)}
+     * @deprecated use {@link #ECDSA512(ECPublicKey, ECPrivateKey)} or {@link #ECDSA512(ECKeyProvider)}
      */
     @Deprecated
     public static Algorithm ECDSA512(ECKey key) throws IllegalArgumentException {

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -30,10 +30,6 @@ class ECDSAAlgorithm extends Algorithm {
         this.ecNumberSize = ecNumberSize;
     }
 
-    ECDSAAlgorithm(String id, String algorithm, int ecNumberSize, ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        this(new CryptoHelper(), id, algorithm, ecNumberSize, providerForKeys(publicKey, privateKey));
-    }
-
     ECDSAAlgorithm(String id, String algorithm, int ecNumberSize, ECKeyProvider keyProvider) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, ecNumberSize, keyProvider);
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -2,6 +2,7 @@ package com.auth0.jwt.algorithms;
 
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.ECKeyProvider;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -11,45 +12,50 @@ import java.security.interfaces.ECPublicKey;
 
 class ECDSAAlgorithm extends Algorithm {
 
-    private final ECPublicKey publicKey;
-    private final ECPrivateKey privateKey;
+    private final ECKeyProvider keyProvider;
     private final CryptoHelper crypto;
     private final int ecNumberSize;
 
     //Visible for testing
-    ECDSAAlgorithm(CryptoHelper crypto, String id, String algorithm, int ecNumberSize, ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
+    ECDSAAlgorithm(CryptoHelper crypto, String id, String algorithm, int ecNumberSize, ECKeyProvider keyProvider) throws IllegalArgumentException {
         super(id, algorithm);
-        if (publicKey == null && privateKey == null) {
+        if (keyProvider == null) {
+            throw new IllegalArgumentException("The Key Provider cannot be null.");
+        }
+        if (keyProvider.getPublicKey() == null && keyProvider.getPrivateKey() == null) {
             throw new IllegalArgumentException("Both provided Keys cannot be null.");
         }
-        this.publicKey = publicKey;
-        this.privateKey = privateKey;
-        this.ecNumberSize = ecNumberSize;
+        this.keyProvider = keyProvider;
         this.crypto = crypto;
+        this.ecNumberSize = ecNumberSize;
     }
 
     ECDSAAlgorithm(String id, String algorithm, int ecNumberSize, ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        this(new CryptoHelper(), id, algorithm, ecNumberSize, publicKey, privateKey);
+        this(new CryptoHelper(), id, algorithm, ecNumberSize, providerForKeys(publicKey, privateKey));
+    }
+
+    ECDSAAlgorithm(String id, String algorithm, int ecNumberSize, ECKeyProvider keyProvider) throws IllegalArgumentException {
+        this(new CryptoHelper(), id, algorithm, ecNumberSize, keyProvider);
     }
 
     ECPublicKey getPublicKey() {
-        return publicKey;
+        return keyProvider.getPublicKey();
     }
 
     ECPrivateKey getPrivateKey() {
-        return privateKey;
+        return keyProvider.getPrivateKey();
     }
 
     @Override
     public void verify(byte[] contentBytes, byte[] signatureBytes) throws SignatureVerificationException {
         try {
-            if (publicKey == null) {
+            if (keyProvider.getPublicKey() == null) {
                 throw new IllegalStateException("The given Public Key is null.");
             }
             if (!isDERSignature(signatureBytes)) {
                 signatureBytes = JOSEToDER(signatureBytes);
             }
-            boolean valid = crypto.verifySignatureFor(getDescription(), publicKey, contentBytes, signatureBytes);
+            boolean valid = crypto.verifySignatureFor(getDescription(), keyProvider.getPublicKey(), contentBytes, signatureBytes);
 
             if (!valid) {
                 throw new SignatureVerificationException(this);
@@ -62,14 +68,15 @@ class ECDSAAlgorithm extends Algorithm {
     @Override
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
-            if (privateKey == null) {
+            if (keyProvider.getPrivateKey() == null) {
                 throw new IllegalStateException("The given Private Key is null.");
             }
-            return crypto.createSignatureFor(getDescription(), privateKey, contentBytes);
+            return crypto.createSignatureFor(getDescription(), keyProvider.getPrivateKey(), contentBytes);
         } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
             throw new SignatureGenerationException(this, e);
         }
     }
+
 
     private boolean isDERSignature(byte[] signature) {
         // DER Structure: http://crypto.stackexchange.com/a/1797
@@ -131,5 +138,20 @@ class ECDSAAlgorithm extends Algorithm {
             padding++;
         }
         return bytes[fromIndex + padding] > 0x7f ? padding : padding - 1;
+    }
+
+    //Visible for testing
+    static ECKeyProvider providerForKeys(final ECPublicKey publicKey, final ECPrivateKey privateKey) {
+        return new ECKeyProvider() {
+            @Override
+            public ECPublicKey getPublicKey() {
+                return publicKey;
+            }
+
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return privateKey;
+            }
+        };
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -28,10 +28,6 @@ class RSAAlgorithm extends Algorithm {
         this.crypto = crypto;
     }
 
-    RSAAlgorithm(String id, String algorithm, RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        this(new CryptoHelper(), id, algorithm, providerForKeys(publicKey, privateKey));
-    }
-
     RSAAlgorithm(String id, String algorithm, RSAKeyProvider keyProvider) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, keyProvider);
     }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/ECKeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/ECKeyProvider.java
@@ -1,0 +1,10 @@
+package com.auth0.jwt.interfaces;
+
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+
+/**
+ * Elliptic Curve (EC) Public/Private Key provider.
+ */
+public interface ECKeyProvider extends KeyProvider<ECPublicKey, ECPrivateKey> {
+}

--- a/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
@@ -1,0 +1,27 @@
+package com.auth0.jwt.interfaces;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+/**
+ * Generic Public/Private Key provider.
+ *
+ * @param <U> the class that represents the Public Key
+ * @param <R> the class that represents the Private Key
+ */
+interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
+
+    /**
+     * Getter for the Public Key instance, used to verify the signature.
+     *
+     * @return the Public Key instance
+     */
+    U getPublicKey();
+
+    /**
+     * Getter for the Private Key instance, used to sign the content.
+     *
+     * @return the Private Key instance
+     */
+    R getPrivateKey();
+}

--- a/lib/src/main/java/com/auth0/jwt/interfaces/RSAKeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/RSAKeyProvider.java
@@ -1,0 +1,10 @@
+package com.auth0.jwt.interfaces;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+/**
+ * RSA Public/Private Key provider.
+ */
+public interface RSAKeyProvider extends KeyProvider<RSAPublicKey, RSAPrivateKey> {
+}

--- a/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
@@ -1,5 +1,7 @@
 package com.auth0.jwt.algorithms;
 
+import com.auth0.jwt.interfaces.ECKeyProvider;
+import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -70,7 +72,8 @@ public class AlgorithmTest {
     public void shouldThrowRSA256InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
-        Algorithm.RSA256(null);
+        RSAKey key = null;
+        Algorithm.RSA256(key);
     }
 
     @Test
@@ -81,10 +84,19 @@ public class AlgorithmTest {
     }
 
     @Test
+    public void shouldThrowRSA256InstanceWithNullKeyProvider() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Key Provider cannot be null.");
+        RSAKeyProvider provider = null;
+        Algorithm.RSA256(provider);
+    }
+
+    @Test
     public void shouldThrowRSA384InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
-        Algorithm.RSA384(null);
+        RSAKey key = null;
+        Algorithm.RSA384(key);
     }
 
     @Test
@@ -95,10 +107,19 @@ public class AlgorithmTest {
     }
 
     @Test
+    public void shouldThrowRSA384InstanceWithNullKeyProvider() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Key Provider cannot be null.");
+        RSAKeyProvider provider = null;
+        Algorithm.RSA384(provider);
+    }
+
+    @Test
     public void shouldThrowRSA512InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
-        Algorithm.RSA512(null);
+        RSAKey key = null;
+        Algorithm.RSA512(key);
     }
 
     @Test
@@ -109,10 +130,19 @@ public class AlgorithmTest {
     }
 
     @Test
+    public void shouldThrowRSA512InstanceWithNullKeyProvider() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Key Provider cannot be null.");
+        RSAKeyProvider provider = null;
+        Algorithm.RSA512(provider);
+    }
+
+    @Test
     public void shouldThrowECDSA256InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
-        Algorithm.ECDSA256(null);
+        ECKey key = null;
+        Algorithm.ECDSA256(key);
     }
 
     @Test
@@ -123,10 +153,19 @@ public class AlgorithmTest {
     }
 
     @Test
+    public void shouldThrowECDSA256InstanceWithNullKeyProvider() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Key Provider cannot be null.");
+        ECKeyProvider provider = null;
+        Algorithm.ECDSA256(provider);
+    }
+
+    @Test
     public void shouldThrowECDSA384InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
-        Algorithm.ECDSA384(null);
+        ECKey key = null;
+        Algorithm.ECDSA384(key);
     }
 
     @Test
@@ -137,10 +176,19 @@ public class AlgorithmTest {
     }
 
     @Test
+    public void shouldThrowECDSA384InstanceWithNullKeyProvider() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Key Provider cannot be null.");
+        ECKeyProvider provider = null;
+        Algorithm.ECDSA384(provider);
+    }
+
+    @Test
     public void shouldThrowECDSA512InstanceWithNullKey() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
-        Algorithm.ECDSA512(null);
+        ECKey key = null;
+        Algorithm.ECDSA512(key);
     }
 
     @Test
@@ -148,6 +196,14 @@ public class AlgorithmTest {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Both provided Keys cannot be null.");
         Algorithm.ECDSA512(null, null);
+    }
+
+    @Test
+    public void shouldThrowECDSA512InstanceWithNullKeyProvider() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Key Provider cannot be null.");
+        ECKeyProvider provider = null;
+        Algorithm.ECDSA512(provider);
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -2,6 +2,7 @@ package com.auth0.jwt.algorithms;
 
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.ECKeyProvider;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Rule;
 import org.junit.Test;
@@ -351,7 +352,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -368,7 +370,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -385,7 +388,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.4iVk3-Y0v4RT4_9IaQlp-8dZ_4fsTzIylgrPTDLrEvTHBTyVS3tgPbr2_IZfLETtiKRqCg0aQ5sh9eIsTTwB1g";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -504,7 +508,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -520,7 +525,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -536,7 +542,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -336,7 +336,8 @@ public class ECDSAAlgorithmTest {
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        Algorithm algorithm = new ECDSAAlgorithm("ES256", "SHA256withECDSA", 128, publicKey, privateKey);
+        ECKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new ECDSAAlgorithm("ES256", "SHA256withECDSA", 128, provider);
         AlgorithmUtils.verify(algorithm, jwt);
     }
 

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -2,6 +2,7 @@ package com.auth0.jwt.algorithms;
 
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Rule;
 import org.junit.Test;
@@ -148,7 +149,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -165,7 +167,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -182,7 +185,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         AlgorithmUtils.verify(algorithm, jwt);
     }
@@ -326,7 +330,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -342,7 +347,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -358,7 +364,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", publicKey, privateKey);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         algorithm.sign(RS256Header.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
A `KeyProvider` will allow the algorithm to be instantiated without the keys right away, but rather provide them at the time they are needed. This makes easier to use an external provider like [this one](https://github.com/auth0/jwks-rsa-java) while keeping the `Algorithm` and `JWTVerifier` instance reusable.

Depends on https://github.com/auth0/java-jwt/pull/147