### PR TITLE
Change the JWT.decode() return type to DecodedJWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ try {
     JWTVerifier verifier = JWT.require(Algorithm.HMAC256("secret"))
         .withIssuer("auth0")
         .build(); //Reusable verifier instance
-    JWT jwt = verifier.verify(token);
+    DecodedJWT jwt = verifier.verify(token);
 } catch (JWTVerificationException exception){
     //Invalid signature/claims
 }
@@ -105,7 +105,7 @@ try {
     JWTVerifier verifier = JWT.require(Algorithm.RSA256(key))
         .withIssuer("auth0")
         .build(); //Reusable verifier instance
-    JWT jwt = verifier.verify(token);
+    DecodedJWT jwt = verifier.verify(token);
 } catch (JWTVerificationException exception){
     //Invalid signature/claims
 }
@@ -155,7 +155,7 @@ JWTVerifier verifier = verification.build(clock);
 ```java
 String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
 try {
-    JWT jwt = JWT.decode(token);
+    DecodedJWT jwt = JWT.decode(token);
 } catch (JWTDecodeException exception){
     //Invalid token
 }

--- a/lib/src/main/java/com/auth0/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/jwt/JWT.java
@@ -9,15 +9,15 @@ import com.auth0.jwt.interfaces.Verification;
 public abstract class JWT implements DecodedJWT {
 
     /**
-     * Decode a given JWT token.
+     * Decode a given Json Web Token.
      * <p>
      * Note that this method <b>doesn't verify the token's signature!</b> Use it only if you trust the token or you already verified it.
      *
      * @param token with jwt format as string.
-     * @return a decoded token.
+     * @return a decoded JWT.
      * @throws JWTDecodeException if any part of the token contained an invalid jwt or JSON format of each of the jwt parts.
      */
-    public static JWT decode(String token) throws JWTDecodeException {
+    public static DecodedJWT decode(String token) throws JWTDecodeException {
         return new JWTDecoder(token);
     }
 
@@ -33,9 +33,9 @@ public abstract class JWT implements DecodedJWT {
     }
 
     /**
-     * Returns a JWT builder used to create and sign jwt tokens
+     * Returns a Json Web Token builder used to create and sign tokens
      *
-     * @return a jwt token builder.
+     * @return a token builder.
      */
     public static JWTCreator.Builder create() {
         return JWTCreator.init();


### PR DESCRIPTION
This is for consistency, as the `JWTVerifier.verify()` also returns a `DecodedJWT`