### PR TITLE
Allow to get a Claim as Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ The Claim class is a wrapper for the Claim values. It allows you to get the Clai
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.
 
 * **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.
+* **asMap()**: Returns the value parsed as **Map<String, Object>**.
 * **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
 * **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
 

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -3,7 +3,6 @@ package com.auth0.jwt;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.impl.JWTParser;
 import com.auth0.jwt.interfaces.Claim;
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Header;
 import com.auth0.jwt.interfaces.Payload;
 import org.apache.commons.codec.binary.Base64;

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -3,6 +3,7 @@ package com.auth0.jwt.impl;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -88,6 +89,18 @@ class JsonNodeClaim implements Claim {
             }
         }
         return list;
+    }
+
+    @Override
+    public Map<String, Object> asMap() throws JWTDecodeException {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            TypeReference<Map<String, Object>> mapType = new TypeReference<Map<String, Object>>() {
+            };
+            return mapper.treeAsTokens(data).readValueAs(mapType);
+        } catch (IOException e) {
+            throw new JWTDecodeException("Couldn't map the Claim value to Map", e);
+        }
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -93,6 +93,10 @@ class JsonNodeClaim implements Claim {
 
     @Override
     public Map<String, Object> asMap() throws JWTDecodeException {
+        if (!data.isObject()) {
+            return null;
+        }
+
         ObjectMapper mapper = new ObjectMapper();
         try {
             TypeReference<Map<String, Object>> mapType = new TypeReference<Map<String, Object>>() {

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.interfaces.Claim;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The {@link NullClaim} class is a Claim implementation that returns null when any of it's methods it's called.
@@ -47,6 +48,11 @@ public class NullClaim implements Claim {
 
     @Override
     public <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> asMap() throws JWTDecodeException {
         return null;
     }
 

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The Claim class holds the value in a generic way so that it can be recovered in many representations.
@@ -74,6 +75,14 @@ public interface Claim {
      * @throws JWTDecodeException if the values inside the List can't be converted to a class T.
      */
     <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException;
+
+    /**
+     * Get this Claim as a generic Map of values.
+     *
+     * @return the value as instance of Map.
+     * @throws JWTDecodeException if the value can't be converted to a Map.
+     */
+    Map<String, Object> asMap() throws JWTDecodeException;
 
     /**
      * Get this Claim as a custom type T.

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -197,6 +198,66 @@ public class JWTDecoderTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getClaim("object"), is(notNullValue()));
         assertThat(jwt.getClaim("object").isNull(), is(false));
+    }
+
+    @Test
+    public void shouldGetCustomClaimOfTypeInteger() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxMjN9.XZAudnA7h3_Al5kJydzLjw6RzZC3Q6OvnLEYlhNW7HA";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asInt(), is(123));
+    }
+
+    @Test
+    public void shouldGetCustomClaimOfTypeDouble() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoyMy40NX0.7pyX2OmEGaU9q15T8bGFqRm-d3RVTYnqmZNZtxMKSlA";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asDouble(), is(23.45));
+    }
+
+    @Test
+    public void shouldGetCustomClaimOfTypeBoolean() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjp0cnVlfQ.FwQ8VfsZNRqBa9PXMinSIQplfLU4-rkCLfIlTLg_MV0";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asBoolean(), is(true));
+    }
+
+    @Test
+    public void shouldGetCustomClaimOfTypeDate() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
+        Date date = new Date(1478891521000L);
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asDate().getTime(), is(date.getTime()));
+    }
+
+    @Test
+    public void shouldGetCustomArrayClaimOfTypeString() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asArray(String.class), arrayContaining("text", "123", "true"));
+    }
+
+    @Test
+    public void shouldGetCustomArrayClaimOfTypeInteger() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asArray(Integer.class), arrayContaining(1, 2, 3));
+    }
+
+    @Test
+    public void shouldGetCustomMapClaim() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InN0cmluZyI6InZhbHVlIiwibnVtYmVyIjoxLCJib29sZWFuIjp0cnVlfX0.-8aIaXd2-rp1lLuDEQmCeisCBX9X_zbqdPn2llGxNoc";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat(map, hasEntry("string", (Object) "value"));
+        Assert.assertThat(map, hasEntry("number", (Object) 1));
+        Assert.assertThat(map, hasEntry("boolean", (Object) true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -201,6 +202,36 @@ public class JsonNodeClaimTest {
 
         exception.expect(JWTDecodeException.class);
         claim.asList(UserPojo.class);
+    }
+
+    @Test
+    public void shouldGetMapValue() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("text", "extraValue");
+        map.put("number", 12);
+        map.put("boolean", true);
+        map.put("object", Collections.singletonMap("something", "else"));
+
+        JsonNode value = mapper.valueToTree(map);
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim, is(notNullValue()));
+        Map<String, Object> backMap = claim.asMap();
+        assertThat(backMap, is(notNullValue()));
+        assertThat(backMap, hasEntry("text", (Object) "extraValue"));
+        assertThat(backMap, hasEntry("number", (Object) 12));
+        assertThat(backMap, hasEntry("boolean", (Object) true));
+        assertThat(backMap, hasKey("object"));
+        assertThat((Map<String, Object>) backMap.get("object"), IsMapContaining.hasEntry("something", (Object) "else"));
+    }
+
+    @Test
+    public void shouldThrowIfMapClassMismatch() throws Exception {
+        JsonNode value = mapper.valueToTree("text node");
+        Claim claim = claimFromNode(value);
+
+        exception.expect(JWTDecodeException.class);
+        claim.asMap();
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -57,6 +57,11 @@ public class NullClaimTest {
     }
 
     @Test
+    public void shouldGetAsMap() throws Exception {
+        assertThat(claim.asMap(), is(nullValue()));
+    }
+
+    @Test
     public void shouldGetAsCustomClass() throws Exception {
         assertThat(claim.as(Object.class), is(nullValue()));
     }


### PR DESCRIPTION
This PR introduces the option to get a `Claim` as `Map<String, Object>`.

example usage:

```
DecodedJWT jwt = // decode or verify the jwt
Map<String, Object> userDataMap = jwt.getClaim("user-data").asMap();
```

Fixes https://github.com/auth0/java-jwt/issues/146