### PR TITLE
add verify overload

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -337,8 +337,12 @@ public final class JWTVerifier {
      */
     public DecodedJWT verify(String token) throws JWTVerificationException {
         DecodedJWT jwt = JWTDecoder.decode(token);
+        return verify(jwt);
+    }
+
+    public DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException {
         verifyAlgorithm(jwt, algorithm);
-        verifySignature(TokenUtils.splitToken(token));
+        verifySignature(TokenUtils.splitToken(jwt.getToken()));
         verifyClaims(jwt, claims);
         return jwt;
     }


### PR DESCRIPTION
This allows an already-decoded JWT to be used without decoding twice. This is useful, for instance, when the `kid` is used to look up the public key. 