### PR TITLE
[WIP] Add Custom Map Claim

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -290,6 +290,19 @@ public final class JWTCreator {
         }
 
         /**
+         * Add a custom Map Claim with the given items
+         * @param name the Claim's name.
+         * @param map  the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException IllegalArgumentException if the name is null.
+         */
+        public Builder withMapClaim(String name, Map map) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, map);
+            return this;
+        }
+
+        /**
          * Creates a new JWT and signs is with the given algorithm
          *
          * @param algorithm used to sign the JWT

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -281,4 +281,32 @@ public class JWTCreatorTest {
         String[] parts = jwt.split("\\.");
         assertThat(parts[1], is("eyJuYW1lIjpbMSwyLDNdfQ"));
     }
+
+    @Test
+    public void shouldAcceptCustomMapStringString() throws Exception {
+        Map <String, String> map = new HashMap<>();
+        map.put("test", "1");
+
+        String jwt = JWTCreator.init()
+                .withMapClaim("map", map)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJtYXAiOnsidGVzdCI6IjEifX0"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapStringInt() throws Exception {
+        Map <String, Object> map = new HashMap<>();
+        map.put("test", 1);
+
+        String jwt = JWTCreator.init()
+                .withMapClaim("map", map)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJtYXAiOnsidGVzdCI6MX19"));
+    }
 }


### PR DESCRIPTION
I need to create a claim that is a map, so added a method the JWT Builder to add custom map. Example:
```
{
    "user": {
        "id": "u1234",
        "accountId": "a5678",
        "firstName": "Joe",
        "lastName": "Tester",
        "email": "joe.tester@example.com",
        "paymentProviderId": null
    }
}
```


## TODO as requested by peer review. 

* [ ] The method must add claims of type Map<String, Object> (not Map).
* [ ] The readme states which types of claim can be set and read. Add a clear warning message
explaining the above, telling that only primitives and collections are allowed and that custom classes are not guaranteed to be handled just fine and may throw.
* [ ] Add the same warning to the javadoc of the withClaim() method that receives the Map.
* [ ] Add enough tests to assert that primitives and collections are supported, but that custom classes will throw an error. Keep in mind that this should work in create and decode functions.
See https://docs.referralsaasquatch.com/topics/json-web-tokens/