### PR TITLE
v2 Remove apache commons-io v1.3.2 since not being used 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,6 @@
       <version>3.4</version>
     </dependency>
 
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
-    </dependency>
-
     <!-- test -->
 
     <dependency>


### PR DESCRIPTION
This PR removes apache commons-io from v2 branch.

v2 branch still references maven compile dependency on apache commons-io v1.3.2 which is not referenced in source.

Consumers of java-jwt get this version of commons-io and must explicitly exclude it. 
