### PR TITLE
Using ObjectReader to cache Jackson bindings when parsing JWT

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/jwt/JWT.java
@@ -2,11 +2,35 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.impl.JWTParser;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
 
 @SuppressWarnings("WeakerAccess")
-public abstract class JWT {
+public class JWT {
+
+    private final JWTParser parser;
+
+    /**
+     * Constructs a new instance of the JWT library. Use this if you need to decode many JWT
+     * tokens on the fly and do not wish to instantiate a new parser for each invocation.
+     */
+    public JWT() {
+        parser = new JWTParser();
+    }
+
+    /**
+     * Decode a given Json Web Token.
+     * <p>
+     * Note that this method <b>doesn't verify the token's signature!</b> Use it only if you trust the token or you already verified it.
+     *
+     * @param token with jwt format as string.
+     * @return a decoded JWT.
+     * @throws JWTDecodeException if any part of the token contained an invalid jwt or JSON format of each of the jwt parts.
+     */
+    public DecodedJWT decodeJwt(String token) throws JWTDecodeException {
+        return new JWTDecoder(parser, token);
+    }
 
     /**
      * Decode a given Json Web Token.

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -24,8 +24,11 @@ final class JWTDecoder implements DecodedJWT {
     private final Payload payload;
 
     JWTDecoder(String jwt) throws JWTDecodeException {
+        this(new JWTParser(), jwt);
+    }
+
+    JWTDecoder(JWTParser converter, String jwt) throws JWTDecodeException {
         parts = TokenUtils.splitToken(jwt);
-        final JWTParser converter = new JWTParser();
         String headerJson;
         String payloadJson;
         try {

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -46,6 +46,15 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
     }
 
+    @Test
+    public void shouldDecodeAStringTokenUsingInstance() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
+        JWT jwt = new JWT();
+        DecodedJWT decodedJWT = jwt.decodeJwt(token);
+
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
     // getToken
     @Test
     public void shouldGetStringToken() throws Exception {
@@ -55,6 +64,15 @@ public class JWTTest {
         assertThat(jwt.getToken(), is("eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ"));
     }
 
+    // getToken
+    @Test
+    public void shouldGetStringTokenUsingInstance() throws Exception {
+        JWT jwt = new JWT();
+        DecodedJWT decodedJWT = jwt.decodeJwt("eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ");
+        assertThat(decodedJWT, is(notNullValue()));
+        assertThat(decodedJWT.getToken(), is(notNullValue()));
+        assertThat(decodedJWT.getToken(), is("eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ"));
+    }
 
     // Verify
 


### PR DESCRIPTION
Hey Guys,

While perf testing a web service which uses auth0-spring-security-api, I noticed that a chunk of performance was getting taken up by Jackson's ObjectMapper.readValue due to the reflection required on every call to set up its bindings.

Thankfully, Jackson provides an ObjectReader which caches the bindings for us, and is completely thread safe once after initial configuration. Since all configuration happens in the JWTParser header, this is perfectly safe to do and provides some significant performance improvements.

Here is a quick and dirty test I wrote to test the performance:
```java
public class PerfTest {

    private static final String TOKEN = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
    private static final int COUNT = 10000;
    private static final int THREADS = 50;

    @BeforeClass
    public static void warmup() {
        JWT jwt = new JWT();
        for (int i = 0; i < 1000; i++) {
            jwt.decodeJwt(TOKEN);
        }

        for (int i = 0; i < 1000; i++) {
            JWT.decode(TOKEN);
        }
    }

    @Test
    public void singleInstancePerformance() throws Exception {
        long start = System.nanoTime();

        JWT jwt = new JWT();
        runSingleThread(() -> jwt.decodeJwt(TOKEN));

        System.out.println("singleInstancePerformance:" + (System.nanoTime() - start) / 1000000L);
    }

    @Test
    public void singleInstanceThreadedPerformance() throws Exception {
        long start = System.nanoTime();

        JWT jwt = new JWT();
        runThreaded(() -> jwt.decodeJwt(TOKEN));

        System.out.println("singleInstanceThreadedPerformance:" + (System.nanoTime() - start) / 1000000L);
    }

    @Test
    public void staticPerformance() throws Exception {
        long start = System.nanoTime();

        runSingleThread(() -> JWT.decode(TOKEN));

        System.out.println("staticPerformance:" + (System.nanoTime() - start) / 1000000L);
    }

    @Test
    public void staticThreadedPerformance() throws Exception {
        long start = System.nanoTime();

        runThreaded(() -> JWT.decode(TOKEN));

        System.out.println("staticThreadedPerformance:" + (System.nanoTime() - start) / 1000000L);
    }

    private void runSingleThread(Runnable runnable) throws Exception {
        for (int i = 0; i < COUNT; i++) {
            runnable.run();
        }
    }

    private void runThreaded(Runnable runnable) throws Exception {
        List<Thread> threads = new LinkedList<>();
        for (int i = 0; i < THREADS; i++) {
            Thread thread = new Thread(() -> {
                for (int j = 0; j < COUNT; j++) {
                    runnable.run();
                }
            });
            thread.start();
            threads.add(thread);
        }

        for (Thread thread : threads) {
            thread.join();
        }
    }
}
```

This gives the following using this version of the code on my Core i5 2.5GHz x4 16GB:
```
staticPerformance:1062
staticThreadedPerformance:9340
singleInstancePerformance:81
singleInstanceThreadedPerformance:3897
```

Running only the static tests on master gives the following:
```
staticPerformance:2243
staticThreadedPerformance:13758
```

which equates to a rather nice performance improvement on a web server under load.

Would someone consider merging this in and releasing a new version so I can make another PR on auth0-spring-security-api? I'm happy to make an alternative implementation if you're not happy with this one.