### PR TITLE
Instantiate exception only when required

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
@@ -49,14 +49,17 @@ public class JWTParser implements JWTPartsParser {
 
     @SuppressWarnings("WeakerAccess")
     <T> T convertFromJSON(String json, Class<T> tClazz) throws JWTDecodeException {
-        JWTDecodeException exception = new JWTDecodeException(String.format("The string '%s' doesn't have a valid JSON format.", json));
         if (json == null) {
-            throw exception;
+            throw exceptionForInvalidJson(null);
         }
         try {
             return mapper.readValue(json, tClazz);
         } catch (IOException e) {
-            throw exception;
+            throw exceptionForInvalidJson(json);
         }
+    }
+
+    private JWTDecodeException exceptionForInvalidJson(String json) {
+        return new JWTDecodeException(String.format("The string '%s' doesn't have a valid JSON format.", json));
     }
 }


### PR DESCRIPTION
The `convertFromJSON()` method in the `JWTParser` class instantiates an exception (which is accompanied by an invocation of the somewhat expensive `String.format()` method) for every JSON string to be converted. This occurs even if the given JSON string is valid and the exception will never be thrown. As the `convertFromJSON()` method is invoked twice for every token verification this PR proposes to only instantiate an exception if the JSON string is _invalid_, hence requiring the exception to actually be thrown.
