### PR TITLE
Method for adding strings as RawValue

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.util.RawValue;
+
 import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
@@ -287,6 +289,20 @@ public final class JWTCreator {
         public Builder withArrayClaim(String name, Long[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
+            return this;
+        }
+
+        /**
+         * Add a custom Claim value as {@link RawValue}. It will not be escaped to a string this way. 
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withRawClaim(String name, String value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, new RawValue(value));
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -51,6 +51,11 @@ class JsonNodeClaim implements Claim {
     }
 
     @Override
+    public String asRawValue() {
+        return data.toString();
+    }
+
+    @Override
     public Date asDate() {
         if (!data.canConvertToLong()) {
             return null;

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -42,6 +42,11 @@ public class NullClaim implements Claim {
     }
 
     @Override
+    public String asRawValue() {
+        return null;
+    }
+
+    @Override
     public Date asDate() {
         return null;
     }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -59,6 +59,14 @@ public interface Claim {
     String asString();
 
     /**
+     * Get this Claim as a raw value.
+     * The value will be returned as a raw String if present.
+     *
+     * @return the value as a raw String or null.
+     */
+	String asRawValue();
+
+    /**
      * Get this Claim as a Date.
      * If the value can't be converted to a Date, null will be returned.
      *

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -357,4 +357,15 @@ public class JWTCreatorTest {
         String[] parts = jwt.split("\\.");
         assertThat(parts[1], is("eyJuYW1lIjpbMSwyLDNdfQ"));
     }
+
+    @Test
+    public void shouldAcceptCustomRawClaim() throws Exception {
+        String jwt = JWTCreator.init()
+                .withRawClaim("name", "{\"key\":\"value\"}")
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7ImtleSI6InZhbHVlIn19"));
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -361,11 +361,22 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomRawClaim() throws Exception {
         String jwt = JWTCreator.init()
-                .withRawClaim("name", "{\"key\":\"value\"}")
+                .withRawClaim("name", "{\"name\":\"George\",\"id\":1}")
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
-        assertThat(parts[1], is("eyJuYW1lIjp7ImtleSI6InZhbHVlIn19"));
+        assertThat(parts[1], is("eyJuYW1lIjp7Im5hbWUiOiJHZW9yZ2UiLCJpZCI6MX19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomRawClaimWithArray() throws Exception {
+        String jwt = JWTCreator.init()
+                .withRawClaim("name", "[{\"name\":\"George\",\"id\":1},{\"name\":\"Mark\",\"id\":2}]")
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbeyJuYW1lIjoiR2VvcmdlIiwiaWQiOjF9LHsibmFtZSI6Ik1hcmsiLCJpZCI6Mn1dfQ"));
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -247,6 +247,14 @@ public class JWTDecoderTest {
     }
 
     @Test
+    public void shouldGetCustomClaimOfTypeRawValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7Im5hbWUiOiJHZW9yZ2UiLCJpZCI6MX19.lbRLPEQEcHChKTproSQnrI6iQywfDHTjbF5iR4VvhEA";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asRawValue(), is("{\"name\":\"George\",\"id\":1}"));
+    }
+
+    @Test
     public void shouldGetCustomArrayClaimOfTypeString() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
         DecodedJWT jwt = JWT.decode(token);

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -141,6 +141,42 @@ public class JsonNodeClaimTest {
     }
 
     @Test
+    public void shouldGetRawValue() throws Exception {
+        JsonNode value = mapper.valueToTree(new UserPojo("George", 1));
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim.asRawValue(), is(notNullValue()));
+        assertThat(claim.asRawValue(), is("{\"name\":\"George\",\"id\":1}"));
+    }
+
+    @Test
+    public void shouldGetRawValueWithArray() throws Exception {
+        JsonNode value = mapper.valueToTree(new UserPojo[]{new UserPojo("George", 1), new UserPojo("Mark", 2)});
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim.asRawValue(), is(notNullValue()));
+        assertThat(claim.asRawValue(), is("[{\"name\":\"George\",\"id\":1},{\"name\":\"Mark\",\"id\":2}]"));
+    }
+
+    @Test
+    public void shouldGetRawValueWithInteger() throws Exception {
+        JsonNode value = mapper.valueToTree(1);
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim.asRawValue(), is(notNullValue()));
+        assertThat(claim.asRawValue(), is("1"));
+    }
+
+    @Test
+    public void shouldGetRawValueWithBoolean() throws Exception {
+        JsonNode value = mapper.valueToTree(true);
+        Claim claim = claimFromNode(value);
+
+        assertThat(claim.asRawValue(), is(notNullValue()));
+        assertThat(claim.asRawValue(), is("true"));
+    }
+
+    @Test
     public void shouldGetArrayValueOfCustomClass() throws Exception {
         JsonNode value = mapper.valueToTree(new UserPojo[]{new UserPojo("George", 1), new UserPojo("Mark", 2)});
         Claim claim = claimFromNode(value);

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -47,6 +47,11 @@ public class NullClaimTest {
     }
 
     @Test
+    public void shouldGetAsRawValue() throws Exception {
+        assertThat(claim.asRawValue(), is(nullValue()));
+    }
+
+    @Test
     public void shouldGetAsDate() throws Exception {
         assertThat(claim.asDate(), is(nullValue()));
     }


### PR DESCRIPTION
You should add the possibility to add a string as [RawValue](https://fasterxml.github.io/jackson-databind/javadoc/2.6/com/fasterxml/jackson/databind/util/RawValue.html).
That way we can serialize our objects ourselves and still get a "pretty" output.

ATM if we add a string claim, it will be escaped and all quotation etc. starts with a backslash which is really annoying and can lead to problem with usage on consumer side.

This could also help #163.