### PR TITLE
Rework ECDSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Temporary Items
 
 # IntelliJ
 /out/
+/lib/out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,13 +34,13 @@ compileJava {
 }
 
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.4'
-    compile 'commons-codec:commons-codec:1.10'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.2'
+    compile 'commons-codec:commons-codec:1.11'
     testCompile 'org.bouncycastle:bcprov-jdk15on:1.58'
     testCompile 'junit:junit:4.12'
-    testCompile 'net.jodah:concurrentunit:0.4.2'
+    testCompile 'net.jodah:concurrentunit:0.4.3'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testCompile 'org.mockito:mockito-core:2.2.8'
+    testCompile 'org.mockito:mockito-core:2.11.0'
 }
 
 jacocoTestReport {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -36,10 +36,10 @@ compileJava {
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.4'
     compile 'commons-codec:commons-codec:1.10'
-    compile 'org.bouncycastle:bcprov-jdk15on:1.55'
+    testCompile 'org.bouncycastle:bcprov-jdk15on:1.58'
     testCompile 'junit:junit:4.12'
     testCompile 'net.jodah:concurrentunit:0.4.2'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:2.2.8'
 }
 

--- a/lib/src/test/java/com/auth0/jwt/ConcurrentVerifyTest.java
+++ b/lib/src/test/java/com/auth0/jwt/ConcurrentVerifyTest.java
@@ -141,16 +141,6 @@ public class ConcurrentVerifyTest {
     }
 
     @Test
-    public void shouldPassECDSA256VerificationWithDERSignature() throws Exception {
-        String token = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.MEYCIQDiJWTf5jS/hFPj/0hpCWn7x1n/h+xPMjKWCs9MMusS9AIhAMcFPJVLe2A9uvb8hl8sRO2IpGoKDRpDmyH14ixNPAHW";
-        ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
-        Algorithm algorithm = Algorithm.ECDSA256(key);
-        JWTVerifier verifier = JWTVerifier.init(algorithm).withIssuer("auth0").build();
-
-        concurrentVerify(verifier, token);
-    }
-
-    @Test
     public void shouldPassECDSA384VerificationWithJOSESignature() throws Exception {
         String token = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.50UU5VKNdF1wfykY8jQBKpvuHZoe6IZBJm5NvoB8bR-hnRg6ti-CHbmvoRtlLfnHfwITa_8cJMy6TenMC2g63GQHytc8rYoXqbwtS4R0Ko_AXbLFUmfxnGnMC6v4MS_z";
         ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
@@ -161,28 +151,8 @@ public class ConcurrentVerifyTest {
     }
 
     @Test
-    public void shouldPassECDSA384VerificationWithDERSignature() throws Exception {
-        String token = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.MGUCMQDnRRTlUo10XXB/KRjyNAEqm+4dmh7ohkEmbk2+gHxtH6GdGDq2L4Idua+hG2Ut+ccCMH8CE2v/HCTMuk3pzAtoOtxkB8rXPK2KF6m8LUuEdCqPwF2yxVJn8ZxpzAur+DEv8w==";
-        ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
-        Algorithm algorithm = Algorithm.ECDSA384(key);
-        JWTVerifier verifier = JWTVerifier.init(algorithm).withIssuer("auth0").build();
-
-        concurrentVerify(verifier, token);
-    }
-
-    @Test
     public void shouldPassECDSA512VerificationWithJOSESignature() throws Exception {
         String token = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.AeCJPDIsSHhwRSGZCY6rspi8zekOw0K9qYMNridP1Fu9uhrA1QrG-EUxXlE06yvmh2R7Rz0aE7kxBwrnq8L8aOBCAYAsqhzPeUvyp8fXjjgs0Eto5I0mndE2QHlgcMSFASyjHbU8wD2Rq7ZNzGQ5b2MZfpv030WGUajT-aZYWFUJHVg2";
-        ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
-        Algorithm algorithm = Algorithm.ECDSA512(key);
-        JWTVerifier verifier = JWTVerifier.init(algorithm).withIssuer("auth0").build();
-
-        concurrentVerify(verifier, token);
-    }
-
-    @Test
-    public void shouldPassECDSA512VerificationWithDERSignature() throws Exception {
-        String token = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0/UW726GsDVCsb4RTFeUTTrK+aHZHtHPRoTuTEHCuerwvxo4EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0/mmWFhVCR1YNg==";
         ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
         Algorithm algorithm = Algorithm.ECDSA512(key);
         JWTVerifier verifier = JWTVerifier.init(algorithm).withIssuer("auth0").build();

--- a/lib/src/test/java/com/auth0/jwt/PemUtils.java
+++ b/lib/src/test/java/com/auth0/jwt/PemUtils.java
@@ -3,12 +3,14 @@ package com.auth0.jwt;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.interfaces.ECPublicKey;
 import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -22,7 +24,9 @@ public class PemUtils {
         }
         PemReader reader = new PemReader(new FileReader(pemFile));
         PemObject pemObject = reader.readPemObject();
-        return pemObject.getContent();
+        byte[] content = pemObject.getContent();
+        reader.close();
+        return content;
     }
 
     private static PublicKey getPublicKey(byte[] keyBytes, String algorithm) {


### PR DESCRIPTION
This PR fixes a lot of ECDSA Algorithm issues. The problem was mainly that the signature format conversion was being made on one way but not in the other. I've added some tests that mimic the signature format and test the converter methods. What I'm not so sure about is if we should have a different exception message when the total signature length or the R/S numbers length is not the expected. We could throw the same error message "invalid signature length" for all 3 cases. Check lines [104](https://github.com/auth0/java-jwt/compare/rework-ecdsa?expand=1#diff-535ab2373cdedf6aa0c947591a23dddeR104), [113](https://github.com/auth0/java-jwt/compare/rework-ecdsa?expand=1#diff-535ab2373cdedf6aa0c947591a23dddeR113) and [125](https://github.com/auth0/java-jwt/compare/rework-ecdsa?expand=1#diff-535ab2373cdedf6aa0c947591a23dddeR125).

Tests should run against both JDK 7 & JDK 8. I don't know why but tests were failing on JDK8, something we didn't caught because we never run the tests on that JDK. I added a separate PR to use _CircleCI Workflows_ to attempt to run the tests in both JDKs, but because the tests don't pass in master merging that to master will "break master" until this PR is merged. I'd add it sourced from this last commit.