### PR TITLE
Java 9 Module Name

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -28,6 +28,12 @@ auth0 {
     }
 }
 
+jar {
+    manifest {
+        attributes("Automatic-Module-Name": "${project.group}.jwt")
+    }
+}
+
 compileJava {
     sourceCompatibility '1.7'
     targetCompatibility '1.7'


### PR DESCRIPTION
This pull request adds the `Automatic-Module-Name` header to the JAR manifest in order to establish basic compatibility with Java 9 applications and libraries.

**Motivation**
Along with the introduction of Java 9, a new module system was introduced which relies on module identifiers to resolve modules from various sources. When no identifier is given, Java will generate a name for the module based on its respective file name (e.g. a jar archive with the name ```com.auth0.jwt-1.0.jar``` will result in a module named `com.auth0.jwt`). While this provides basic compatibility with existing implementations, it also introduces its own problems (e.g. changing the way the archive is named will automatically cause a new name to be generated).

**Implementation Choices**
- `com.auth0.jwt` was chosen as it matches the root package. This seems to be the most common 
naming scheme at the moment and is the least likely to conflict with implementations of other vendors
- the `Automatic-Module-Name` header was chosen over a full `module-info.java` for as a module manifest requires all dependencies to define a name on their own (additionally, compiling a `module-info.java` requires a Java 9 SDK)