### PR TITLE
Token with custom objects as claims

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -186,7 +186,7 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withArrayClaim(String name, Object... items) throws IllegalArgumentException {
+        public <T> Builder withArrayClaim(String name, @SuppressWarnings("unchecked") T... items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
             return this;

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -15,6 +15,7 @@ import org.apache.commons.codec.binary.Base64;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -233,6 +234,20 @@ public final class JWTCreator {
             addClaim(name, value);
             return this;
         }
+        
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, Object value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }        
 
         /**
          * Add a custom Claim value.
@@ -247,7 +262,35 @@ public final class JWTCreator {
             addClaim(name, value);
             return this;
         }
+        
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, List<?> value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
 
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        public Builder withClaim(String name, Object[] value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
+        
         /**
          * Add a custom Array Claim with the given items.
          *

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -15,7 +15,6 @@ import org.apache.commons.codec.binary.Base64;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -173,119 +172,7 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Boolean value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, Integer value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, Long value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, Double value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, String value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-        
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, Object value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }        
-
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, Date value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-        
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, List<?> value) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Add a custom Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withClaim(String name, Object[] value) throws IllegalArgumentException {
+        public <T> Builder withClaim(String name, T value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -299,40 +186,12 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withArrayClaim(String name, String[] items) throws IllegalArgumentException {
+        public Builder withArrayClaim(String name, Object... items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
             return this;
         }
-
-        /**
-         * Add a custom Array Claim with the given items.
-         *
-         * @param name  the Claim's name.
-         * @param items the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withArrayClaim(String name, Integer[] items) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, items);
-            return this;
-        }
-
-        /**
-         * Add a custom Array Claim with the given items.
-         *
-         * @param name  the Claim's name.
-         * @param items the Claim's value.
-         * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        public Builder withArrayClaim(String name, Long[] items) throws IllegalArgumentException {
-            assertNonNull(name);
-            addClaim(name, items);
-            return this;
-        }
-
+        
         /**
          * Creates a new JWT and signs is with the given algorithm
          *

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -251,6 +251,22 @@ public final class JWTVerifier {
             requireClaim(name, value);
             return this;
         }
+        
+        /**
+         * Require a specific Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        @Override
+        
+        public Verification withClaim(String name, Object value) throws IllegalArgumentException{
+        	assertNonNull(name);
+        	requireClaim(name, value);
+        	return this;
+        }
 
         /**
          * Require a specific Array Claim to contain at least the given items.
@@ -280,6 +296,21 @@ public final class JWTVerifier {
             assertNonNull(name);
             requireClaim(name, items);
             return this;
+        }
+        
+        /**
+         * Require a specific Array Claim to contain at least the given items.
+         *
+         * @param name  the Claim's name.
+         * @param items the items the Claim must contain.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        @Override
+        public Verification withArrayClaim(String name, Object... items) throws IllegalArgumentException{
+        	  assertNonNull(name);
+              requireClaim(name, items);
+              return this;
         }
 
         /**
@@ -412,8 +443,13 @@ public final class JWTVerifier {
             List<Object> claimArr = Arrays.asList(claim.as(Object[].class));
             List<Object> valueArr = Arrays.asList((Object[]) value);
             isValid = claimArr.containsAll(valueArr);
+        } else{
+        	try{
+        		isValid = value.equals(claim.as(value.getClass()));
+        	}catch(Exception e){
+        		//ignore
+        	}
         }
-
         if (!isValid) {
             throw new InvalidClaimException(String.format("The Claim '%s' value doesn't match the required one.", claimName));
         }

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -171,98 +171,7 @@ public final class JWTVerifier {
          * @throws IllegalArgumentException if the name is null.
          */
         @Override
-        public Verification withClaim(String name, Boolean value) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Require a specific Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withClaim(String name, Integer value) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Require a specific Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withClaim(String name, Long value) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Require a specific Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withClaim(String name, Double value) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Require a specific Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withClaim(String name, String value) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, value);
-            return this;
-        }
-
-        /**
-         * Require a specific Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withClaim(String name, Date value) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, value);
-            return this;
-        }
-        
-        /**
-         * Require a specific Claim value.
-         *
-         * @param name  the Claim's name.
-         * @param value the Claim's value.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        
-        public Verification withClaim(String name, Object value) throws IllegalArgumentException{
+        public <T> Verification withClaim(String name, T value) throws IllegalArgumentException{
         	assertNonNull(name);
         	requireClaim(name, value);
         	return this;
@@ -277,40 +186,10 @@ public final class JWTVerifier {
          * @throws IllegalArgumentException if the name is null.
          */
         @Override
-        public Verification withArrayClaim(String name, String... items) throws IllegalArgumentException {
+        public Verification withArrayClaim(String name, Object... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
             return this;
-        }
-
-        /**
-         * Require a specific Array Claim to contain at least the given items.
-         *
-         * @param name  the Claim's name.
-         * @param items the items the Claim must contain.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException {
-            assertNonNull(name);
-            requireClaim(name, items);
-            return this;
-        }
-        
-        /**
-         * Require a specific Array Claim to contain at least the given items.
-         *
-         * @param name  the Claim's name.
-         * @param items the items the Claim must contain.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
-        @Override
-        public Verification withArrayClaim(String name, Object... items) throws IllegalArgumentException{
-        	  assertNonNull(name);
-              requireClaim(name, items);
-              return this;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -21,7 +21,7 @@ public interface Verification {
 
     <T> Verification withClaim(String name, T value) throws IllegalArgumentException;
     
-    Verification withArrayClaim(String name, Object... values) throws IllegalArgumentException;
+    <T> Verification withArrayClaim(String name, @SuppressWarnings("unchecked") T... values) throws IllegalArgumentException;
 
     JWTVerifier build();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -2,8 +2,6 @@ package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.JWTVerifier;
 
-import java.util.Date;
-
 public interface Verification {
     Verification withIssuer(String issuer);
 
@@ -21,25 +19,9 @@ public interface Verification {
 
     Verification withJWTId(String jwtId);
 
-    Verification withClaim(String name, Boolean value) throws IllegalArgumentException;
-
-    Verification withClaim(String name, Integer value) throws IllegalArgumentException;
-
-    Verification withClaim(String name, Long value) throws IllegalArgumentException;
-
-    Verification withClaim(String name, Double value) throws IllegalArgumentException;
-
-    Verification withClaim(String name, String value) throws IllegalArgumentException;
-
-    Verification withClaim(String name, Date value) throws IllegalArgumentException;
+    <T> Verification withClaim(String name, T value) throws IllegalArgumentException;
     
-    Verification withClaim(String name, Object value) throws IllegalArgumentException;
-
-    Verification withArrayClaim(String name, String... items) throws IllegalArgumentException;
-
-    Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
-    
-    Verification withArrayClaim(String name, Object... items) throws IllegalArgumentException;
+    Verification withArrayClaim(String name, Object... values) throws IllegalArgumentException;
 
     JWTVerifier build();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -32,10 +32,14 @@ public interface Verification {
     Verification withClaim(String name, String value) throws IllegalArgumentException;
 
     Verification withClaim(String name, Date value) throws IllegalArgumentException;
+    
+    Verification withClaim(String name, Object value) throws IllegalArgumentException;
 
     Verification withArrayClaim(String name, String... items) throws IllegalArgumentException;
 
     Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
+    
+    Verification withArrayClaim(String name, Object... items) throws IllegalArgumentException;
 
     JWTVerifier build();
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -354,7 +354,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
         String jwt = JWTCreator.init()
-                .withArrayClaim("name", new String[]{"text", "123", "true"})
+                .withClaim("name", new String[]{"text", "123", "true"})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -365,7 +365,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeInteger() throws Exception {
         String jwt = JWTCreator.init()
-                .withArrayClaim("name", new Integer[]{1, 2, 3})
+                .withClaim("name", new Integer[]{1, 2, 3})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -376,7 +376,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeLong() throws Exception {
         String jwt = JWTCreator.init()
-                .withArrayClaim("name", new Long[]{1L, 2L, 3L})
+                .withClaim("name", new Long[]{1L, 2L, 3L})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -354,7 +354,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
         String jwt = JWTCreator.init()
-                .withClaim("name", new String[]{"text", "123", "true"})
+                .withArrayClaim("name", new String[]{"text", "123", "true"})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -365,7 +365,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeInteger() throws Exception {
         String jwt = JWTCreator.init()
-                .withClaim("name", new Integer[]{1, 2, 3})
+                .withArrayClaim("name", new Integer[]{1, 2, 3})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -376,7 +376,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeLong() throws Exception {
         String jwt = JWTCreator.init()
-                .withClaim("name", new Long[]{1L, 2L, 3L})
+                .withArrayClaim("name", new Long[]{1L, 2L, 3L})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -324,6 +324,32 @@ public class JWTCreatorTest {
         String[] parts = jwt.split("\\.");
         assertThat(parts[1], is("eyJuYW1lIjoxNDc4ODkxNTIxfQ"));
     }
+    
+    @Test
+    public void shouldAcceptCustomClaimOfTypeObject() throws Exception {
+        Map<String, Object> data = new HashMap<>();
+        data.put("test1", "abc");
+        data.put("test2", "def");
+        String jwt = JWTCreator.init()
+                .withClaim("data", data)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJkYXRhIjp7InRlc3QyIjoiZGVmIiwidGVzdDEiOiJhYmMifX0"));
+    }
+    
+    @Test
+    public void shouldAcceptCustomClaimOfTypeUserPojo() throws Exception{
+    	UserPojo pojo = new UserPojo("Michael", 255);
+    	String jwt = JWTCreator.init()
+                 .withClaim("pojo", pojo)
+                 .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJwb2pvIjp7ImlkIjoyNTUsIm5hbWUiOiJNaWNoYWVsIn19"));
+    }
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -272,6 +272,26 @@ public class JWTDecoderTest {
         Assert.assertThat(map, hasEntry("number", (Object) 1));
         Assert.assertThat(map, hasEntry("boolean", (Object) true));
     }
+    
+    @Test
+    public void shouldGetCustomMapClaim2() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InRlc3QyIjoiZGVmIiwidGVzdDEiOiJhYmMifX0.BR0WMOEyFBJ7oZP8W5oLPTLmLaXGjKjJUa-BTa6lfIY";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat(map, hasEntry("test1", "abc"));
+        Assert.assertThat(map, hasEntry("test2", "def"));
+    }
+    
+    @Test
+    public void shouldGetCustomUserPojo() throws Exception{
+    	String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJwb2pvIjp7ImlkIjoyNTUsIm5hbWUiOiJNaWNoYWVsIn19._WnoWtkLT7IUR8pE1ytOlvi6ArxS02WHLdUqTrA3ySg";
+    	DecodedJWT jwt = JWT.decode(token);
+    	Assert.assertThat(jwt, is(notNullValue()));
+    	UserPojo pojo = jwt.getClaim("pojo").as(UserPojo.class);
+    	Assert.assertThat("Michael", is(pojo.getName()));
+    	Assert.assertThat(255, is(255));
+    }
 
     @Test
     public void shouldGetAvailableClaims() throws Exception {

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -279,8 +279,8 @@ public class JWTDecoderTest {
         DecodedJWT jwt = JWT.decode(token);
         Assert.assertThat(jwt, is(notNullValue()));
         Map<String, Object> map = jwt.getClaim("name").asMap();
-        Assert.assertThat(map, hasEntry("test1", "abc"));
-        Assert.assertThat(map, hasEntry("test2", "def"));
+        Assert.assertThat(map, hasEntry("test1",(Object) "abc"));
+        Assert.assertThat(map, hasEntry("test2",(Object) "def"));
     }
     
     @Test
@@ -289,8 +289,8 @@ public class JWTDecoderTest {
     	DecodedJWT jwt = JWT.decode(token);
     	Assert.assertThat(jwt, is(notNullValue()));
     	UserPojo pojo = jwt.getClaim("pojo").as(UserPojo.class);
-    	Assert.assertThat("Michael", is(pojo.getName()));
-    	Assert.assertThat(255, is(255));
+    	Assert.assertThat(pojo.getName(), is("Michael"));
+    	Assert.assertThat(pojo.getId(), is(255));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -21,557 +21,475 @@ import static org.mockito.Mockito.when;
 
 public class JWTVerifierTest {
 
-    private static final long DATE_TOKEN_MS_VALUE = 1477592 * 1000;
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Test
-    public void shouldThrowWhenInitializedWithoutAlgorithm() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The Algorithm cannot be null");
-        JWTVerifier.init(null);
-    }
-
-    @Test
-    public void shouldThrowWhenAlgorithmDoesntMatchTheTokensAlgorithm() throws Exception {
-        exception.expect(AlgorithmMismatchException.class);
-        exception.expectMessage("The provided Algorithm doesn't match the one defined in the JWT's Header.");
-        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC512("secret")).build();
-        verifier.verify("eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.s69x7Mmu4JqwmdxiK6sesALO7tcedbFsKEEITUxw9ho");
-    }
-
-    @Test
-    public void shouldValidateIssuer() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withIssuer("auth0")
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidIssuer() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'iss' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withIssuer("invalid")
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldValidateSubject() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withSubject("1234567890")
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidSubject() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'sub' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withSubject("invalid")
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldValidateAudience() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJNYXJrIn0.xWB6czYI0XObbVhLAxe55TwChWZg7zO08RxONWU2iY4";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withAudience("Mark")
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-
-        String tokenArr = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIl19.6WfbIt8m61f9WlCYIQn5CThvw4UNyC66qrPaoinfssw";
-        DecodedJWT jwtArr = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withAudience("Mark", "David")
-                .build()
-                .verify(tokenArr);
-
-        assertThat(jwtArr, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldAcceptPartialAudience() throws Exception {
-        //Token 'aud' = ["Mark", "David", "John"]
-        String tokenArr = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIiwiSm9obiJdfQ.DX5xXiCaYvr54x_iL0LZsJhK7O6HhAdHeDYkgDeb0Rw";
-        DecodedJWT jwtArr = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withAudience("John")
-                .build()
-                .verify(tokenArr);
-
-        assertThat(jwtArr, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidAudience() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withAudience("nope")
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldThrowOnNullCustomClaimName() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The Custom Claim's name can't be null.");
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim(null, "value");
-    }
-
-    @Test
-    public void shouldThrowOnInvalidCustomClaimValueOfTypeString() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", "value")
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldThrowOnInvalidCustomClaimValueOfTypeInteger() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", 123)
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldThrowOnInvalidCustomClaimValueOfTypeDouble() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", 23.45)
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldThrowOnInvalidCustomClaimValueOfTypeBoolean() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", true)
-                .build()
-                .verify(token);
-    }
-
-
-    @Test
-    public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", new Date())
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldThrowOnInvalidCustomClaimValue() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
-        Map<String, Object> map = new HashMap<>();
-        map.put("name", new Object());
-        JWTVerifier verifier = new JWTVerifier(Algorithm.HMAC256("secret"), map, new ClockImpl());
-        verifier.verify(token);
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeString() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidmFsdWUifQ.Jki8pvw6KGbxpMinufrgo6RDL1cu7AtNMJYVh6t-_cE";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", "value")
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeInteger() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxMjN9.XZAudnA7h3_Al5kJydzLjw6RzZC3Q6OvnLEYlhNW7HA";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", 123)
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeLong() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjo5MjIzMzcyMDM2ODU0Nzc2MDB9.km-IwQ5IDnTZFmuJzhSgvjTzGkn_Z5X29g4nAuVC56I";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", 922337203685477600L)
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeDouble() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoyMy40NX0.7pyX2OmEGaU9q15T8bGFqRm-d3RVTYnqmZNZtxMKSlA";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", 23.45)
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeBoolean() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjp0cnVlfQ.FwQ8VfsZNRqBa9PXMinSIQplfLU4-rkCLfIlTLg_MV0";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", true)
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomClaimOfTypeDate() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
-        Date date = new Date(1478891521000L);
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", date)
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomArrayClaimOfTypeString() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withArrayClaim("name", "text", "123", "true")
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateCustomArrayClaimOfTypeInteger() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withArrayClaim("name", 1, 2, 3)
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    // Generic Delta
-    @SuppressWarnings("RedundantCast")
-    @Test
-    public void shouldAddDefaultLeewayToDateClaims() throws Exception {
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier verifier = JWTVerifier.init(algorithm)
-                .build();
-
-        assertThat(verifier.claims, is(notNullValue()));
-        assertThat(verifier.claims, hasEntry("iat", (Object) 0L));
-        assertThat(verifier.claims, hasEntry("exp", (Object) 0L));
-        assertThat(verifier.claims, hasEntry("nbf", (Object) 0L));
-    }
-
-    @SuppressWarnings("RedundantCast")
-    @Test
-    public void shouldAddCustomLeewayToDateClaims() throws Exception {
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier verifier = JWTVerifier.init(algorithm)
-                .acceptLeeway(1234L)
-                .build();
-
-        assertThat(verifier.claims, is(notNullValue()));
-        assertThat(verifier.claims, hasEntry("iat", (Object) 1234L));
-        assertThat(verifier.claims, hasEntry("exp", (Object) 1234L));
-        assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
-    }
-
-    @SuppressWarnings("RedundantCast")
-    @Test
-    public void shouldOverrideDefaultIssuedAtLeeway() throws Exception {
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier verifier = JWTVerifier.init(algorithm)
-                .acceptLeeway(1234L)
-                .acceptIssuedAt(9999L)
-                .build();
-
-        assertThat(verifier.claims, is(notNullValue()));
-        assertThat(verifier.claims, hasEntry("iat", (Object) 9999L));
-        assertThat(verifier.claims, hasEntry("exp", (Object) 1234L));
-        assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
-    }
-
-    @SuppressWarnings("RedundantCast")
-    @Test
-    public void shouldOverrideDefaultExpiresAtLeeway() throws Exception {
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier verifier = JWTVerifier.init(algorithm)
-                .acceptLeeway(1234L)
-                .acceptExpiresAt(9999L)
-                .build();
-
-        assertThat(verifier.claims, is(notNullValue()));
-        assertThat(verifier.claims, hasEntry("iat", (Object) 1234L));
-        assertThat(verifier.claims, hasEntry("exp", (Object) 9999L));
-        assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
-    }
-
-    @SuppressWarnings("RedundantCast")
-    @Test
-    public void shouldOverrideDefaultNotBeforeLeeway() throws Exception {
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier verifier = JWTVerifier.init(algorithm)
-                .acceptLeeway(1234L)
-                .acceptNotBefore(9999L)
-                .build();
-
-        assertThat(verifier.claims, is(notNullValue()));
-        assertThat(verifier.claims, hasEntry("iat", (Object) 1234L));
-        assertThat(verifier.claims, hasEntry("exp", (Object) 1234L));
-        assertThat(verifier.claims, hasEntry("nbf", (Object) 9999L));
-    }
-
-    @Test
-    public void shouldThrowOnNegativeCustomLeeway() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Leeway value can't be negative.");
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier.init(algorithm)
-                .acceptLeeway(-1);
-    }
-
-    // Expires At
-    @Test
-    public void shouldValidateExpiresAtWithLeeway() throws Exception {
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .acceptExpiresAt(2);
-        DecodedJWT jwt = verification
-                .build(clock)
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldValidateExpiresAtIfPresent() throws Exception {
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        DecodedJWT jwt = verification
-                .build(clock)
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidExpiresAtIfPresent() throws Exception {
-        exception.expect(TokenExpiredException.class);
-        exception.expectMessage(startsWith("The Token has expired on"));
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        verification
-                .build(clock)
-                .verify(token);
-    }
-
-    @Test
-    public void shouldThrowOnNegativeExpiresAtLeeway() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Leeway value can't be negative.");
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier.init(algorithm)
-                .acceptExpiresAt(-1);
-    }
-
-    // Not before
-    @Test
-    public void shouldValidateNotBeforeWithLeeway() throws Exception {
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .acceptNotBefore(2);
-        DecodedJWT jwt = verification
-                .build(clock)
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidNotBeforeIfPresent() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage(startsWith("The Token can't be used before"));
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        verification
-                .build(clock)
-                .verify(token);
-    }
-
-    @Test
-    public void shouldValidateNotBeforeIfPresent() throws Exception {
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        DecodedJWT jwt = verification
-                .build(clock)
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnNegativeNotBeforeLeeway() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Leeway value can't be negative.");
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier.init(algorithm)
-                .acceptNotBefore(-1);
-    }
-
-    // Issued At
-    @Test
-    public void shouldValidateIssuedAtWithLeeway() throws Exception {
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .acceptIssuedAt(2);
-        DecodedJWT jwt = verification
-                .build(clock)
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidIssuedAtIfPresent() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage(startsWith("The Token can't be used before"));
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        verification
-                .build(clock)
-                .verify(token);
-    }
-
-    @Test
-    public void shouldValidateIssuedAtIfPresent() throws Exception {
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
-
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        DecodedJWT jwt = verification
-                .build(clock)
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnNegativeIssuedAtLeeway() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Leeway value can't be negative.");
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier.init(algorithm)
-                .acceptIssuedAt(-1);
-    }
-
-    @Test
-    public void shouldValidateJWTId() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJqd3RfaWRfMTIzIn0.0kegfXUvwOYioP8PDaLMY1IlV8HOAzSVz3EGL7-jWF4";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withJWTId("jwt_id_123")
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnInvalidJWTId() throws Exception {
-        exception.expect(InvalidClaimException.class);
-        exception.expectMessage("The Claim 'jti' value doesn't match the required one.");
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJqd3RfaWRfMTIzIn0.0kegfXUvwOYioP8PDaLMY1IlV8HOAzSVz3EGL7-jWF4";
-        JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withJWTId("invalid")
-                .build()
-                .verify(token);
-    }
-
-    @Test
-    public void shouldRemoveClaimWhenPassingNull() throws Exception {
-        Algorithm algorithm = mock(Algorithm.class);
-        JWTVerifier verifier = JWTVerifier.init(algorithm)
-                .withIssuer("iss")
-                .withIssuer(null)
-                .build();
-
-        assertThat(verifier.claims, is(notNullValue()));
-        assertThat(verifier.claims, not(hasKey("iss")));
-    }
-
-    @Test
-    public void shouldSkipClaimValidationsIfNoClaimsRequired() throws Exception {
-        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M";
-        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .build()
-                .verify(token);
-
-        assertThat(jwt, is(notNullValue()));
-    }
+	private static final long DATE_TOKEN_MS_VALUE = 1477592 * 1000;
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void shouldThrowWhenInitializedWithoutAlgorithm() throws Exception {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("The Algorithm cannot be null");
+		JWTVerifier.init(null);
+	}
+
+	@Test
+	public void shouldThrowWhenAlgorithmDoesntMatchTheTokensAlgorithm() throws Exception {
+		exception.expect(AlgorithmMismatchException.class);
+		exception.expectMessage("The provided Algorithm doesn't match the one defined in the JWT's Header.");
+		JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC512("secret")).build();
+		verifier.verify("eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.s69x7Mmu4JqwmdxiK6sesALO7tcedbFsKEEITUxw9ho");
+	}
+
+	@Test
+	public void shouldValidateIssuer() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withIssuer("auth0").build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidIssuer() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'iss' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withIssuer("invalid").build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnInvalidPojo() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'pojo' value doesn't match the required one.");
+		String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJwb2pvIjp7ImlkIjoyNTUsIm5hbWUiOiJNaWNoYWVsIn19._WnoWtkLT7IUR8pE1ytOlvi6ArxS02WHLdUqTrA3ySg";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("pojo", new UserPojo()).build()
+				.verify(token);
+		assertThat(jwt, is(notNullValue()));
+	}
+	
+	@Test
+	public void shouldValidatePojo() throws Exception {
+		String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJwb2pvIjp7ImlkIjoyNTUsIm5hbWUiOiJNaWNoYWVsIn19._WnoWtkLT7IUR8pE1ytOlvi6ArxS02WHLdUqTrA3ySg";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("pojo", new UserPojo("Michael", 255)).build()
+				.verify(token);
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateSubject() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withSubject("1234567890").build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidSubject() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'sub' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withSubject("invalid").build().verify(token);
+	}
+
+	@Test
+	public void shouldValidateAudience() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJNYXJrIn0.xWB6czYI0XObbVhLAxe55TwChWZg7zO08RxONWU2iY4";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withAudience("Mark").build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+
+		String tokenArr = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIl19.6WfbIt8m61f9WlCYIQn5CThvw4UNyC66qrPaoinfssw";
+		DecodedJWT jwtArr = JWTVerifier.init(Algorithm.HMAC256("secret")).withAudience("Mark", "David").build()
+				.verify(tokenArr);
+
+		assertThat(jwtArr, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldAcceptPartialAudience() throws Exception {
+		// Token 'aud' = ["Mark", "David", "John"]
+		String tokenArr = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIiwiSm9obiJdfQ.DX5xXiCaYvr54x_iL0LZsJhK7O6HhAdHeDYkgDeb0Rw";
+		DecodedJWT jwtArr = JWTVerifier.init(Algorithm.HMAC256("secret")).withAudience("John").build().verify(tokenArr);
+
+		assertThat(jwtArr, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidAudience() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withAudience("nope").build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnNullCustomClaimName() throws Exception {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("The Custom Claim's name can't be null.");
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim(null, "value");
+	}
+
+	@Test
+	public void shouldThrowOnInvalidCustomClaimValueOfTypeString() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", "value").build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnInvalidCustomClaimValueOfTypeInteger() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", 123).build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnInvalidCustomClaimValueOfTypeDouble() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", 23.45).build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnInvalidCustomClaimValueOfTypeBoolean() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", true).build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", new Date()).build().verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnInvalidCustomClaimValue() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+		Map<String, Object> map = new HashMap<>();
+		map.put("name", new Object());
+		JWTVerifier verifier = new JWTVerifier(Algorithm.HMAC256("secret"), map, new ClockImpl());
+		verifier.verify(token);
+	}
+
+	@Test
+	public void shouldValidateCustomClaimOfTypeString() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidmFsdWUifQ.Jki8pvw6KGbxpMinufrgo6RDL1cu7AtNMJYVh6t-_cE";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", "value").build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomClaimOfTypeInteger() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxMjN9.XZAudnA7h3_Al5kJydzLjw6RzZC3Q6OvnLEYlhNW7HA";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", 123).build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomClaimOfTypeLong() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjo5MjIzMzcyMDM2ODU0Nzc2MDB9.km-IwQ5IDnTZFmuJzhSgvjTzGkn_Z5X29g4nAuVC56I";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", 922337203685477600L).build()
+				.verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomClaimOfTypeDouble() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoyMy40NX0.7pyX2OmEGaU9q15T8bGFqRm-d3RVTYnqmZNZtxMKSlA";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", 23.45).build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomClaimOfTypeBoolean() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjp0cnVlfQ.FwQ8VfsZNRqBa9PXMinSIQplfLU4-rkCLfIlTLg_MV0";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", true).build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomClaimOfTypeDate() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
+		Date date = new Date(1478891521000L);
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withClaim("name", date).build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomArrayClaimOfTypeString() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withArrayClaim("name", "text", "123", "true")
+				.build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateCustomArrayClaimOfTypeInteger() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withArrayClaim("name", 1, 2, 3).build()
+				.verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	// Generic Delta
+	@SuppressWarnings("RedundantCast")
+	@Test
+	public void shouldAddDefaultLeewayToDateClaims() throws Exception {
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier verifier = JWTVerifier.init(algorithm).build();
+
+		assertThat(verifier.claims, is(notNullValue()));
+		assertThat(verifier.claims, hasEntry("iat", (Object) 0L));
+		assertThat(verifier.claims, hasEntry("exp", (Object) 0L));
+		assertThat(verifier.claims, hasEntry("nbf", (Object) 0L));
+	}
+
+	@SuppressWarnings("RedundantCast")
+	@Test
+	public void shouldAddCustomLeewayToDateClaims() throws Exception {
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier verifier = JWTVerifier.init(algorithm).acceptLeeway(1234L).build();
+
+		assertThat(verifier.claims, is(notNullValue()));
+		assertThat(verifier.claims, hasEntry("iat", (Object) 1234L));
+		assertThat(verifier.claims, hasEntry("exp", (Object) 1234L));
+		assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
+	}
+
+	@SuppressWarnings("RedundantCast")
+	@Test
+	public void shouldOverrideDefaultIssuedAtLeeway() throws Exception {
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier verifier = JWTVerifier.init(algorithm).acceptLeeway(1234L).acceptIssuedAt(9999L).build();
+
+		assertThat(verifier.claims, is(notNullValue()));
+		assertThat(verifier.claims, hasEntry("iat", (Object) 9999L));
+		assertThat(verifier.claims, hasEntry("exp", (Object) 1234L));
+		assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
+	}
+
+	@SuppressWarnings("RedundantCast")
+	@Test
+	public void shouldOverrideDefaultExpiresAtLeeway() throws Exception {
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier verifier = JWTVerifier.init(algorithm).acceptLeeway(1234L).acceptExpiresAt(9999L).build();
+
+		assertThat(verifier.claims, is(notNullValue()));
+		assertThat(verifier.claims, hasEntry("iat", (Object) 1234L));
+		assertThat(verifier.claims, hasEntry("exp", (Object) 9999L));
+		assertThat(verifier.claims, hasEntry("nbf", (Object) 1234L));
+	}
+
+	@SuppressWarnings("RedundantCast")
+	@Test
+	public void shouldOverrideDefaultNotBeforeLeeway() throws Exception {
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier verifier = JWTVerifier.init(algorithm).acceptLeeway(1234L).acceptNotBefore(9999L).build();
+
+		assertThat(verifier.claims, is(notNullValue()));
+		assertThat(verifier.claims, hasEntry("iat", (Object) 1234L));
+		assertThat(verifier.claims, hasEntry("exp", (Object) 1234L));
+		assertThat(verifier.claims, hasEntry("nbf", (Object) 9999L));
+	}
+
+	@Test
+	public void shouldThrowOnNegativeCustomLeeway() throws Exception {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Leeway value can't be negative.");
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier.init(algorithm).acceptLeeway(-1);
+	}
+
+	// Expires At
+	@Test
+	public void shouldValidateExpiresAtWithLeeway() throws Exception {
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret")).acceptExpiresAt(2);
+		DecodedJWT jwt = verification.build(clock).verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldValidateExpiresAtIfPresent() throws Exception {
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret"));
+		DecodedJWT jwt = verification.build(clock).verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidExpiresAtIfPresent() throws Exception {
+		exception.expect(TokenExpiredException.class);
+		exception.expectMessage(startsWith("The Token has expired on"));
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret"));
+		verification.build(clock).verify(token);
+	}
+
+	@Test
+	public void shouldThrowOnNegativeExpiresAtLeeway() throws Exception {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Leeway value can't be negative.");
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier.init(algorithm).acceptExpiresAt(-1);
+	}
+
+	// Not before
+	@Test
+	public void shouldValidateNotBeforeWithLeeway() throws Exception {
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret")).acceptNotBefore(2);
+		DecodedJWT jwt = verification.build(clock).verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidNotBeforeIfPresent() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage(startsWith("The Token can't be used before"));
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret"));
+		verification.build(clock).verify(token);
+	}
+
+	@Test
+	public void shouldValidateNotBeforeIfPresent() throws Exception {
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret"));
+		DecodedJWT jwt = verification.build(clock).verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnNegativeNotBeforeLeeway() throws Exception {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Leeway value can't be negative.");
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier.init(algorithm).acceptNotBefore(-1);
+	}
+
+	// Issued At
+	@Test
+	public void shouldValidateIssuedAtWithLeeway() throws Exception {
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret")).acceptIssuedAt(2);
+		DecodedJWT jwt = verification.build(clock).verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidIssuedAtIfPresent() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage(startsWith("The Token can't be used before"));
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret"));
+		verification.build(clock).verify(token);
+	}
+
+	@Test
+	public void shouldValidateIssuedAtIfPresent() throws Exception {
+		Clock clock = mock(Clock.class);
+		when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
+
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
+		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier
+				.init(Algorithm.HMAC256("secret"));
+		DecodedJWT jwt = verification.build(clock).verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnNegativeIssuedAtLeeway() throws Exception {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Leeway value can't be negative.");
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier.init(algorithm).acceptIssuedAt(-1);
+	}
+
+	@Test
+	public void shouldValidateJWTId() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJqd3RfaWRfMTIzIn0.0kegfXUvwOYioP8PDaLMY1IlV8HOAzSVz3EGL7-jWF4";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).withJWTId("jwt_id_123").build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldThrowOnInvalidJWTId() throws Exception {
+		exception.expect(InvalidClaimException.class);
+		exception.expectMessage("The Claim 'jti' value doesn't match the required one.");
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJqd3RfaWRfMTIzIn0.0kegfXUvwOYioP8PDaLMY1IlV8HOAzSVz3EGL7-jWF4";
+		JWTVerifier.init(Algorithm.HMAC256("secret")).withJWTId("invalid").build().verify(token);
+	}
+
+	@Test
+	public void shouldRemoveClaimWhenPassingNull() throws Exception {
+		Algorithm algorithm = mock(Algorithm.class);
+		JWTVerifier verifier = JWTVerifier.init(algorithm).withIssuer("iss").withIssuer(null).build();
+
+		assertThat(verifier.claims, is(notNullValue()));
+		assertThat(verifier.claims, not(hasKey("iss")));
+	}
+
+	@Test
+	public void shouldSkipClaimValidationsIfNoClaimsRequired() throws Exception {
+		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M";
+		DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret")).build().verify(token);
+
+		assertThat(jwt, is(notNullValue()));
+	}
 }


### PR DESCRIPTION
This pull requests adds the ability to create tokens with custom objects as claims. 

## Motivation
It was possible to verify tokens with JSON objects as claim values, but it was not possible to create them. The public API didn't provide the necessary methods to add custom objects to the token as a claim value. 
This pull request enables a user of this library to do so, furthermore it is now also possible to pass mandatory object claims during verification of the token. 