### PR TITLE
Throw JWTDecodeException when date claim format is invalid

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -69,7 +69,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
             return null;
         }
         if (!node.canConvertToLong()) {
-            throw new JWTDecodeException(String.format("The claim '%s' contained an unexpected value.", claimName));
+            throw new JWTDecodeException(String.format("The claim '%s' contained a non-numeric date value.", claimName));
         }
         final long ms = node.asLong() * 1000;
         return new Date(ms);

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -65,8 +65,11 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
 
     Date getDateFromSeconds(Map<String, JsonNode> tree, String claimName) {
         JsonNode node = tree.get(claimName);
-        if (node == null || node.isNull() || !node.canConvertToLong()) {
+        if (node == null || node.isNull()) {
             return null;
+        }
+        if (!node.canConvertToLong()) {
+            throw new JWTDecodeException(String.format("The claim '%s' contained an unexpected value.", claimName));
         }
         final long ms = node.asLong() * 1000;
         return new Date(ms);

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -275,7 +275,7 @@ public class JWTDecoderTest {
 
     @Test
     public void shouldGetAvailableClaims() throws Exception {
-        DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjM0NTY3ODkwIiwiaWF0IjoiMTIzNDU2Nzg5MCIsIm5iZiI6IjEyMzQ1Njc4OTAiLCJqdGkiOiJodHRwczovL2p3dC5pby8iLCJhdWQiOiJodHRwczovL2RvbWFpbi5hdXRoMC5jb20iLCJzdWIiOiJsb2dpbiIsImlzcyI6ImF1dGgwIiwiZXh0cmFDbGFpbSI6IkpvaG4gRG9lIn0.TX9Ct4feGp9YyeGK9Zl91tO0YBOrguJ4As9jeqgHdZQ");
+        DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEyMzQ1Njc4OTAsImlhdCI6MTIzNDU2Nzg5MCwibmJmIjoxMjM0NTY3ODkwLCJqdGkiOiJodHRwczovL2p3dC5pby8iLCJhdWQiOiJodHRwczovL2RvbWFpbi5hdXRoMC5jb20iLCJzdWIiOiJsb2dpbiIsImlzcyI6ImF1dGgwIiwiZXh0cmFDbGFpbSI6IkpvaG4gRG9lIn0.2_0nxDPJwOk64U5V5V9pt8U92jTPJbGsHYQ35HYhbdE");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getClaims(), is(notNullValue()));
         assertThat(jwt.getClaims(), is(instanceOf(Map.class)));

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -200,7 +200,7 @@ public class PayloadDeserializerTest {
     @Test
     public void shouldThrowWhenParsingNonNumericNode() throws Exception {
         exception.expect(JWTDecodeException.class);
-        exception.expectMessage("The claim 'key' contained an unexpected value.");
+        exception.expectMessage("The claim 'key' contained a non-numeric date value.");
 
         Map<String, JsonNode> tree = new HashMap<>();
         TextNode node = new TextNode("123456789");

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -198,13 +198,15 @@ public class PayloadDeserializerTest {
     }
 
     @Test
-    public void shouldGetNullDateWhenParsingNonNumericNode() throws Exception {
+    public void shouldThrowWhenParsingNonNumericNode() throws Exception {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage("The claim 'key' contained an unexpected value.");
+
         Map<String, JsonNode> tree = new HashMap<>();
         TextNode node = new TextNode("123456789");
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(nullValue()));
+        deserializer.getDateFromSeconds(tree, "key");
     }
 
     @Test


### PR DESCRIPTION
WDYT about the exception message?

Fixes https://github.com/auth0/java-jwt/issues/240