### PR TITLE
Bump Jackson dependency

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,7 +34,7 @@ compileJava {
 }
 
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.2'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
     compile 'commons-codec:commons-codec:1.11'
     testCompile 'org.bouncycastle:bcprov-jdk15on:1.58'
     testCompile 'junit:junit:4.12'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,7 +34,7 @@ compileJava {
 }
 
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     compile 'commons-codec:commons-codec:1.11'
     testCompile 'org.bouncycastle:bcprov-jdk15on:1.58'
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Bump dependencies to fix a [security bug](https://nvd.nist.gov/vuln/detail/CVE-2017-17485) in Jackson.