### PR TITLE
getting HMAC* Algorithm does not throw UnsupportedEncodingException

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -6,7 +6,6 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 
-import java.io.UnsupportedEncodingException;
 import java.security.interfaces.*;
 
 /**
@@ -138,9 +137,8 @@ public abstract class Algorithm {
      * @param secret the secret to use in the verify or signing instance.
      * @return a valid HMAC256 Algorithm.
      * @throws IllegalArgumentException     if the provided Secret is null.
-     * @throws UnsupportedEncodingException if the current Java platform implementation doesn't support the UTF-8 character encoding.
      */
-    public static Algorithm HMAC256(String secret) throws IllegalArgumentException, UnsupportedEncodingException {
+    public static Algorithm HMAC256(String secret) throws IllegalArgumentException {
         return new HMACAlgorithm("HS256", "HmacSHA256", secret);
     }
 
@@ -150,9 +148,8 @@ public abstract class Algorithm {
      * @param secret the secret to use in the verify or signing instance.
      * @return a valid HMAC384 Algorithm.
      * @throws IllegalArgumentException     if the provided Secret is null.
-     * @throws UnsupportedEncodingException if the current Java platform implementation doesn't support the UTF-8 character encoding.
      */
-    public static Algorithm HMAC384(String secret) throws IllegalArgumentException, UnsupportedEncodingException {
+    public static Algorithm HMAC384(String secret) throws IllegalArgumentException {
         return new HMACAlgorithm("HS384", "HmacSHA384", secret);
     }
 
@@ -162,9 +159,8 @@ public abstract class Algorithm {
      * @param secret the secret to use in the verify or signing instance.
      * @return a valid HMAC512 Algorithm.
      * @throws IllegalArgumentException     if the provided Secret is null.
-     * @throws UnsupportedEncodingException if the current Java platform implementation doesn't support the UTF-8 character encoding.
      */
-    public static Algorithm HMAC512(String secret) throws IllegalArgumentException, UnsupportedEncodingException {
+    public static Algorithm HMAC512(String secret) throws IllegalArgumentException {
         return new HMACAlgorithm("HS512", "HmacSHA512", secret);
     }
 

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -3,10 +3,8 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.codec.binary.Base64;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -30,16 +28,16 @@ class HMACAlgorithm extends Algorithm {
         this(new CryptoHelper(), id, algorithm, secretBytes);
     }
 
-    HMACAlgorithm(String id, String algorithm, String secret) throws IllegalArgumentException, UnsupportedEncodingException {
+    HMACAlgorithm(String id, String algorithm, String secret) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, getSecretBytes(secret));
     }
 
     //Visible for testing
-    static byte[] getSecretBytes(String secret) throws IllegalArgumentException, UnsupportedEncodingException {
+    static byte[] getSecretBytes(String secret) throws IllegalArgumentException {
         if (secret == null) {
             throw new IllegalArgumentException("The Secret cannot be null");
         }
-        return secret.getBytes(CharEncoding.UTF_8);
+        return secret.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override


### PR DESCRIPTION
using StandardCharsets.UTF_8 instead of CharEncoding.UTF_8 does not
require to handle CharEncoding.UTF_8