### PR TITLE
nbf is checked if it is in the past

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If the token has an invalid signature or the Claim requirement is not met, a `JW
 The JWT token may include DateNumber fields that can be used to validate that:
 * The token was issued in a past date `"iat" < TODAY`
 * The token hasn't expired yet `"exp" > TODAY` and
-* The token can already be used. `"nbf" > TODAY`
+* The token can already be used. `"nbf" < TODAY`
 
 When verifying a token the time validation occurs automatically, resulting in a `JWTVerificationException` being throw when the values are invalid. If any of the previous fields are missing they won't be considered in this validation.
 

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ If the token has an invalid signature or the Claim requirement is not met, a `JW
 
 The JWT token may include DateNumber fields that can be used to validate that:
 * The token was issued in a past date `"iat" < TODAY`
-* The token hasn't expired yet `"exp" > TODAY` and
-* The token can already be used. `"nbf" < TODAY`
+* The token can already be used. `"nbf" < TODAY` and
+* The token hasn't expired yet `"exp" > TODAY`
 
 When verifying a token the time validation occurs automatically, resulting in a `JWTVerificationException` being throw when the values are invalid. If any of the previous fields are missing they won't be considered in this validation.
 


### PR DESCRIPTION
Just a small fix to the docs to avoid confusion. Unlike `exp` which must be in the future, `nbf` must be in the past.