### PR TITLE
Support verification of Long[] datatype like in JWTCreator

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -325,7 +325,23 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         } else if (value instanceof Date) {
             isValid = value.equals(claim.asDate());
         } else if (value instanceof Object[]) {
-            List<Object> claimArr = Arrays.asList(claim.as(Object[].class));
+            List<Object> claimArr;
+            Object[] claimAsObject = claim.as(Object[].class);
+
+            // Jackson uses 'natural' mapping which uses Integer if value fits in 32 bits.
+            if(value instanceof Long[]) {
+                // convert Integers to Longs for comparison with equals
+                claimArr = new ArrayList<>(claimAsObject.length);
+                for(Object cao : claimAsObject) {
+                    if(cao instanceof Integer) {
+                        claimArr.add(((Integer)cao).longValue());
+                    } else {
+                        claimArr.add(cao);
+                    }
+                }
+            } else {
+                claimArr = Arrays.asList(claim.as(Object[].class));
+            }
             List<Object> valueArr = Arrays.asList((Object[]) value);
             isValid = claimArr.containsAll(valueArr);
         }

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -168,6 +168,21 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             requireClaim(name, items);
             return this;
         }
+        
+        /**
+         * Require a specific Array Claim to contain at least the given items.
+         *
+         * @param name  the Claim's name.
+         * @param items the items the Claim must contain.
+         * @return this same Verification instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        @Override
+        public Verification withArrayClaim(String name, Long ... items) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, items);
+            return this;
+        }        
 
         @Override
         public JWTVerifier build() {

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -161,14 +161,17 @@ public interface Verification {
     Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
 
     /**
-     * Skip the Issued At ("iat") date verification. By default, the verification is performed.
-     */
-    Verification ignoreIssuedAt();
-
-    /**
      * Creates a new and reusable instance of the JWTVerifier with the configuration already provided.
      *
      * @return a new JWTVerifier instance.
      */
+    Verification withArrayClaim(String name, Long ... items) throws IllegalArgumentException;
+
+    
+    /**
+     * Skip the Issued At ("iat") date verification. By default, the verification is performed.
+     */
+    Verification ignoreIssuedAt();
+
     JWTVerifier build();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -161,17 +161,25 @@ public interface Verification {
     Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
 
     /**
-     * Creates a new and reusable instance of the JWTVerifier with the configuration already provided.
+     * Require a specific Array Claim to contain at least the given items.
      *
-     * @return a new JWTVerifier instance.
+     * @param name  the Claim's name.
+     * @param items the items the Claim must contain.
+     * @return this same Verification instance.
+     * @throws IllegalArgumentException if the name is null.
      */
+
     Verification withArrayClaim(String name, Long ... items) throws IllegalArgumentException;
 
-    
     /**
      * Skip the Issued At ("iat") date verification. By default, the verification is performed.
      */
     Verification ignoreIssuedAt();
 
+    /**
+     * Creates a new and reusable instance of the JWTVerifier with the configuration already provided.
+     *
+     * @return a new JWTVerifier instance.
+     */
     JWTVerifier build();
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -326,6 +326,38 @@ public class JWTVerifierTest {
         assertThat(jwt, is(notNullValue()));
     }
 
+    @Test
+    public void shouldValidateCustomArrayClaimOfTypeLong() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbNTAwMDAwMDAwMDAxLDUwMDAwMDAwMDAwMiw1MDAwMDAwMDAwMDNdfQ.vzV7S0gbV9ZAVxChuIt4XZuSVTxMH536rFmoHzxmayM";
+        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withArrayClaim("name", 500000000001L, 500000000002L, 500000000003L)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomArrayClaimOfTypeLongWhenValueIsInteger() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
+        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withArrayClaim("name", 1L, 2L, 3L)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateCustomArrayClaimOfTypeLongWhenValueIsIntegerAndLong() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSw1MDAwMDAwMDAwMDIsNTAwMDAwMDAwMDAzXX0.PQjb2rPPpYjM2sItZEzZcjS2YbfPCp6xksTSPjpjTQA";
+        DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withArrayClaim("name", 1L, 500000000002L, 500000000003L)
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
     // Generic Delta
     @SuppressWarnings("RedundantCast")
     @Test


### PR DESCRIPTION
Add Long array type so that the Verification claim types are the same as supported in JWTCreator.