### PR TITLE
Support custom validation

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/CustomValidation.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/CustomValidation.java
@@ -1,0 +1,14 @@
+package com.auth0.jwt.interfaces;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+
+/**
+ * A custom verification that can be added to the Verifier via
+ * {@link Verification#withCustomValidation(CustomValidation)}.
+ *
+ * The implementation is passed a decoded JWT and should throw JWTVerificationException if the custom
+ * verification logic fails.
+ */
+public interface CustomValidation {
+    void validate(DecodedJWT jwt) throws JWTVerificationException;
+}

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -37,5 +37,7 @@ public interface Verification {
 
     Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
 
+    Verification withCustomValidation(CustomValidation validation) throws IllegalArgumentException;
+
     JWTVerifier build();
 }


### PR DESCRIPTION
Adds the ability for users to add one or more custom validations to the
JWT verification process, by using `withCustomValidation` on the
validation builder.

This is useful to workaround the inability to perform particular
validations directly with the library, such as issue #19, or to do other
validations that are not possible with the built-in validations.