### PR TITLE
Verify a DecodedJWT 

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -351,6 +351,21 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
     @Override
     public DecodedJWT verify(String token) throws JWTVerificationException {
         DecodedJWT jwt = JWT.decode(token);
+        return verify(jwt);
+    }
+
+    /**
+     * Perform the verification against the given decoded JWT, using any previous configured options.
+     *
+     * @param jwt to verify.
+     * @return a verified and decoded JWT.
+     * @throws AlgorithmMismatchException     if the algorithm stated in the token's header it's not equal to the one defined in the {@link JWTVerifier}.
+     * @throws SignatureVerificationException if the signature is invalid.
+     * @throws TokenExpiredException          if the token has expired.
+     * @throws InvalidClaimException          if a claim contained a different value than the expected one.
+     */
+    @Override
+    public DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException {
         verifyAlgorithm(jwt, algorithm);
         algorithm.verify(jwt);
         verifyClaims(jwt, claims);

--- a/lib/src/main/java/com/auth0/jwt/interfaces/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/JWTVerifier.java
@@ -13,4 +13,13 @@ public interface JWTVerifier {
    * @throws JWTVerificationException if any of the verification steps fail
    */
   DecodedJWT verify(String token) throws JWTVerificationException;
+
+  /**
+   * Performs the verification against the given decoded JWT
+   *
+   * @param jwt to verify.
+   * @return a verified and decoded JWT.
+   * @throws JWTVerificationException if any of the verification steps fail
+   */
+  DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException;
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -59,6 +59,18 @@ public class JWTTest {
     // Verify
 
     @Test
+    public void shouldVerifyDecodedToken() throws Exception {
+        String token = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mvL5LoMyIrWYjk5umEXZTmbyIrkbbcVPUkvdGZbu0qFBxGOf0nXP5PZBvPcOu084lvpwVox5n3VaD4iqzW-PsJyvKFgi5TnwmsbKchAp7JexQEsQOnTSGcfRqeUUiBZqRQdYsho71oAB3T4FnalDdFEpM-fztcZY9XqKyayqZLreTeBjqJm4jfOWH7KfGBHgZExQhe96NLq1UA9eUyQwdOA1Z0SgXe4Ja5PxZ6Fm37KnVDtDlNnY4JAAGFo6y74aGNnp_BKgpaVJCGFu1f1S5xCQ1HSvs8ZSdVWs5NgawW3wRd0kRt_GJ_Y3mIwiF4qUyHWGtsSHu_qjVdCTtbFyow";
+        DecodedJWT decodedJWT = JWT.decode(token);
+        RSAKey key = (RSAKey) PemUtils.readPublicKeyFromFile(PUBLIC_KEY_FILE_RSA, "RSA");
+        DecodedJWT jwt = JWT.require(Algorithm.RSA512(key))
+            .build()
+            .verify(decodedJWT);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
     public void shouldAcceptNoneAlgorithm() throws Exception {
         String token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJhdXRoMCJ9.";
         DecodedJWT jwt = JWT.require(Algorithm.none())


### PR DESCRIPTION
Allows verification of a DecodedJWT previously obtained by invoking JWT.decode(). This alleviates the user from having to recompute the values of the DecodedJWT in order to validate the token.

Reopens #279