### PR TITLE
Support to add objects (primitive and collection) as claims in token …

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Claim claim = jwt.getClaim("isAdmin");
 ```
 
 When creating a Token with the `JWT.create()` you can specify a custom Claim by calling `withClaim()` and passing both the name and the value.
+withClaim() can be used to pass Map of <String, Object>. Only primitives and collections are allowed here. 
+Warning: Using custom classes is not guranteed to serialize without issues.
 
 ```java
 String token = JWT.create()

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -211,7 +211,7 @@ public final class JWTCreator {
         }
 
         private static boolean validateClaim(Map<String, Object> claim) {
-            if (claim == null || claim.isEmpty()) {
+            if (claim == null) {
                 return false;
             }
             Collection<Object> values = claim.values();
@@ -219,7 +219,7 @@ public final class JWTCreator {
         }
 
         private static boolean validateClaim(Collection<Object> values) {
-            if (values == null || values.isEmpty()) {
+            if (values == null) {
                 return false;
             }
             for (Object value : values) {

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -223,9 +223,7 @@ public final class JWTCreator {
                 return false;
             }
             for (Object value : values) {
-                if (!isValidClaimValue(value)) {
-                    return false;
-                }
+                isValidClaimValue(value);
             }
             return true;
         }

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -67,8 +67,7 @@ public final class JWTCreator {
         private static final Set<Class<?>> SUPPORTED_ARRAY_TYPES = new HashSet<>();
         static {
             SUPPORTED_ARRAY_TYPES.addAll(Arrays.asList(Integer[].class, Long[].class, String[].class));
-            SUPPORTED_TYPES.addAll(
-                    Arrays.asList(String.class, Integer.class, Double.class, Long.class, Date.class, Boolean.class));
+            SUPPORTED_TYPES.addAll(Arrays.asList(String.class, Integer.class, Double.class, Long.class, Date.class, Boolean.class));
         }
 
         Builder() {
@@ -187,8 +186,7 @@ public final class JWTCreator {
         public Builder withClaim(String name, Map<String, Object> values) throws IllegalArgumentException {
             assertNonNull(name);
             if (!validateClaim(values)) {
-                throw new IllegalArgumentException(
-                        "Unsupported claim type found in passed collection. Refer supported types.");
+                throw new IllegalArgumentException("Unsupported claim type found in passed collection. Refer supported types.");
             }
             addClaim(name, values);
             return this;
@@ -206,8 +204,7 @@ public final class JWTCreator {
         public Builder withClaim(String name, Collection<Object> values) throws IllegalArgumentException {
             assertNonNull(name);
             if (!validateClaim(values)) {
-                throw new IllegalArgumentException(
-                        "Unsupported claim type found in passed collection. Refer supported types.");
+                throw new IllegalArgumentException("Unsupported claim type found in passed collection. Refer supported types.");
             }
             addClaim(name, values);
             return this;
@@ -245,7 +242,10 @@ public final class JWTCreator {
             if (clazz.isArray() && SUPPORTED_ARRAY_TYPES.contains(clazz)) {
                 return true;
             }
-            return SUPPORTED_TYPES.contains(clazz);
+            if(SUPPORTED_TYPES.contains(clazz))
+                return true;
+
+            throw new IllegalArgumentException("For the claim, of value {" + value + "}, it's type {" + clazz + "} is not supported");
         }
 
         /**

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -501,7 +501,7 @@ public class JWTCreatorTest {
         JWTCreator.init().withClaim("name", collection);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldAcceptEmptyCustomCollectionClaim() throws Exception {
         Collection<Object> collection = new ArrayList<>();
         JWTCreator.init().withClaim("name", collection);
@@ -513,7 +513,7 @@ public class JWTCreatorTest {
         JWTCreator.init().withClaim("name", map);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldAcceptEmptyCustomMapClaim() throws Exception {
         Map<String, Object> map = new HashMap<>();
         JWTCreator.init().withClaim("name", map);

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -14,6 +14,9 @@ import java.security.interfaces.RSAPrivateKey;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -356,5 +359,271 @@ public class JWTCreatorTest {
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
         assertThat(parts[1], is("eyJuYW1lIjpbMSwyLDNdfQ"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfBooleanType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(true);
+        collection.add(false);
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbdHJ1ZSxmYWxzZV19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfIntegerType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(1);
+        collection.add(2);
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbMSwyXX0"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfLongType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(1L);
+        collection.add(2L);
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbMSwyXX0"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfStringType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add("1");
+        collection.add("2");
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbIjEiLCIyIl19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfDoubleType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(1.2);
+        collection.add(3.4);
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbMS4yLDMuNF19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfDateType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new Date(123456));
+        collection.add(new Date(7890123));
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbMTIzNDU2LDc4OTAxMjNdfQ"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfIntegerArrayType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new Integer[] { 1, 2 });
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbWzEsMl1dfQ"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfLongArrayType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new Long[] { 3L, 4L });
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbWzMsNF1dfQ"));
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfStringArrayType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new String[] { "5", "6" });
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbWyI1IiwiNiJdXX0"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAcceptCustomCollectionClaimOfUnSupportedType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new JWTTest());
+
+        JWTCreator.init().withClaim("name", collection);
+    }
+
+    @Test
+    public void shouldAcceptCustomCollectionClaimOfArrayType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new Integer[] { 1, 2, 3 });
+        collection.add(new Long[] { 1L, 2L, 3L });
+        collection.add(new String[] { "1", "2", "3" });
+
+        String jwt = JWTCreator.init().withClaim("name", collection).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjpbWzEsMiwzXSxbMSwyLDNdLFsiMSIsIjIiLCIzIl1dfQ"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAcceptCustomCollectionClaimOfUnSupportedArrayType() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        collection.add(new Boolean[] { true });
+
+        JWTCreator.init().withClaim("name", collection);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAcceptNullCustomCollectionClaim() throws Exception {
+        Collection<Object> collection = null;
+        JWTCreator.init().withClaim("name", collection);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldAcceptEmptyCustomCollectionClaim() throws Exception {
+        Collection<Object> collection = new ArrayList<>();
+        JWTCreator.init().withClaim("name", collection);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAcceptNullCustomMapClaim() throws Exception {
+        Map<String, Object> map = null;
+        JWTCreator.init().withClaim("name", map);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldAcceptEmptyCustomMapClaim() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        JWTCreator.init().withClaim("name", map);
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfTypeLong() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", 1L);
+        map.put("two", Long.MAX_VALUE);
+        map.put("three", null);
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7InR3byI6OTIyMzM3MjAzNjg1NDc3NTgwNywidGhyZWUiOm51bGwsImZpcnN0IjoxfX0"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfTypeInteger() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", 1);
+        map.put("two", Integer.MAX_VALUE);
+        map.put("three", null);
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7InR3byI6MjE0NzQ4MzY0NywidGhyZWUiOm51bGwsImZpcnN0IjoxfX0"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfTypeDouble() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", 12.34);
+        map.put("two", Double.MAX_VALUE);
+        map.put("three", null);
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1],
+                is("eyJuYW1lIjp7InR3byI6MS43OTc2OTMxMzQ4NjIzMTU3RTMwOCwidGhyZWUiOm51bGwsImZpcnN0IjoxMi4zNH19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfTypeString() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", "test");
+        map.put("two", "name");
+        map.put("three", null);
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7InR3byI6Im5hbWUiLCJ0aHJlZSI6bnVsbCwiZmlyc3QiOiJ0ZXN0In19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfTypeDate() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", new Date(1478891521000L));
+        map.put("two", null);
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7InR3byI6bnVsbCwiZmlyc3QiOjE0Nzg4OTE1MjEwMDB9fQ"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfTypeBoolean() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", true);
+        map.put("two", false);
+        map.put("three", null);
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7InR3byI6ZmFsc2UsInRocmVlIjpudWxsLCJmaXJzdCI6dHJ1ZX19"));
+    }
+
+    @Test
+    public void shouldAcceptCustomMapClaimOfArrayType() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", new Integer[] { 1, 2, 3 });
+        map.put("two", new Long[] { 4L, 5L, 6L });
+        map.put("three", new String[] { "1", "2", "3" });
+
+        String jwt = JWTCreator.init().withClaim("name", map).sign(Algorithm.HMAC256("secret"));
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjp7InR3byI6WzQsNSw2XSwidGhyZWUiOlsiMSIsIjIiLCIzIl0sImZpcnN0IjpbMSwyLDNdfX0"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAcceptCustomMapClaimOfTypeCollection() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", Arrays.asList(new Integer[] { 1, 2, 3 }));
+        map.put("two", new Integer[] { 2, 3, 4 });
+
+        JWTCreator.init().withClaim("name", map);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAcceptWhenNonSerializedCustomClassIsUsed() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("first", new JWTCreatorTest());
+
+        JWTCreator.init().withClaim("name", map);
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -15,10 +15,15 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+@SuppressWarnings("unchecked")
 public class JWTDecoderTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -289,7 +294,176 @@ public class JWTDecoderTest {
         assertThat(jwt.getClaims().get("extraClaim"), is(notNullValue()));
     }
 
-    //Helper Methods
+    @Test
+    public void shouldGetMapOfListIntegerClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6WzIsMyw0XSwiZmlyc3QiOlsxLDIsM119fQ.25extEOljDo2RDMGI1C9s8dy-0OYcSbf__rCX-7O8ig";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat((List<Integer>) map.get("first"), contains(1, 2, 3));
+        Assert.assertThat((List<Integer>) map.get("two"), contains(2, 3, 4));
+    }
+
+    @Test
+    public void shouldGetMapOfBooleanClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6ZmFsc2UsInRocmVlIjpudWxsLCJmaXJzdCI6dHJ1ZX19.1tXW692Iq-7OVj1248_vKCvpoR6K_6dHcfH-K9OWg7s";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertTrue((Boolean) map.get("first"));
+        Assert.assertFalse((Boolean) map.get("two"));
+    }
+
+    @Test
+    public void shouldGetMapOfDateClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6bnVsbCwiZmlyc3QiOjE0Nzg4OTE1MjEwMDB9fQ.xckuzg5t5zheqoWhQD5hStMmYE1pgbtv7fDj_v-shqw";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Date date = new Date(1478891521000L);
+        Assert.assertThat(map.get("first"), is(date.getTime()));
+    }
+
+    @Test
+    public void shouldGetMapOfStringClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6Im5hbWUiLCJ0aHJlZSI6bnVsbCwiZmlyc3QiOiJ0ZXN0In19.vfTKLWeuC3yOeh6olaBjcj4bPoVo9huW-NERdak1A5Q";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat(map.get("first"), is("test"));
+        Assert.assertThat(map.get("two"), is("name"));
+    }
+
+    @Test
+    public void shouldGetMapOfDoubleClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6MS43OTc2OTMxMzQ4NjIzMTU3RTMwOCwidGhyZWUiOm51bGwsImZpcnN0IjoxMi4zNH19.Q7xT-5kca5tB9VrmyLU7P9-Ezjt1TEEFGrZnd46u3A4";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat(map.get("first"), is(12.34));
+        Assert.assertThat(map.get("two"), is(Double.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldGetMapOfIntegerClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6MjE0NzQ4MzY0NywidGhyZWUiOm51bGwsImZpcnN0IjoxfX0.9a6g-D1nYSDeDb9vW6cLYW4tUgHh4S2JE07E26pcMeE";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat(map.get("first"), is(1));
+        Assert.assertThat(map.get("two"), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldGetMapOfLongClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6OTIyMzM3MjAzNjg1NDc3NTgwNywidGhyZWUiOm51bGwsImZpcnN0IjoxfX0.SWbYSAdyczKPQS_lMSNThNZDINd7MXygnpEKnGD6e9I";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat(map.get("first"), is(1));
+        Assert.assertThat(map.get("two"), is(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfBooleanType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbdHJ1ZSxmYWxzZV19.qhhvteWitJkKbLWBvIyVTSEPQyg0zYxvdbqAG_BxPwE";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Collection<Object> collection = jwt.getClaim("name").as(ArrayList.class);
+        Assert.assertThat(collection, contains(true, false));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfIntegerType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyXX0.7UnsF12puwoNHdzSbGkKqtx_KEW33kqWZxBHlIT8vFA";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Collection<Object> collection = jwt.getClaim("name").as(ArrayList.class);
+        Assert.assertThat(collection, contains(1, 2));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfLongType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyXX0.7UnsF12puwoNHdzSbGkKqtx_KEW33kqWZxBHlIT8vFA";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Collection<Object> collection = jwt.getClaim("name").as(ArrayList.class);
+        Assert.assertThat(collection, contains(1, 2));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfStringType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbIjEiLCIyIl19.bLhvAR2OqHu9IAKG0ABgY63noD9ItlBWWJ3ZNjby8BI";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Collection<Object> collection = jwt.getClaim("name").as(ArrayList.class);
+        Assert.assertThat(collection, contains("1", "2"));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfDoubleType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMS4yLDMuNF19.pxiRelpYpibcJY-rFisSTbfr-QiIEVS5hTmDXlLdTsM";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Collection<Object> collection = jwt.getClaim("name").as(ArrayList.class);
+        Assert.assertThat(collection, contains(1.2, 3.4));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfDateType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMTIzNDU2LDc4OTAxMjNdfQ.pqp27qUJQkM5QwZyMCyHxJOEQ47kZisrquLlHIc2SYg";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Collection<Long> collection = jwt.getClaim("name").asList(Long.class);
+        Date date1 = new Date(123456L);
+        Date date2 = new Date(7890123L);
+
+        Assert.assertTrue(collection.containsAll(Arrays.asList(date1.getTime(), date2.getTime())));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfIntegerArrayType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbWzEsMl1dfQ.ZYBv7vFg71YsD1Sq_QWcvEABUTYfMvba7fl1pO3TaS8";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        List<Object> collection = jwt.getClaim("name").asList(Object.class);
+        List<Object> expected = (ArrayList<Object>) collection.get(0);
+
+        Assert.assertTrue(expected.containsAll(Arrays.asList(1, 2)));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfLongArrayType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbWzMsNF1dfQ.eN4lyqCSFT9TbpC7j6x4ZsLUPYAUOHGvoRHahjjpvJE";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        List<Object> collection = jwt.getClaim("name").asList(Object.class);
+        List<Object> expected = (ArrayList<Object>) collection.get(0);
+
+        Assert.assertTrue(expected.containsAll(Arrays.asList(3, 4)));
+    }
+
+    @Test
+    public void shouldGetCustomCollectionClaimOfStringArrayType() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbWyI1IiwiNiJdXX0.5XhPlStgVHMhnqYuJ2WWnbZclTMXJbU1Npy1A5tWkT4";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        List<Object> collection = jwt.getClaim("name").asList(Object.class);
+        List<Object> expected = (ArrayList<Object>) collection.get(0);
+
+        Assert.assertTrue(expected.containsAll(Arrays.asList("5", "6")));
+    }
+
+    @Test
+    public void shouldGetMapOfArrayClaimValue() throws Exception {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InR3byI6WzQsNSw2XSwidGhyZWUiOlsiMSIsIjIiLCIzIl0sImZpcnN0IjpbMSwyLDNdfX0.mhQ6n5tgcjAsNfpn8Ye8Bxq4EmP4CIYy2SYrHiCa-UU";
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Map<String, Object> map = jwt.getClaim("name").asMap();
+        Assert.assertThat((List<Integer>) map.get("first"), contains(1, 2, 3));
+        Assert.assertThat((List<Long>) map.get("two"), contains(4, 5, 6));
+        Assert.assertThat((List<String>) map.get("three"), contains("1", "2", "3"));
+    }
 
     private DecodedJWT customJWT(String jsonHeader, String jsonPayload, String signature) {
         String header = Base64.encodeBase64URLSafeString(jsonHeader.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
…payload

As requested @gustavoamigo we are giving support to add objects if primitive and collection types as claim in token payload.

Followed the suggestion by @lbalmaceda to make this change.
#164 (comment)

This PR is in continution to the old PR #289 which was accidentally closed. Please continue the review, thank you.