### PR TITLE
Fixing JwtCreator builder when setting headers as a map

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -67,14 +67,15 @@ public final class JWTCreator {
         /**
          * Add specific Claims to set as the Header.
          * If provided map is null then nothing is changed
-         * If provided map contains a header with null value then that header will be removed from the header claims
+         * If provided map contains a claim with null value then that claim will be removed from the header
          *
          * @param headerClaims the values to use as Claims in the token's Header.
          * @return this same Builder instance.
          */
         public Builder withHeader(Map<String, Object> headerClaims) {
-            if (headerClaims == null)
+            if (headerClaims == null) {
                 return this;
+            }
 
             for (Map.Entry<String, Object> entry : headerClaims.entrySet()) {
                 if (entry.getValue() == null) {

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -66,12 +66,24 @@ public final class JWTCreator {
 
         /**
          * Add specific Claims to set as the Header.
+         * If provided map is null then nothing
+         * If provided map contains a header with null value then that header will be removed from the header claims
          *
          * @param headerClaims the values to use as Claims in the token's Header.
          * @return this same Builder instance.
          */
         public Builder withHeader(Map<String, Object> headerClaims) {
-            this.headerClaims.putAll(headerClaims);
+            if (headerClaims == null)
+                return this;
+
+            for (Map.Entry<String, Object> entry : headerClaims.entrySet()) {
+                if (entry.getValue() == null) {
+                    this.headerClaims.remove(entry.getKey());
+                } else {
+                    this.headerClaims.put(entry.getKey(), entry.getValue());
+                }
+            }
+
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -66,7 +66,7 @@ public final class JWTCreator {
 
         /**
          * Add specific Claims to set as the Header.
-         * If provided map is null then nothing
+         * If provided map is null then nothing is changed
          * If provided map contains a header with null value then that header will be removed from the header claims
          *
          * @param headerClaims the values to use as Claims in the token's Header.

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -71,7 +71,7 @@ public final class JWTCreator {
          * @return this same Builder instance.
          */
         public Builder withHeader(Map<String, Object> headerClaims) {
-            this.headerClaims = new HashMap<>(headerClaims);
+            this.headerClaims.putAll(headerClaims);
             return this;
         }
 

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -64,7 +64,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldOverwriteExistingIfHeadersMapContainsTheSameKey() throws Exception {
+    public void shouldOverwriteExistingHeaderIfHeaderMapContainsTheSameKey() throws Exception {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put(PublicClaims.KEY_ID, "xyz");
 

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.apache.commons.codec.binary.Base64;
@@ -65,34 +66,50 @@ public class JWTCreatorTest {
     @Test
     public void shouldOverwriteExistingIfHeadersMapContainsTheSameKey() throws Exception {
         Map<String, Object> header = new HashMap<String, Object>();
-        header.put("test", 456);
+        header.put(PublicClaims.KEY_ID, "xyz");
 
         String signed = JWTCreator.init()
-                                  .withClaim("test", 123)
+                                  .withKeyId("abc")
                                   .withHeader(header)
                                   .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
         String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
-        assertThat(headerJson, JsonMatcher.hasEntry("test", 456));
+        assertThat(headerJson, JsonMatcher.hasEntry(PublicClaims.KEY_ID, "xyz"));
+    }
+
+    @Test
+    public void shouldOverwriteExistingHeadersWhenSettingSameHeaderKey() throws Exception {
+        Map<String, Object> header = new HashMap<String, Object>();
+        header.put(PublicClaims.KEY_ID, "xyz");
+
+        String signed = JWTCreator.init()
+                                  .withHeader(header)
+                                  .withKeyId("abc")
+                                  .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        assertThat(headerJson, JsonMatcher.hasEntry(PublicClaims.KEY_ID, "abc"));
     }
 
     @Test
     public void shouldRemoveHeaderIfTheValueIsNull() throws Exception {
         Map<String, Object> header = new HashMap<String, Object>();
-        header.put("test", null);
+        header.put(PublicClaims.KEY_ID, null);
         header.put("test2", "isSet");
 
         String signed = JWTCreator.init()
-                                  .withClaim("test", 123)
+                                  .withKeyId("test")
                                   .withHeader(header)
                                   .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
         String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
-        assertThat(headerJson, JsonMatcher.hasEntry("test", null));
+        assertThat(headerJson, JsonMatcher.isNotPresent(PublicClaims.KEY_ID));
         assertThat(headerJson, JsonMatcher.hasEntry("test2", "isSet"));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -54,6 +54,49 @@ public class JWTCreatorTest {
     }
 
     @Test
+    public void shouldReturnBuilderIfNullMapIsProvided() throws Exception {
+        String signed = JWTCreator.init()
+                                  .withHeader(null)
+                                  .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldOverwriteExistingIfHeadersMapContainsTheSameKey() throws Exception {
+        Map<String, Object> header = new HashMap<String, Object>();
+        header.put("test", 456);
+
+        String signed = JWTCreator.init()
+                                  .withClaim("test", 123)
+                                  .withHeader(header)
+                                  .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        assertThat(headerJson, JsonMatcher.hasEntry("test", 456));
+    }
+
+    @Test
+    public void shouldRemoveHeaderIfTheValueIsNull() throws Exception {
+        Map<String, Object> header = new HashMap<String, Object>();
+        header.put("test", null);
+        header.put("test2", "isSet");
+
+        String signed = JWTCreator.init()
+                                  .withClaim("test", 123)
+                                  .withHeader(header)
+                                  .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        assertThat(headerJson, JsonMatcher.hasEntry("test", null));
+        assertThat(headerJson, JsonMatcher.hasEntry("test2", "isSet"));
+    }
+
+    @Test
     public void shouldAddKeyId() throws Exception {
         String signed = JWTCreator.init()
                 .withKeyId("56a8bd44da435300010000015f5ed")

--- a/lib/src/test/java/com/auth0/jwt/JsonMatcher.java
+++ b/lib/src/test/java/com/auth0/jwt/JsonMatcher.java
@@ -68,6 +68,10 @@ public class JsonMatcher extends TypeSafeDiagnosingMatcher<String> {
         return new JsonMatcher(key, null, valueMatcher);
     }
 
+    public static JsonMatcher isNotPresent(String key) {
+        return new JsonMatcher(key, null, null);
+    }
+
     private String getStringKey(String key) {
         return "\"" + key + "\":";
     }


### PR DESCRIPTION
currently when using JwtCreator when setting headers as a map it is overwriting existing headers map, which forces to use `withHeader(Map<String, Object> headerClaims)` first then any other headers.

e.g.
1. the key id is missing if I do `JWT.create().withKeyId(ID).withHeader(map)`
2. the key id is not missing if I do `JWT.create().withHeader(map).withKeyId(ID)`