### PR TITLE
Fix issue #344 - handle null better for varargs in claims.

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -66,7 +66,8 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
          */
         @Override
         public Verification withIssuer(String... issuer) {
-            requireClaim(PublicClaims.ISSUER, issuer == null ? null : Arrays.asList(issuer));
+            List<String> claims = toValidClaims(issuer);
+            requireClaim(PublicClaims.ISSUER, claims);
             return this;
         }
 
@@ -90,7 +91,8 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
          */
         @Override
         public Verification withAudience(String... audience) {
-            requireClaim(PublicClaims.AUDIENCE, audience == null ? null : Arrays.asList(audience));
+            List<String> claims = toValidClaims(audience);
+            requireClaim(PublicClaims.AUDIENCE, claims);
             return this;
         }
 
@@ -342,6 +344,25 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             if (!claims.containsKey(PublicClaims.ISSUED_AT)) {
                 claims.put(PublicClaims.ISSUED_AT, defaultLeeway);
             }
+        }
+
+        private static List<String> toValidClaims(String ... claims) {
+            if (claims == null) {
+                return null;
+            }
+
+            List<String> validClaims = new ArrayList<>(claims.length);
+            for (String claim : claims) {
+                if (claim != null) {
+                    validClaims.add(claim);
+                }
+            }
+
+            if (validClaims.isEmpty()) {
+                return null;
+            }
+
+            return validClaims;
         }
 
         private void requireClaim(String name, Object value) {

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -6,12 +6,14 @@ import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.Verification;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
@@ -151,15 +153,39 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldRemoveAudienceWhenPassingNull() throws Exception {
+    public void shouldRemoveAudienceWhenPassingNullArray() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
         JWTVerifier verifier = JWTVerifier.init(algorithm)
                 .withAudience("John")
-                .withAudience(null)
+                .withAudience((String[]) null)
                 .build();
 
         assertThat(verifier.claims, is(notNullValue()));
         assertThat(verifier.claims, not(hasKey("aud")));
+    }
+
+    @Test
+    public void shouldRemoveAudienceWhenPassingNullString() {
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withAudience("John")
+                .withAudience((String) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
+    }
+
+    @Test
+    public void shouldRemoveNullValueFromAudience() {
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withAudience("John", null, "James")
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat((List<String>) verifier.claims.get("aud"), contains("John", "James"));
+        assertThat((List<String>) verifier.claims.get("aud"), not(contains(nullValue())));
     }
 
     @Test
@@ -615,15 +641,39 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldRemoveClaimWhenPassingNull() throws Exception {
+    public void shouldRemoveIssuerWhenPassingNullArray() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
         JWTVerifier verifier = JWTVerifier.init(algorithm)
                 .withIssuer("iss")
-                .withIssuer(null)
+                .withIssuer((String[]) null)
                 .build();
 
         assertThat(verifier.claims, is(notNullValue()));
         assertThat(verifier.claims, not(hasKey("iss")));
+    }
+
+    @Test
+    public void shouldRemoveIssuerWhenPassingNullString() {
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withIssuer("theIssuer")
+                .withIssuer((String) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+    }
+
+    @Test
+    public void shouldRemoveNullValueFromIssuers() {
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withIssuer("theIssuer", null, "otherIssuer")
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat((List<String>) verifier.claims.get("iss"), contains("theIssuer", "otherIssuer"));
+        assertThat((List<String>) verifier.claims.get("iss"), not(contains(nullValue())));
     }
 
     @Test


### PR DESCRIPTION
### Changes

Removed ambiguity of vararg parameters for `JWTVerifier` audience and issuer claims.  Passing a `null` `String[]` and a `null` `String` now have the same effect.

Fixed warnings on test - warning of exactly this ambiguity, and added extra tests which demonstrate the issue.

If multiple issuer or audience values are now passed, and nulls are included, these are excluded from the claim object, as they cannot ever succeed in verification.

### References

This resolves https://github.com/auth0/java-jwt/issues/344

### Testing

New unit tests added.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
