### PR TITLE
Add custom provider support for PKCS11.

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -6,7 +6,9 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 
-import java.io.ByteArrayOutputStream;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
 import java.security.interfaces.*;
 
 /**
@@ -38,7 +40,20 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if both provided Keys are null.
      */
     public static Algorithm RSA256(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return RSA256(RSAAlgorithm.providerForKeys(publicKey, privateKey));
+        return RSA256(RSAAlgorithm.providerForKeys(publicKey, privateKey, null));
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withRSA. Tokens specify this as "RS256".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @param securityProvider the Security Provider to use in the signing.
+     * @return a valid RSA256 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA256(PublicKey publicKey, PrivateKey privateKey, Provider securityProvider) throws IllegalArgumentException {
+        return RSA256(RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider));
     }
 
     /**
@@ -76,7 +91,20 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if both provided Keys are null.
      */
     public static Algorithm RSA384(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return RSA384(RSAAlgorithm.providerForKeys(publicKey, privateKey));
+        return RSA384(RSAAlgorithm.providerForKeys(publicKey, privateKey, null));
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withRSA. Tokens specify this as "RS384".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @param securityProvider the Security Provider to use in the signing.
+     * @return a valid RSA384 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA384(RSAPublicKey publicKey, RSAPrivateKey privateKey, Provider securityProvider) throws IllegalArgumentException {
+        return RSA384(RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider));
     }
 
     /**
@@ -114,7 +142,20 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if both provided Keys are null.
      */
     public static Algorithm RSA512(RSAPublicKey publicKey, RSAPrivateKey privateKey) throws IllegalArgumentException {
-        return RSA512(RSAAlgorithm.providerForKeys(publicKey, privateKey));
+        return RSA512(RSAAlgorithm.providerForKeys(publicKey, privateKey, null));
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA512withRSA. Tokens specify this as "RS512".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @param securityProvider the Security Provider to use in the signing.
+     * @return a valid RSA512 Algorithm.
+     * @throws IllegalArgumentException if both provided Keys are null.
+     */
+    public static Algorithm RSA512(RSAPublicKey publicKey, RSAPrivateKey privateKey, Provider securityProvider) throws IllegalArgumentException {
+        return RSA512(RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider));
     }
 
     /**
@@ -218,7 +259,20 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if the provided Key is null.
      */
     public static Algorithm ECDSA256(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return ECDSA256(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
+        return ECDSA256(ECDSAAlgorithm.providerForKeys(publicKey, privateKey, null));
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA256withECDSA. Tokens specify this as "ES256".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @param securityProvider the Security Provider to use in the signing.
+     * @return a valid ECDSA256 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA256(PublicKey publicKey, PrivateKey privateKey, Provider securityProvider) throws IllegalArgumentException {
+        return ECDSA256(ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider));
     }
 
     /**
@@ -256,7 +310,20 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if the provided Key is null.
      */
     public static Algorithm ECDSA384(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return ECDSA384(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
+        return ECDSA384(ECDSAAlgorithm.providerForKeys(publicKey, privateKey, null));
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA384withECDSA. Tokens specify this as "ES384".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @param securityProvider the Security Provider to use in the signing.
+     * @return a valid ECDSA384 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA384(PublicKey publicKey, PrivateKey privateKey, Provider securityProvider) throws IllegalArgumentException {
+        return ECDSA384(ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider));
     }
 
     /**
@@ -294,7 +361,20 @@ public abstract class Algorithm {
      * @throws IllegalArgumentException if the provided Key is null.
      */
     public static Algorithm ECDSA512(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
-        return ECDSA512(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
+        return ECDSA512(ECDSAAlgorithm.providerForKeys(publicKey, privateKey, null));
+    }
+
+    /**
+     * Creates a new Algorithm instance using SHA512withECDSA. Tokens specify this as "ES512".
+     *
+     * @param publicKey  the key to use in the verify instance.
+     * @param privateKey the key to use in the signing instance.
+     * @param securityProvider the Security Provider to use in the signing.
+     * @return a valid ECDSA512 Algorithm.
+     * @throws IllegalArgumentException if the provided Key is null.
+     */
+    public static Algorithm ECDSA512(ECPublicKey publicKey, ECPrivateKey privateKey, Provider securityProvider) throws IllegalArgumentException {
+        return ECDSA512(ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider));
     }
 
     /**
@@ -311,7 +391,6 @@ public abstract class Algorithm {
         ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
         return ECDSA512(publicKey, privateKey);
     }
-
 
     public static Algorithm none() {
         return new NoneAlgorithm();

--- a/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
@@ -108,6 +108,7 @@ class CryptoHelper {
      *
      * @param algorithm algorithm name.
      * @param privateKey the private key to use for signing.
+     * @param securityProvider the security provider to use for signing.
      * @param headerBytes JWT header.
      * @param payloadBytes JWT payload.
      * @return the signature bytes.
@@ -116,8 +117,12 @@ class CryptoHelper {
      * @throws SignatureException if this signature object is not initialized properly or if this signature algorithm is unable to process the input data provided.
      */
 
-    byte[] createSignatureFor(String algorithm, PrivateKey privateKey, byte[] headerBytes, byte[] payloadBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        final Signature s = Signature.getInstance(algorithm);
+    byte[] createSignatureFor(String algorithm, PrivateKey privateKey, Provider securityProvider, byte[] headerBytes, byte[] payloadBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        final Signature s;
+        if(securityProvider == null)
+            s = Signature.getInstance(algorithm);
+        else
+            s = Signature.getInstance(algorithm, securityProvider);
         s.initSign(privateKey);
         s.update(headerBytes);
         s.update(JWT_PART_SEPARATOR);
@@ -189,6 +194,7 @@ class CryptoHelper {
      *
      * @param algorithm algorithm name.
      * @param privateKey the private key to use for signing.
+     * @param securityProvider the security provider to use for signing.
      * @param contentBytes the content to be signed.
      * @return the signature bytes.
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
@@ -198,8 +204,12 @@ class CryptoHelper {
      */
 
     @Deprecated
-    byte[] createSignatureFor(String algorithm, PrivateKey privateKey, byte[] contentBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        final Signature s = Signature.getInstance(algorithm);
+    byte[] createSignatureFor(String algorithm, PrivateKey privateKey, Provider securityProvider, byte[] contentBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        final Signature s;
+        if(securityProvider == null)
+            s = Signature.getInstance(algorithm);
+        else
+            s = Signature.getInstance(algorithm, securityProvider);
         s.initSign(privateKey);
         s.update(contentBytes);
         return s.sign();

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -3,7 +3,6 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.auth0.jwt.interfaces.AsymKeyProvider;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import org.apache.commons.codec.binary.Base64;
 
@@ -11,12 +10,12 @@ import java.security.*;
 
 class ECDSAAlgorithm extends Algorithm {
 
-    private final AsymKeyProvider keyProvider;
+    private final ECDSAKeyProvider keyProvider;
     private final CryptoHelper crypto;
     private final int ecNumberSize;
 
     //Visible for testing
-    ECDSAAlgorithm(CryptoHelper crypto, String id, String algorithm, int ecNumberSize, AsymKeyProvider keyProvider) throws IllegalArgumentException {
+    ECDSAAlgorithm(CryptoHelper crypto, String id, String algorithm, int ecNumberSize, ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
         super(id, algorithm);
         if (keyProvider == null) {
             throw new IllegalArgumentException("The Key Provider cannot be null.");
@@ -26,7 +25,7 @@ class ECDSAAlgorithm extends Algorithm {
         this.ecNumberSize = ecNumberSize;
     }
 
-    ECDSAAlgorithm(String id, String algorithm, int ecNumberSize, AsymKeyProvider keyProvider) throws IllegalArgumentException {
+    ECDSAAlgorithm(String id, String algorithm, int ecNumberSize, ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, ecNumberSize, keyProvider);
     }
 

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -3,8 +3,6 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.auth0.jwt.interfaces.AsymKeyProvider;
-import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.apache.commons.codec.binary.Base64;
 
@@ -12,11 +10,11 @@ import java.security.*;
 
 class RSAAlgorithm extends Algorithm {
 
-    private final AsymKeyProvider keyProvider;
+    private final RSAKeyProvider keyProvider;
     private final CryptoHelper crypto;
 
     //Visible for testing
-    RSAAlgorithm(CryptoHelper crypto, String id, String algorithm, AsymKeyProvider keyProvider) throws IllegalArgumentException {
+    RSAAlgorithm(CryptoHelper crypto, String id, String algorithm, RSAKeyProvider keyProvider) throws IllegalArgumentException {
         super(id, algorithm);
         if (keyProvider == null) {
             throw new IllegalArgumentException("The Key Provider cannot be null.");
@@ -25,7 +23,7 @@ class RSAAlgorithm extends Algorithm {
         this.crypto = crypto;
     }
 
-    RSAAlgorithm(String id, String algorithm, AsymKeyProvider keyProvider) throws IllegalArgumentException {
+    RSAAlgorithm(String id, String algorithm, RSAKeyProvider keyProvider) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, keyProvider);
     }
 

--- a/lib/src/main/java/com/auth0/jwt/interfaces/ECDSAKeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/ECDSAKeyProvider.java
@@ -1,10 +1,10 @@
 package com.auth0.jwt.interfaces;
 
-import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.ECPublicKey;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 
 /**
  * Elliptic Curve (EC) Public/Private Key provider.
  */
-public interface ECDSAKeyProvider extends KeyProvider<ECPublicKey, ECPrivateKey> {
+public interface ECDSAKeyProvider extends KeyProvider<PublicKey, PrivateKey> {
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt.interfaces;
 
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 
 /**
@@ -32,4 +33,11 @@ interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
      * @return the Key Id that identifies the Private Key or null if it's not specified.
      */
     String getPrivateKeyId();
+
+    /**
+     * Getter for the Security Provider instance. Used to use Private Key. It is essential on the PKCS11 Private Key.
+     *
+     * @return the Security Provider instance or null if it's not specified.
+     */
+    Provider getSecurityProvider();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/RSAKeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/RSAKeyProvider.java
@@ -1,10 +1,10 @@
 package com.auth0.jwt.interfaces;
 
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 
 /**
  * RSA Public/Private Key provider.
  */
-public interface RSAKeyProvider extends KeyProvider<RSAPublicKey, RSAPrivateKey> {
+public interface RSAKeyProvider extends KeyProvider<PublicKey, PrivateKey> {
 }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -3,6 +3,7 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 
 import org.apache.commons.codec.binary.Base64;
@@ -12,18 +13,21 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import sun.security.pkcs11.SunPKCS11;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.Arrays;
 
 
-import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
-import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
+import static com.auth0.jwt.PemUtils.*;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.asJWT;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignaturePresent;
 import static org.hamcrest.CoreMatchers.is;
@@ -40,14 +44,17 @@ public class ECDSAAlgorithmTest {
 
     private static final String PRIVATE_KEY_FILE_256 = "src/test/resources/ec256-key-private.pem";
     private static final String PUBLIC_KEY_FILE_256 = "src/test/resources/ec256-key-public.pem";
+    private static final String CERTIFICATE_FILE_256 = "src/test/resources/ec256-certificate.pem";
     private static final String INVALID_PUBLIC_KEY_FILE_256 = "src/test/resources/ec256-key-public-invalid.pem";
 
     private static final String PRIVATE_KEY_FILE_384 = "src/test/resources/ec384-key-private.pem";
     private static final String PUBLIC_KEY_FILE_384 = "src/test/resources/ec384-key-public.pem";
+    private static final String CERTIFICATE_FILE_384 = "src/test/resources/ec384-certificate.pem";
     private static final String INVALID_PUBLIC_KEY_FILE_384 = "src/test/resources/ec384-key-public-invalid.pem";
 
     private static final String PRIVATE_KEY_FILE_512 = "src/test/resources/ec512-key-private.pem";
     private static final String PUBLIC_KEY_FILE_512 = "src/test/resources/ec512-key-public.pem";
+    private static final String CERTIFICATE_FILE_512 = "src/test/resources/ec512-certificate.pem";
     private static final String INVALID_PUBLIC_KEY_FILE_512 = "src/test/resources/ec512-key-public-invalid.pem";
 
     @Rule
@@ -706,12 +713,13 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256HeaderBytes, new byte[0]);
     }
@@ -723,12 +731,13 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256HeaderBytes, new byte[0]);
     }
@@ -740,12 +749,13 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(isA(SignatureException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256HeaderBytes, new byte[0]);
     }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
@@ -709,12 +709,13 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8), new byte[0]);
     }
@@ -726,12 +727,13 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8), new byte[0]);
     }
@@ -743,12 +745,13 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
         algorithm.sign(ES256Header.getBytes(StandardCharsets.UTF_8), new byte[0]);
     }
@@ -757,7 +760,8 @@ public class ECDSABouncyCastleProviderTests {
     public void shouldReturnNullSigningKeyIdIfCreatedWithDefaultProvider() throws Exception {
         ECPublicKey publicKey = mock(ECPublicKey.class);
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
-        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new ECDSAAlgorithm("some-alg", "some-algorithm", 32, provider);
 
         assertThat(algorithm.getSigningKeyId(), is(nullValue()));

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -220,7 +220,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         algorithm.verify(JWT.decode(jwt));
@@ -238,7 +239,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         algorithm.verify(JWT.decode(jwt));
@@ -256,7 +258,8 @@ public class RSAAlgorithmTest {
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNuLAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
         algorithm.verify(JWT.decode(jwt));
@@ -468,12 +471,13 @@ public class RSAAlgorithmTest {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -485,12 +489,13 @@ public class RSAAlgorithmTest {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -502,12 +507,13 @@ public class RSAAlgorithmTest {
         exception.expectCause(isA(SignatureException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(Provider.class), any(byte[].class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm(crypto, "some-alg", "some-algorithm", provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -516,7 +522,8 @@ public class RSAAlgorithmTest {
     public void shouldReturnNullSigningKeyIdIfCreatedWithDefaultProvider() throws Exception {
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
         RSAPrivateKey privateKey = mock(RSAPrivateKey.class);
-        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
+        Provider securityProvider = mock(Provider.class);
+        RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey, securityProvider);
         Algorithm algorithm = new RSAAlgorithm("some-alg", "some-algorithm", provider);
 
         assertThat(algorithm.getSigningKeyId(), is(nullValue()));


### PR DESCRIPTION
In the past, only the default JCE Provider can be used, and ECPrivateKey, ECPublicKey, RSAPrivateKey, and RSAPublicKey types can not be used for PKCS11 support.

The following changes have been made to support PKCS11.
* Added getSecurityProvider method to KeyProvider. (Used in Signature.getInstance for sign)
* Use PublicKey, PrivateKey type instead of ECKey or RSAKey.