### PR TITLE
Fix: updated jackson-databind to 2.10.0.pr3 to block CVE

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,7 +34,7 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0.pr3'
     implementation 'commons-codec:commons-codec:1.12'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
### Changes

Version bump for jackson-databind dependency to 2.10.0.pr3

### References

https://github.com/auth0/java-jwt/issues/355