### PR TITLE
Automatic module name property in manifest

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -56,3 +56,13 @@ test {
         exceptionFormat "short"
     }
 }
+
+ext.moduleName = "com.auth0.jwt"
+
+jar {
+    inputs.property("moduleName", moduleName)
+
+    manifest {
+       attributes  'Automatic-Module-Name': moduleName
+   }
+}


### PR DESCRIPTION
### Changes

Add a manifest entry for automatic module name as a small improvement for use with modules and JDK9+. Or better yet, use a plugin to create a release compatible with both 8 and 9+, for example a multi-release jar.

### References

http://branchandbound.net/blog/java/2017/12/automatic-module-name/

### Testing

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

Manually inspected resulting jar.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
