### PR TITLE
Update CHANGELOG for breaking changes in 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,15 @@
 ## [3.4.0](https://github.com/auth0/java-jwt/tree/3.4.0) (2018-06-13)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/3.3.0...3.4.0)
 
+**Breaking Changes**
+- Fix for [\#236](https://github.com/auth0/java-jwt/pull/236) - refactored HMACAlgorithm so that it doesn't throw an UnsupportedEncodingException [\#242](https://github.com/auth0/java-jwt/pull/242) ([obecker](https://github.com/obecker)). 
+
+Clients using the following methods may need to update their code to not catch an `UnsupportedEncodingException`:
+- `public static Algorithm HMAC384(String secret)`
+- `public static Algorithm HMAC256(String secret)`
+- `public static Algorithm HMAC512(String secret)`
+
 **Changed**
-- Fix for issue #236 - refactored HMACAlgorithm so that it doesn't throw an UnsupportedEncodingException [\#242](https://github.com/auth0/java-jwt/pull/242) ([obecker](https://github.com/obecker))
 - Throw JWTDecodeException when date claim format is invalid [\#241](https://github.com/auth0/java-jwt/pull/241) ([lbalmaceda](https://github.com/lbalmaceda))
 
 **Security**


### PR DESCRIPTION
### Changes

Closes #376 

Clients catching an `UnsupportedEncodingException` when using a HMAC algorithm will have compile failures when migrating to 3.4.0 or later. 

Since we cannot revert that change without breaking others, this PR updates the `CHANGELOG.md` to explicitly call out the breaking change introduced in version 3.4.0.

### References

#376 

### Testing

Documentation-only change. No test impact.
- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
