### PR TITLE
Key reader gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ RSAPrivateKey privateKey = //Get the key instance
 Algorithm algorithmRS = Algorithm.RSA256(publicKey, privateKey);
 ```
 
-> Note: How you obtain or read keys is not in the scope of this library. For an example of how you might implement this, you can see the example [here](https://gist.github.com/lbalmaceda/9a0c7890c2965826c04119dcfb1a5469).
+> Note: How you obtain or read keys is not in the scope of this library. For an example of how you might implement this, see [this gist](https://gist.github.com/lbalmaceda/9a0c7890c2965826c04119dcfb1a5469).
 
 #### Using a KeyProvider:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ RSAPrivateKey privateKey = //Get the key instance
 Algorithm algorithmRS = Algorithm.RSA256(publicKey, privateKey);
 ```
 
+> Note: How you obtain or read keys is not in the scope of this library. For an example of how you might implement this, you can see the example [here](https://gist.github.com/lbalmaceda/9a0c7890c2965826c04119dcfb1a5469).
+
 #### Using a KeyProvider:
 
 By using a `KeyProvider` you can change in runtime the key used either to verify the token signature or to sign a new token for RSA or ECDSA algorithms. This is achieved by implementing either `RSAKeyProvider` or `ECDSAKeyProvider` methods:
@@ -137,7 +139,6 @@ try {
 ```
 
 If a Claim couldn't be converted to JSON or the Key used in the signing process was invalid a `JWTCreationException` will raise.
-
 
 ### Verify a Token
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ try {
 
 If a Claim couldn't be converted to JSON or the Key used in the signing process was invalid a `JWTCreationException` will raise.
 
+
 ### Verify a Token
 
 You'll first need to create a `JWTVerifier` instance by calling `JWT.require()` and passing the `Algorithm` instance. If you require the token to have specific Claim values, use the builder to define them. The instance returned by the method `build()` is reusable, so you can define it once and use it to verify different tokens. Finally call `verifier.verify()` passing the token.


### PR DESCRIPTION
### Changes

Closes #374 

We've had requests to demonstrate how to obtain keys. While providing detailed docs or guidance for how to obtain keys is not in the scope of this library, since it's been a repeated request we can at least link to a gist we've used in the past to help. 

### References

See #374 and #214 

### Testing

Documentation-only change. No test impact.

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
