### PR TITLE
Allow to customize the typ header claim

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -316,7 +316,9 @@ public final class JWTCreator {
                 throw new IllegalArgumentException("The Algorithm cannot be null.");
             }
             headerClaims.put(PublicClaims.ALGORITHM, algorithm.getName());
-            headerClaims.put(PublicClaims.TYPE, "JWT");
+            if (!headerClaims.containsKey(PublicClaims.TYPE)) {
+                headerClaims.put(PublicClaims.TYPE, "JWT");
+            }
             String signingKeyId = algorithm.getSigningKeyId();
             if (signingKeyId != null) {
                 withKeyId(signingKeyId);

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -292,7 +293,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldSetCorrectTypeInTheHeader() throws Exception {
+    public void shouldSetDefaultTypeInTheHeader() throws Exception {
         String signed = JWTCreator.init()
                 .sign(Algorithm.HMAC256("secret"));
 
@@ -300,6 +301,19 @@ public class JWTCreatorTest {
         String[] parts = signed.split("\\.");
         String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
+    }
+
+    @Test
+    public void shouldSetCustomTypeInTheHeader() throws Exception {
+        Map<String, Object> header = Collections.singletonMap("typ", "passport");
+        String signed = JWTCreator.init()
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        assertThat(headerJson, JsonMatcher.hasEntry("typ", "passport"));
     }
 
     @Test


### PR DESCRIPTION
### Changes

This PR adds the ability to customize the `typ` header claim value. If a value is not provided, the default of `JWT` will be used.
### References

Will close https://github.com/auth0/java-jwt/issues/369

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
