### PR TITLE
Updated date time APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ JWTVerifier verifier = JWT.require(algorithm)
 DecodedJWT jwt = verifier.verify("my.jwt.token");
 ```
 
-> Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Instant and Arrays of type String and Integer.
+> Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Instant (for NumericDate) and Arrays of type String and Integer.
 
 
 ### Claim Class

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ JWTVerifier verifier = JWT.require(algorithm)
     .build();
 ```
 
-You can also specify a custom value for a given Date claim and override the default one for only that claim.
+You can also specify a custom value for a given DateNumber claim and override the default one for only that claim.
 
 ```java
 JWTVerifier verifier = JWT.require(algorithm)
@@ -319,7 +319,7 @@ List<String> audience = jwt.getAudience();
 Returns the Expiration Time value or null if it's not defined in the Payload.
 
 ```java
-Date expiresAt = jwt.getExpiresAt();
+Instant expiresAt = jwt.getExpiresAt();
 ```
 
 #### Not Before ("nbf")
@@ -327,7 +327,7 @@ Date expiresAt = jwt.getExpiresAt();
 Returns the Not Before value or null if it's not defined in the Payload.
 
 ```java
-Date notBefore = jwt.getNotBefore();
+Instant notBefore = jwt.getNotBefore();
 ```
 
 #### Issued At ("iat")
@@ -335,7 +335,7 @@ Date notBefore = jwt.getNotBefore();
 Returns the Issued At value or null if it's not defined in the Payload.
 
 ```java
-Date issuedAt = jwt.getIssuedAt();
+Instant issuedAt = jwt.getIssuedAt();
 ```
 
 #### JWT ID ("jti")
@@ -380,7 +380,7 @@ JWTVerifier verifier = JWT.require(algorithm)
 DecodedJWT jwt = verifier.verify("my.jwt.token");
 ```
 
-> Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Date and Arrays of type String and Integer.
+> Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Instant and Arrays of type String and Integer.
 
 
 ### Claim Class
@@ -392,7 +392,7 @@ The Claim class is a wrapper for the Claim values. It allows you to get the Clai
 * **asDouble()**: Returns the Double value or null if it can't be converted.
 * **asLong()**: Returns the Long value or null if it can't be converted.
 * **asString()**: Returns the String value or null if it can't be converted.
-* **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
+* **asInstant()**: Returns the Instant value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
 
 #### Custom Classes and Collections
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.

--- a/lib/src/main/java/com/auth0/jwt/ClockImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/ClockImpl.java
@@ -3,6 +3,7 @@ package com.auth0.jwt;
 import com.auth0.jwt.interfaces.Clock;
 
 import java.time.Instant;
+import java.util.Date;
 
 final class ClockImpl implements Clock {
 
@@ -11,7 +12,12 @@ final class ClockImpl implements Clock {
     }
 
     @Override
-    public Instant getToday() {
+    public Instant getNow() {
         return Instant.now();
+    }
+
+    @Override
+    public Date getToday() {
+        return new Date();
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/ClockImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/ClockImpl.java
@@ -2,7 +2,7 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.interfaces.Clock;
 
-import java.util.Date;
+import java.time.Instant;
 
 final class ClockImpl implements Clock {
 
@@ -11,7 +11,7 @@ final class ClockImpl implements Clock {
     }
 
     @Override
-    public Date getToday() {
-        return new Date();
+    public Instant getToday() {
+        return Instant.now();
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +140,7 @@ public final class JWTCreator {
          * @param expiresAt the Expires At value.
          * @return this same Builder instance.
          */
-        public Builder withExpiresAt(Date expiresAt) {
+        public Builder withExpiresAt(Instant expiresAt) {
             addClaim(PublicClaims.EXPIRES_AT, expiresAt);
             return this;
         }
@@ -151,7 +151,7 @@ public final class JWTCreator {
          * @param notBefore the Not Before value.
          * @return this same Builder instance.
          */
-        public Builder withNotBefore(Date notBefore) {
+        public Builder withNotBefore(Instant notBefore) {
             addClaim(PublicClaims.NOT_BEFORE, notBefore);
             return this;
         }
@@ -162,7 +162,7 @@ public final class JWTCreator {
          * @param issuedAt the Issued At value.
          * @return this same Builder instance.
          */
-        public Builder withIssuedAt(Date issuedAt) {
+        public Builder withIssuedAt(Instant issuedAt) {
             addClaim(PublicClaims.ISSUED_AT, issuedAt);
             return this;
         }
@@ -256,7 +256,7 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Date value) throws IllegalArgumentException {
+        public Builder withClaim(String name, Instant value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -14,6 +14,7 @@ import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +147,17 @@ public final class JWTCreator {
         }
 
         /**
+         * Add a specific Expires At ("exp") claim to the Payload.
+         *
+         * @param expiresAt the Expires At value.
+         * @return this same Builder instance.
+         */
+        // TODO - Deprecate this method in favor of withExpiresAtInstant
+        public Builder withExpiresAt(Date expiresAt) {
+            return withExpiresAt(expiresAt.toInstant());
+        }
+
+        /**
          * Add a specific Not Before ("nbf") claim to the Payload.
          *
          * @param notBefore the Not Before value.
@@ -157,6 +169,17 @@ public final class JWTCreator {
         }
 
         /**
+         * Add a specific Not Before ("nbf") claim to the Payload.
+         *
+         * @param notBefore the Not Before value.
+         * @return this same Builder instance.
+         */
+        // TODO - Deprecate this method in favor of withNotBeforeInstant
+        public Builder withNotBefore(Date notBefore) {
+            return withNotBefore(notBefore.toInstant());
+        }
+
+        /**
          * Add a specific Issued At ("iat") claim to the Payload.
          *
          * @param issuedAt the Issued At value.
@@ -165,6 +188,17 @@ public final class JWTCreator {
         public Builder withIssuedAt(Instant issuedAt) {
             addClaim(PublicClaims.ISSUED_AT, issuedAt);
             return this;
+        }
+
+        /**
+         * Add a specific Issued At ("iat") claim to the Payload.
+         *
+         * @param issuedAt the Issued At value.
+         * @return this same Builder instance.
+         */
+        // TODO - Deprecate this method in favor of withIssuedAtInstant
+        public Builder withIssuedAt(Date issuedAt) {
+            return withIssuedAt(issuedAt.toInstant());
         }
 
         /**
@@ -260,6 +294,19 @@ public final class JWTCreator {
             assertNonNull(name);
             addClaim(name, value);
             return this;
+        }
+
+        /**
+         * Add a custom Claim value.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
+        // TODO - Deprecate this method in favor of withClaim(String name, Instant value)
+        public Builder withClaim(String name, Date value) throws IllegalArgumentException {
+            return withClaim(name, value.toInstant());
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -356,7 +356,7 @@ public final class JWTCreator {
          * 
          * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
          * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
-         * {@linkplain String} and {@linkplain Instant}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain String}, {@linkplain Instant}, and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
          * {@linkplain List}s can contain null elements.
          *
          * @param name  the Claim's name.
@@ -379,7 +379,7 @@ public final class JWTCreator {
          *
          * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
          * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
-         * {@linkplain String} and {@linkplain Instant}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain String}, {@linkplain Instant}, and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
          * {@linkplain List}s can contain null elements.
          *
          * @param name  the Claim's name.
@@ -438,7 +438,7 @@ public final class JWTCreator {
             if(c.isArray()) {
                 return c == Integer[].class || c == Long[].class || c == String[].class;
             }
-            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Instant.class || c == Boolean.class;
+            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Instant.class || c == Boolean.class;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -309,7 +309,7 @@ public final class JWTCreator {
          * 
          * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
          * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
-         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain String} and {@linkplain Instant}. {@linkplain Map}s cannot contain null keys or values.
          * {@linkplain List}s can contain null elements.
          *
          * @param name  the Claim's name.
@@ -321,7 +321,7 @@ public final class JWTCreator {
             assertNonNull(name);
             // validate map contents
             if(!validateClaim(map)) {
-                throw new IllegalArgumentException("Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
+                throw new IllegalArgumentException("Expected map containing Map, List, Boolean, Integer, Long, Double, String and Instant");
             }
             addClaim(name, map);
             return this;
@@ -332,7 +332,7 @@ public final class JWTCreator {
          *
          * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
          * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
-         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain String} and {@linkplain Instant}. {@linkplain Map}s cannot contain null keys or values.
          * {@linkplain List}s can contain null elements.
          *
          * @param name  the Claim's name.
@@ -344,7 +344,7 @@ public final class JWTCreator {
             assertNonNull(name);
             // validate list contents
             if(!validateClaim(list)) {
-                throw new IllegalArgumentException("Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
+                throw new IllegalArgumentException("Expected list containing Map, List, Boolean, Integer, Long, Double, String and Instant");
             }
             addClaim(name, list);
             return this;
@@ -391,7 +391,7 @@ public final class JWTCreator {
             if(c.isArray()) {
                 return c == Integer[].class || c == Long[].class || c == String[].class;
             }
-            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Boolean.class;
+            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Instant.class || c == Boolean.class;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -11,6 +11,7 @@ import org.apache.commons.codec.binary.StringUtils;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -84,17 +85,32 @@ final class JWTDecoder implements DecodedJWT, Serializable {
     }
 
     @Override
-    public Instant getExpiresAt() {
+    public Instant getExpiresAtInstant() {
+        return payload.getExpiresAtInstant();
+    }
+
+    @Override
+    public Instant getNotBeforeInstant() {
+        return payload.getNotBeforeInstant();
+    }
+
+    @Override
+    public Instant getIssuedAtInstant() {
+        return payload.getIssuedAtInstant();
+    }
+
+    @Override
+    public Date getExpiresAt() {
         return payload.getExpiresAt();
     }
 
     @Override
-    public Instant getNotBefore() {
+    public Date getNotBefore() {
         return payload.getNotBefore();
     }
 
     @Override
-    public Instant getIssuedAt() {
+    public Date getIssuedAt() {
         return payload.getIssuedAt();
     }
 

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -10,7 +10,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -84,17 +84,17 @@ final class JWTDecoder implements DecodedJWT, Serializable {
     }
 
     @Override
-    public Date getExpiresAt() {
+    public Instant getExpiresAt() {
         return payload.getExpiresAt();
     }
 
     @Override
-    public Date getNotBefore() {
+    public Instant getNotBefore() {
         return payload.getNotBefore();
     }
 
     @Override
-    public Date getIssuedAt() {
+    public Instant getIssuedAt() {
         return payload.getIssuedAt();
     }
 

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -158,6 +158,13 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         }
 
         @Override
+        public Verification withClaim(String name, Date value) throws IllegalArgumentException {
+            assertNonNull(name);
+            requireClaim(name, value);
+            return this;
+        }
+
+        @Override
         public Verification withArrayClaim(String name, String... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
@@ -308,6 +315,8 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             isValid = value.equals(claim.asBoolean());
         } else if (value instanceof Double) {
             isValid = value.equals(claim.asDouble());
+        } else if (value instanceof Date) {
+            isValid = value.equals(claim.asDate());
         } else if (value instanceof Instant) {
             isValid = value.equals(claim.asInstant());
         } else if (value instanceof Object[]) {

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -272,13 +272,13 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
                     assertValidAudienceClaim(jwt.getAudience(), (List<String>) entry.getValue());
                     break;
                 case PublicClaims.EXPIRES_AT:
-                    assertValidInstantClaim(jwt.getExpiresAt(), (Long) entry.getValue(), true);
+                    assertValidInstantClaim(jwt.getExpiresAtInstant(), (Long) entry.getValue(), true);
                     break;
                 case PublicClaims.ISSUED_AT:
-                    assertValidInstantClaim(jwt.getIssuedAt(), (Long) entry.getValue(), false);
+                    assertValidInstantClaim(jwt.getIssuedAtInstant(), (Long) entry.getValue(), false);
                     break;
                 case PublicClaims.NOT_BEFORE:
-                    assertValidInstantClaim(jwt.getNotBefore(), (Long) entry.getValue(), false);
+                    assertValidInstantClaim(jwt.getNotBeforeInstant(), (Long) entry.getValue(), false);
                     break;
                 case PublicClaims.ISSUER:
                     assertValidIssuerClaim(jwt.getIssuer(), (List<String>) entry.getValue());
@@ -328,7 +328,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
     }
 
     private void assertValidInstantClaim(Instant claimVal, long leeway, boolean shouldBeFuture) {
-        Instant today = clock.getToday();
+        Instant today = clock.getNow();
         if (shouldBeFuture) {
             assertInstantIsFuture(claimVal, leeway, today);
         } else {

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -9,6 +9,8 @@ import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -149,7 +151,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         }
 
         @Override
-        public Verification withClaim(String name, Date value) throws IllegalArgumentException {
+        public Verification withClaim(String name, Instant value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
@@ -270,13 +272,13 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
                     assertValidAudienceClaim(jwt.getAudience(), (List<String>) entry.getValue());
                     break;
                 case PublicClaims.EXPIRES_AT:
-                    assertValidDateClaim(jwt.getExpiresAt(), (Long) entry.getValue(), true);
+                    assertValidInstantClaim(jwt.getExpiresAt(), (Long) entry.getValue(), true);
                     break;
                 case PublicClaims.ISSUED_AT:
-                    assertValidDateClaim(jwt.getIssuedAt(), (Long) entry.getValue(), false);
+                    assertValidInstantClaim(jwt.getIssuedAt(), (Long) entry.getValue(), false);
                     break;
                 case PublicClaims.NOT_BEFORE:
-                    assertValidDateClaim(jwt.getNotBefore(), (Long) entry.getValue(), false);
+                    assertValidInstantClaim(jwt.getNotBefore(), (Long) entry.getValue(), false);
                     break;
                 case PublicClaims.ISSUER:
                     assertValidIssuerClaim(jwt.getIssuer(), (List<String>) entry.getValue());
@@ -306,8 +308,8 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             isValid = value.equals(claim.asBoolean());
         } else if (value instanceof Double) {
             isValid = value.equals(claim.asDouble());
-        } else if (value instanceof Date) {
-            isValid = value.equals(claim.asDate());
+        } else if (value instanceof Instant) {
+            isValid = value.equals(claim.asInstant());
         } else if (value instanceof Object[]) {
             List<Object> claimArr = Arrays.asList(claim.as(Object[].class));
             List<Object> valueArr = Arrays.asList((Object[]) value);
@@ -325,27 +327,24 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         }
     }
 
-    private void assertValidDateClaim(Date date, long leeway, boolean shouldBeFuture) {
-        Date today = clock.getToday();
-        today.setTime(today.getTime() / 1000 * 1000); // truncate millis
+    private void assertValidInstantClaim(Instant claimVal, long leeway, boolean shouldBeFuture) {
+        Instant today = clock.getToday();
         if (shouldBeFuture) {
-            assertDateIsFuture(date, leeway, today);
+            assertInstantIsFuture(claimVal, leeway, today);
         } else {
-            assertDateIsPast(date, leeway, today);
+            assertInstantIsPast(claimVal, leeway, today);
         }
     }
 
-    private void assertDateIsFuture(Date date, long leeway, Date today) {
-        today.setTime(today.getTime() - leeway * 1000);
-        if (date != null && today.after(date)) {
-            throw new TokenExpiredException(String.format("The Token has expired on %s.", date));
+    private void assertInstantIsFuture(Instant claimVal, long leeway, Instant now) {
+        if (claimVal != null && now.minus(Duration.ofSeconds(leeway)).isAfter(claimVal)) {
+            throw new TokenExpiredException(String.format("The Token has expired on %s.", claimVal));
         }
     }
 
-    private void assertDateIsPast(Date date, long leeway, Date today) {
-        today.setTime(today.getTime() + leeway * 1000);
-        if (date != null && today.before(date)) {
-            throw new InvalidClaimException(String.format("The Token can't be used before %s.", date));
+    private void assertInstantIsPast(Instant claimVal, long leeway, Instant now) {
+        if (claimVal != null && now.plus(Duration.ofSeconds(leeway)).isBefore(claimVal)) {
+            throw new InvalidClaimException(String.format("The Token can't be used before %s.", claimVal));
         }
     }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -54,12 +54,12 @@ class JsonNodeClaim implements Claim {
     }
 
     @Override
-    public Date asDate() {
+    public Instant asInstant() {
         if (!data.canConvertToLong()) {
             return null;
         }
         long seconds = data.asLong();
-        return new Date(seconds * 1000);
+        return Instant.ofEpochSecond(seconds);
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -51,6 +52,12 @@ class JsonNodeClaim implements Claim {
     @Override
     public String asString() {
         return !data.isTextual() ? null : data.asText();
+    }
+
+    @Override
+    public Date asDate() {
+        Instant instant = asInstant();
+        return (instant != null) ? Date.from(instant) : null;
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -3,7 +3,7 @@ package com.auth0.jwt.impl;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +42,7 @@ public class NullClaim implements Claim {
     }
 
     @Override
-    public Date asDate() {
+    public Instant asInstant() {
         return null;
     }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +44,11 @@ public class NullClaim implements Claim {
 
     @Override
     public Instant asInstant() {
+        return null;
+    }
+
+    @Override
+    public Date asDate() {
         return null;
     }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 class PayloadDeserializer extends StdDeserializer<Payload> {
@@ -37,9 +38,9 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         String issuer = getString(tree, PublicClaims.ISSUER);
         String subject = getString(tree, PublicClaims.SUBJECT);
         List<String> audience = getStringOrArray(tree, PublicClaims.AUDIENCE);
-        Date expiresAt = getDateFromSeconds(tree, PublicClaims.EXPIRES_AT);
-        Date notBefore = getDateFromSeconds(tree, PublicClaims.NOT_BEFORE);
-        Date issuedAt = getDateFromSeconds(tree, PublicClaims.ISSUED_AT);
+        Instant expiresAt = getInstantFromSeconds(tree, PublicClaims.EXPIRES_AT);
+        Instant notBefore = getInstantFromSeconds(tree, PublicClaims.NOT_BEFORE);
+        Instant issuedAt = getInstantFromSeconds(tree, PublicClaims.ISSUED_AT);
         String jwtId = getString(tree, PublicClaims.JWT_ID);
 
         return new PayloadImpl(issuer, subject, audience, expiresAt, notBefore, issuedAt, jwtId, tree, objectReader);
@@ -65,7 +66,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         return list;
     }
 
-    Date getDateFromSeconds(Map<String, JsonNode> tree, String claimName) {
+    Instant getInstantFromSeconds(Map<String, JsonNode> tree, String claimName) {
         JsonNode node = tree.get(claimName);
         if (node == null || node.isNull()) {
             return null;
@@ -73,8 +74,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         if (!node.canConvertToLong()) {
             throw new JWTDecodeException(String.format("The claim '%s' contained a non-numeric date value.", claimName));
         }
-        final long ms = node.asLong() * 1000;
-        return new Date(ms);
+        return Instant.ofEpochSecond(node.asLong());
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.*;
 
 import static com.auth0.jwt.impl.JsonNodeClaim.extractClaim;
@@ -19,14 +20,14 @@ class PayloadImpl implements Payload, Serializable {
     private final String issuer;
     private final String subject;
     private final List<String> audience;
-    private final Date expiresAt;
-    private final Date notBefore;
-    private final Date issuedAt;
+    private final Instant expiresAt;
+    private final Instant notBefore;
+    private final Instant issuedAt;
     private final String jwtId;
     private final Map<String, JsonNode> tree;
     private final ObjectReader objectReader;
 
-    PayloadImpl(String issuer, String subject, List<String> audience, Date expiresAt, Date notBefore, Date issuedAt, String jwtId, Map<String, JsonNode> tree, ObjectReader objectReader) {
+    PayloadImpl(String issuer, String subject, List<String> audience, Instant expiresAt, Instant notBefore, Instant issuedAt, String jwtId, Map<String, JsonNode> tree, ObjectReader objectReader) {
         this.issuer = issuer;
         this.subject = subject;
         this.audience = audience;
@@ -58,17 +59,17 @@ class PayloadImpl implements Payload, Serializable {
     }
 
     @Override
-    public Date getExpiresAt() {
+    public Instant getExpiresAt() {
         return expiresAt;
     }
 
     @Override
-    public Date getNotBefore() {
+    public Instant getNotBefore() {
         return notBefore;
     }
 
     @Override
-    public Date getIssuedAt() {
+    public Instant getIssuedAt() {
         return issuedAt;
     }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
@@ -59,18 +59,33 @@ class PayloadImpl implements Payload, Serializable {
     }
 
     @Override
-    public Instant getExpiresAt() {
+    public Instant getExpiresAtInstant() {
         return expiresAt;
     }
 
     @Override
-    public Instant getNotBefore() {
+    public Instant getNotBeforeInstant() {
         return notBefore;
     }
 
     @Override
-    public Instant getIssuedAt() {
+    public Instant getIssuedAtInstant() {
         return issuedAt;
+    }
+
+    @Override
+    public Date getExpiresAt() {
+        return (expiresAt != null) ? Date.from(expiresAt) : null;
+    }
+
+    @Override
+    public Date getIssuedAt() {
+        return (issuedAt != null) ? Date.from(issuedAt) : null;
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return (notBefore != null) ? Date.from(notBefore) : null;
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -60,7 +60,7 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
      * @param gen the JsonGenerator to use for JSON serialization
      * @throws IOException
      */
-    private void handleInstantSerialization(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
+    private void handleSerialization(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
         gen.writeFieldName(entry.getKey());
         if (entry.getValue() instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
             gen.writeNumber(instantToSeconds((Instant) entry.getValue()));

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -42,12 +42,7 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
                     gen.writeEndArray();
                 }
             } else {
-                gen.writeFieldName(e.getKey());
-                if (e.getValue() instanceof Date) { // true for EXPIRES_AT, ISSUED_AT, NOT_BEFORE
-                    gen.writeNumber(dateToSeconds((Date) e.getValue()));
-                } else {
-                    gen.writeObject(e.getValue());
-                }
+                handleSerialization(e, gen);
             }
         }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -57,16 +57,18 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
      */
     private void handleSerialization(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
         gen.writeFieldName(entry.getKey());
-        if (entry.getValue() instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
-            gen.writeNumber(instantToSeconds((Instant) entry.getValue()));
-        } else if (entry.getValue() instanceof List) {
-            // traverse lists and handle custom Instant serialization
-            serializeList((List<?>) entry.getValue(), gen);
-        } else if (entry.getValue() instanceof Map) {
-            // traverse maps and handle custom Instant serialization
-            serializeMap((Map<?,?>) entry.getValue(), gen);
+        serialize(entry.getValue(), gen);
+    }
+
+    private void serialize(Object value, JsonGenerator gen) throws IOException {
+        if (value instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
+            gen.writeNumber(instantToSeconds((Instant) value));
+        } else if (value instanceof Map) {
+            serializeMap((Map<?, ?>) value, gen);
+        } else if (value instanceof List) {
+            serializeList((List<?>) value, gen);
         } else {
-            gen.writeObject(entry.getValue());
+            gen.writeObject(value);
         }
     }
 
@@ -86,18 +88,6 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
             serialize(entry, gen);
         }
         gen.writeEndArray();
-    }
-
-    private void serialize(Object value, JsonGenerator gen) throws IOException {
-        if (value instanceof Instant) {
-            gen.writeNumber(instantToSeconds((Instant) value));
-        } else if (value instanceof Map) {
-            serializeMap((Map<?, ?>) value, gen);
-        } else if (value instanceof List) {
-            serializeList((List<?>) value, gen);
-        } else {
-            gen.writeObject(value);
-        }
     }
 
     private long instantToSeconds(Instant instant) {

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
@@ -53,7 +53,7 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
         gen.writeEndObject();
     }
 
-    private long dateToSeconds(Date date) {
-        return date.getTime() / 1000;
+    private long instantToSeconds(Instant instant) {
+        return instant.getEpochSecond();
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -42,7 +42,8 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
                     gen.writeEndArray();
                 }
             } else {
-                handleSerialization(e, gen);
+                gen.writeFieldName(e.getKey());
+                handleSerialization(e.getValue(), gen);
             }
         }
 
@@ -51,16 +52,11 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
 
     /**
      * Serializes {@linkplain Instant} to epoch second values, traversing maps and lists as needed.
-     * @param entry the entry to serialize
+     * @param value the object to serialize
      * @param gen the JsonGenerator to use for JSON serialization
      * @throws IOException
      */
-    private void handleSerialization(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
-        gen.writeFieldName(entry.getKey());
-        serialize(entry.getValue(), gen);
-    }
-
-    private void serialize(Object value, JsonGenerator gen) throws IOException {
+    private void handleSerialization(Object value, JsonGenerator gen) throws IOException {
         if (value instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
             gen.writeNumber(instantToSeconds((Instant) value));
         } else if (value instanceof Map) {
@@ -77,7 +73,7 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
         for (Map.Entry<?, ?> entry : map.entrySet()) {
             gen.writeFieldName((String) entry.getKey());
             Object value = entry.getValue();
-            serialize(value, gen);
+            handleSerialization(value, gen);
         }
         gen.writeEndObject();
     }
@@ -85,7 +81,7 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
     private void serializeList(List<?> list, JsonGenerator gen) throws IOException {
         gen.writeStartArray();
         for (Object entry : list) {
-            serialize(entry, gen);
+            handleSerialization(entry, gen);
         }
         gen.writeEndArray();
     }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
@@ -51,6 +52,57 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
         }
 
         gen.writeEndObject();
+    }
+
+    /**
+     * Serializes {@linkplain Instant} to epoch second values, traversing maps and lists as needed.
+     * @param entry the entry to serialize
+     * @param gen the JsonGenerator to use for JSON serialization
+     * @throws IOException
+     */
+    private void handleInstantSerialization(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
+        gen.writeFieldName(entry.getKey());
+        if (entry.getValue() instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
+            gen.writeNumber(instantToSeconds((Instant) entry.getValue()));
+        } else if (entry.getValue() instanceof List) {
+            // traverse lists and handle custom Instant serialization
+            serializeList((List<?>) entry.getValue(), gen);
+        } else if (entry.getValue() instanceof Map) {
+            // traverse maps and handle custom Instant serialization
+            serializeMap((Map<?,?>) entry.getValue(), gen);
+        } else {
+            gen.writeObject(entry.getValue());
+        }
+    }
+
+    private void serializeMap(Map<?, ?> map, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            gen.writeFieldName((String) entry.getKey());
+            Object value = entry.getValue();
+            serialize(value, gen);
+        }
+        gen.writeEndObject();
+    }
+
+    private void serializeList(List<?> list, JsonGenerator gen) throws IOException {
+        gen.writeStartArray();
+        for (Object entry : list) {
+            serialize(entry, gen);
+        }
+        gen.writeEndArray();
+    }
+
+    private void serialize(Object value, JsonGenerator gen) throws IOException {
+        if (value instanceof Instant) {
+            gen.writeNumber(instantToSeconds((Instant) value));
+        } else if (value instanceof Map) {
+            serializeMap((Map<?, ?>) value, gen);
+        } else if (value instanceof List) {
+            serializeList((List<?>) value, gen);
+        } else {
+            gen.writeObject(value);
+        }
     }
 
     private long instantToSeconds(Instant instant) {

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -3,6 +3,7 @@ package com.auth0.jwt.interfaces;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -64,6 +65,15 @@ public interface Claim {
      * @return the value as a Instant or null.
      */
     Instant asInstant();
+
+    /**
+     * Get this Claim as a Date.
+     * If the value can't be converted to a Date, null will be returned.
+     *
+     * @return the value as a Date or null.
+     */
+    // TODO - Deprecate this method in favor of asInstant()
+    Date asDate();
 
     /**
      * Get this Claim as an Array of type T.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -2,7 +2,7 @@ package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -58,12 +58,12 @@ public interface Claim {
     String asString();
 
     /**
-     * Get this Claim as a Date.
-     * If the value can't be converted to a Date, null will be returned.
+     * Get this Claim as an Instant.
+     * If the value can't be converted to an Instant, null will be returned.
      *
-     * @return the value as a Date or null.
+     * @return the value as a Instant or null.
      */
-    Date asDate();
+    Instant asInstant();
 
     /**
      * Get this Claim as an Array of type T.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
@@ -1,15 +1,15 @@
 package com.auth0.jwt.interfaces;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * The Clock class is used to wrap calls to Date class.
  */
 public interface Clock {
     /**
-     * Returns a new Date representing Today's time.
+     * Returns a new Instant representing Today's time.
      *
-     * @return a new Date representing Today's time.
+     * @return a new Instant representing Today's time.
      */
-    Date getToday();
+    Instant getToday();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
@@ -1,15 +1,24 @@
 package com.auth0.jwt.interfaces;
 
 import java.time.Instant;
+import java.util.Date;
 
 /**
  * The Clock class is used to wrap calls to Date class.
  */
 public interface Clock {
     /**
-     * Returns a new Instant representing Today's time.
+     * Returns a new Instant representing the current time.
      *
-     * @return a new Instant representing Today's time.
+     * @return the current time.
      */
-    Instant getToday();
+    Instant getNow();
+
+    /**
+     * Returns a new Date representing Today's time.
+
+     * @return a new Date representing Today's time.
+     */
+    // TODO - Deprecate this method in favor of getNow()
+    Date getToday();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -56,6 +56,7 @@ public interface Payload {
      *
      * @return the Expiration Time value or null.
      */
+    // TODO - deprecate in favor of getExpiresAtInstant
     Date getExpiresAt();
 
     /**
@@ -63,6 +64,7 @@ public interface Payload {
      *
      * @return the Not Before value or null.
      */
+    // TODO - deprecate in favor of getNotBeforeInstant
     Date getNotBefore();
 
     /**
@@ -70,6 +72,7 @@ public interface Payload {
      *
      * @return the Issued At value or null.
      */
+    // TODO - deprecate in favor of getIssuedAtInstant
     Date getIssuedAt();
 
     /**

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt.interfaces;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -34,21 +35,42 @@ public interface Payload {
      *
      * @return the Expiration Time value or null.
      */
-    Instant getExpiresAt();
+    Instant getExpiresAtInstant();
 
     /**
      * Get the value of the "nbf" claim, or null if it's not available.
      *
      * @return the Not Before value or null.
      */
-    Instant getNotBefore();
+    Instant getNotBeforeInstant();
 
     /**
      * Get the value of the "iat" claim, or null if it's not available.
      *
      * @return the Issued At value or null.
      */
-    Instant getIssuedAt();
+    Instant getIssuedAtInstant();
+
+    /**
+     * Get the value of the "exp" claim, or null if it's not available.
+     *
+     * @return the Expiration Time value or null.
+     */
+    Date getExpiresAt();
+
+    /**
+     * Get the value of the "nbf" claim, or null if it's not available.
+     *
+     * @return the Not Before value or null.
+     */
+    Date getNotBefore();
+
+    /**
+     * Get the value of the "iat" claim, or null if it's not available.
+     *
+     * @return the Issued At value or null.
+     */
+    Date getIssuedAt();
 
     /**
      * Get the value of the "jti" claim, or null if it's not available.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -1,6 +1,6 @@
 package com.auth0.jwt.interfaces;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -34,21 +34,21 @@ public interface Payload {
      *
      * @return the Expiration Time value or null.
      */
-    Date getExpiresAt();
+    Instant getExpiresAt();
 
     /**
      * Get the value of the "nbf" claim, or null if it's not available.
      *
      * @return the Not Before value or null.
      */
-    Date getNotBefore();
+    Instant getNotBefore();
 
     /**
      * Get the value of the "iat" claim, or null if it's not available.
      *
      * @return the Issued At value or null.
      */
-    Date getIssuedAt();
+    Instant getIssuedAt();
 
     /**
      * Get the value of the "jti" claim, or null if it's not available.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -3,6 +3,7 @@ package com.auth0.jwt.interfaces;
 import com.auth0.jwt.JWTVerifier;
 
 import java.time.Instant;
+import java.util.Date;
 
 /**
  * Holds the Claims and claim-based configurations required for a JWT to be considered valid.
@@ -139,6 +140,17 @@ public interface Verification {
      * @throws IllegalArgumentException if the name is null.
      */
     Verification withClaim(String name, Instant value) throws IllegalArgumentException;
+
+    /**
+     * Require a specific Claim value.
+     *
+     * @param name  the Claim's name.
+     * @param value the Claim's value.
+     * @return this same Verification instance.
+     * @throws IllegalArgumentException if the name is null.
+     */
+    // TODO deprecate this in favor of withClaim(String name, Instant value)
+    Verification withClaim(String name, Date value) throws IllegalArgumentException;
 
     /**
      * Require a specific Array Claim to contain at least the given items.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -2,7 +2,7 @@ package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.JWTVerifier;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Holds the Claims and claim-based configurations required for a JWT to be considered valid.
@@ -138,7 +138,7 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, Date value) throws IllegalArgumentException;
+    Verification withClaim(String name, Instant value) throws IllegalArgumentException;
 
     /**
      * Require a specific Array Claim to contain at least the given items.

--- a/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.interfaces.Clock;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Date;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -14,7 +15,14 @@ public class ClockImplTest {
     @Test
     public void shouldGetToday() {
         Clock clock = new ClockImpl();
-        Instant clockToday = clock.getToday();
+        Date clockToday = clock.getToday();
+        assertThat(clockToday, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetNow() throws Exception{
+        Clock clock = new ClockImpl();
+        Instant clockToday = clock.getNow();
         assertThat(clockToday, is(notNullValue()));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
@@ -3,18 +3,18 @@ package com.auth0.jwt;
 import com.auth0.jwt.interfaces.Clock;
 import org.junit.Test;
 
-import java.util.Date;
+import java.time.Instant;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class ClockImplTest {
 
     @Test
     public void shouldGetToday() {
         Clock clock = new ClockImpl();
-        Date clockToday = clock.getToday();
+        Instant clockToday = clock.getToday();
         assertThat(clockToday, is(notNullValue()));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -228,7 +228,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddExpiresAt() {
+    public void shouldAddExpiresAtAsInstant() throws Exception {
         String signed = JWTCreator.init()
                 .withExpiresAt(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -238,7 +238,17 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddNotBefore() {
+    public void shouldAddExpiresAtAsDate() throws Exception {
+        String signed = JWTCreator.init()
+                .withExpiresAt(new Date(1477592000))
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        assertThat(TokenUtils.splitToken(signed)[1], is("eyJleHAiOjE0Nzc1OTJ9"));
+    }
+
+    @Test
+    public void shouldAddNotBeforeAsInstant() throws Exception {
         String signed = JWTCreator.init()
                 .withNotBefore(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -248,7 +258,17 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddIssuedAt() {
+    public void shouldAddNotBeforeAsDate() throws Exception {
+        String signed = JWTCreator.init()
+                .withNotBefore(new Date(1477592000))
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        assertThat(TokenUtils.splitToken(signed)[1], is("eyJuYmYiOjE0Nzc1OTJ9"));
+    }
+
+    @Test
+    public void shouldAddIssuedAtAsInstant() throws Exception {
         String signed = JWTCreator.init()
                 .withIssuedAt(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -258,7 +278,17 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddJWTId() {
+    public void shouldAddIssuedAtAsDate() throws Exception {
+        String signed = JWTCreator.init()
+                .withIssuedAt(new Date(1477592000))
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        assertThat(TokenUtils.splitToken(signed)[1], is("eyJpYXQiOjE0Nzc1OTJ9"));
+    }
+
+    @Test
+    public void shouldAddJWTId() throws Exception {
         String signed = JWTCreator.init()
                 .withJWTId("jwt_id_123")
                 .sign(Algorithm.HMAC256("secret"));
@@ -397,7 +427,19 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomArrayClaimOfTypeString() {
+    public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
+        Date date = new Date(1478891521000L);
+        String jwt = JWTCreator.init()
+                .withClaim("name", date)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+        assertThat(parts[1], is("eyJuYW1lIjoxNDc4ODkxNTIxfQ"));
+    }
+
+    @Test
+    public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
         String jwt = JWTCreator.init()
                 .withArrayClaim("name", new String[]{"text", "123", "true"})
                 .sign(Algorithm.HMAC256("secret"));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -228,7 +228,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddExpiresAtAsInstant() throws Exception {
+    public void shouldAddExpiresAtAsInstant() {
         String signed = JWTCreator.init()
                 .withExpiresAt(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -238,7 +238,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddExpiresAtAsDate() throws Exception {
+    public void shouldAddExpiresAtAsDate() {
         String signed = JWTCreator.init()
                 .withExpiresAt(new Date(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -248,7 +248,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddNotBeforeAsInstant() throws Exception {
+    public void shouldAddNotBeforeAsInstant() {
         String signed = JWTCreator.init()
                 .withNotBefore(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -258,7 +258,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddNotBeforeAsDate() throws Exception {
+    public void shouldAddNotBeforeAsDate() {
         String signed = JWTCreator.init()
                 .withNotBefore(new Date(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -268,7 +268,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddIssuedAtAsInstant() throws Exception {
+    public void shouldAddIssuedAtAsInstant() {
         String signed = JWTCreator.init()
                 .withIssuedAt(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -278,7 +278,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddIssuedAtAsDate() throws Exception {
+    public void shouldAddIssuedAtAsDate() {
         String signed = JWTCreator.init()
                 .withIssuedAt(new Date(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
@@ -288,7 +288,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAddJWTId() throws Exception {
+    public void shouldAddJWTId() {
         String signed = JWTCreator.init()
                 .withJWTId("jwt_id_123")
                 .sign(Algorithm.HMAC256("secret"));
@@ -415,7 +415,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomClaimOfTypeInstant() throws Exception {
+    public void shouldAcceptCustomClaimOfTypeInstant() {
         Instant instant = Instant.ofEpochMilli(1478891521000L);
         String jwt = JWTCreator.init()
                 .withClaim("name", instant)
@@ -427,7 +427,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
+    public void shouldAcceptCustomClaimOfTypeDate() {
         Date date = new Date(1478891521000L);
         String jwt = JWTCreator.init()
                 .withClaim("name", date)
@@ -439,7 +439,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
+    public void shouldAcceptCustomArrayClaimOfTypeString() {
         String jwt = JWTCreator.init()
                 .withArrayClaim("name", new String[]{"text", "123", "true"})
                 .sign(Algorithm.HMAC256("secret"));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -507,6 +507,7 @@ public class JWTCreatorTest {
         data.put("integer", 1);
         data.put("long", Long.MAX_VALUE);
         data.put("double", 123.456d);
+        data.put("date", new Date(123L));
         data.put("instant", Instant.ofEpochSecond(123L));
         data.put("boolean", true);
 
@@ -519,6 +520,7 @@ public class JWTCreatorTest {
 
         Map<String, Object> sub = new HashMap<>();
         sub.put("subKey", "subValue");
+        sub.put("subDate", new Date(567L));
         sub.put("subInstant", Instant.ofEpochSecond(567L));
         data.put("map", sub);
 
@@ -537,6 +539,7 @@ public class JWTCreatorTest {
         assertThat(map.get("integer"), is(1));
         assertThat(map.get("long"), is(Long.MAX_VALUE));
         assertThat(map.get("double"), is(123.456d));
+        assertThat(map.get("date"), is(123));
         assertThat(map.get("instant"), is(123));
         assertThat(map.get("boolean"), is(true));
 
@@ -551,6 +554,7 @@ public class JWTCreatorTest {
         // nested map
         Map nested = (Map) map.get("map");
         assertThat(nested.get("subKey"), is("subValue"));
+        assertThat(nested.get("subDate"), is(567));
         assertThat(nested.get("subInstant"), is(567));
     }
 
@@ -564,6 +568,7 @@ public class JWTCreatorTest {
         data.add(1);
         data.add(Long.MAX_VALUE);
         data.add(123.456d);
+        data.add(new Date(123L));
         data.add(Instant.ofEpochSecond(123L));
         data.add(true);
         
@@ -576,6 +581,8 @@ public class JWTCreatorTest {
 
         Map<String, Object> sub = new HashMap<>();
         sub.put("subKey", "subValue");
+        sub.put("subDate", new Date(567L));
+        sub.put("subInstant", Instant.ofEpochSecond(567L));
 
         data.add(sub);
 
@@ -595,17 +602,22 @@ public class JWTCreatorTest {
         assertThat(list.get(2), is(Long.MAX_VALUE));
         assertThat(list.get(3), is(123.456d));
         assertThat(list.get(4), is(123));
-        assertThat(list.get(5), is(true));
+        assertThat(list.get(5), is(123));
+        assertThat(list.get(6), is(true));
         
         // array types
-        assertThat(list.get(6), is(Arrays.asList(3, 5)));
-        assertThat(list.get(7), is(Arrays.asList(Long.MAX_VALUE, Long.MIN_VALUE)));
-        assertThat(list.get(8), is(Arrays.asList("string")));
+        assertThat(list.get(7), is(Arrays.asList(new Integer[]{3, 5})));
+        assertThat(list.get(8), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
+        assertThat(list.get(9), is(Arrays.asList(new String[]{"string"})));
 
         // list
-        assertThat(list.get(9), is(Arrays.asList("a", "b", "c")));
-        assertThat(list.get(10), is(sub));
+        assertThat(list.get(10), is(Arrays.asList("a", "b", "c")));
 
+        // nested map
+        Map nested = (Map) list.get(11);
+        assertThat(nested.get("subKey"), is("subValue"));
+        assertThat(nested.get("subDate"), is(567));
+        assertThat(nested.get("subInstant"), is(567));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -5,7 +5,6 @@ import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,10 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -389,7 +385,7 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
+    public void shouldAcceptCustomClaimOfTypeInstant() throws Exception {
         Instant instant = Instant.ofEpochMilli(1478891521000L);
         String jwt = JWTCreator.init()
                 .withClaim("name", instant)
@@ -469,7 +465,7 @@ public class JWTCreatorTest {
         data.put("integer", 1);
         data.put("long", Long.MAX_VALUE);
         data.put("double", 123.456d);
-        data.put("date", new Date(123L));
+        data.put("instant", Instant.ofEpochSecond(123L));
         data.put("boolean", true);
 
         // array types
@@ -477,11 +473,11 @@ public class JWTCreatorTest {
         data.put("longArray", new Long[]{Long.MAX_VALUE, Long.MIN_VALUE});
         data.put("stringArray", new String[]{"string"});
 
-        data.put("list", Arrays.asList("a", "b", "c"));
+        data.put("list", Arrays.asList("a", "b", "c", Instant.ofEpochSecond(41L)));
 
         Map<String, Object> sub = new HashMap<>();
         sub.put("subKey", "subValue");
-
+        sub.put("subInstant", Instant.ofEpochSecond(567L));
         data.put("map", sub);
 
         String jwt = JWTCreator.init()
@@ -499,7 +495,7 @@ public class JWTCreatorTest {
         assertThat(map.get("integer"), is(1));
         assertThat(map.get("long"), is(Long.MAX_VALUE));
         assertThat(map.get("double"), is(123.456d));
-        assertThat(map.get("date"), is(123));
+        assertThat(map.get("instant"), is(123));
         assertThat(map.get("boolean"), is(true));
 
         // array types
@@ -508,9 +504,12 @@ public class JWTCreatorTest {
         assertThat(map.get("stringArray"), is(Arrays.asList("string")));
 
         // list
-        assertThat(map.get("list"), is(Arrays.asList("a", "b", "c")));
-        assertThat(map.get("map"), is(sub));
+        assertThat(map.get("list"), is(Arrays.asList("a", "b", "c", 41)));
 
+        // nested map
+        Map nested = (Map) map.get("map");
+        assertThat(nested.get("subKey"), is("subValue"));
+        assertThat(nested.get("subInstant"), is(567));
     }
 
     @SuppressWarnings("unchecked")
@@ -523,7 +522,7 @@ public class JWTCreatorTest {
         data.add(1);
         data.add(Long.MAX_VALUE);
         data.add(123.456d);
-        data.add(new Date(123L));
+        data.add(Instant.ofEpochSecond(123L));
         data.add(true);
         
         // array types

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -14,10 +14,8 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -236,7 +234,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAddExpiresAt() {
         String signed = JWTCreator.init()
-                .withExpiresAt(new Date(1477592000))
+                .withExpiresAt(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
@@ -246,7 +244,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAddNotBefore() {
         String signed = JWTCreator.init()
-                .withNotBefore(new Date(1477592000))
+                .withNotBefore(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
@@ -256,7 +254,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAddIssuedAt() {
         String signed = JWTCreator.init()
-                .withIssuedAt(new Date(1477592000))
+                .withIssuedAt(Instant.ofEpochMilli(1477592000))
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
@@ -391,10 +389,10 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomClaimOfTypeDate() {
-        Date date = new Date(1478891521000L);
+    public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
+        Instant instant = Instant.ofEpochMilli(1478891521000L);
         String jwt = JWTCreator.init()
-                .withClaim("name", date)
+                .withClaim("name", instant)
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -15,6 +15,7 @@ import org.junit.rules.ExpectedException;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -131,33 +132,66 @@ public class JWTDecoderTest {
     public void shouldGetExpirationTime() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0NzY3MjcwODZ9.L9dcPHEDQew2u9MkDCORFkfDGcSOsgoPqNY-LUMLEHg");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
         long ms = 1476727086L * 1000;
-        Instant expectedInstant = Instant.ofEpochMilli(ms);
+        Date expectedDate = new Date(ms);
         assertThat(jwt.getExpiresAt(), is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(equalTo(expectedInstant)));
+        assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
     }
 
     @Test
     public void shouldGetNotBefore() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0NzY3MjcwODZ9.tkpD3iCPQPVqjnjpDVp2bJMBAgpVCG9ZjlBuMitass0");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
         long ms = 1476727086L * 1000;
-        Instant expectedInstant = Instant.ofEpochMilli(ms);
+        Date expectedDate = new Date(ms);
         assertThat(jwt.getNotBefore(), is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(equalTo(expectedInstant)));
+        assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
     }
 
     @Test
     public void shouldGetIssuedAt() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0NzY3MjcwODZ9.KPjGoW665E8V5_27Jugab8qSTxLk2cgquhPCBfAP0_w");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
+        long ms = 1476727086L * 1000;
+        Date expectedDate = new Date(ms);
+        assertThat(jwt.getIssuedAt(), is(notNullValue()));
+        assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
+    }
+
+    @Test
+    public void shouldGetExpirationTimeAsInstant() throws Exception {
+        DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0NzY3MjcwODZ9.L9dcPHEDQew2u9MkDCORFkfDGcSOsgoPqNY-LUMLEHg");
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getExpiresAtInstant(), is(instanceOf(Instant.class)));
         long ms = 1476727086L * 1000;
         Instant expectedInstant = Instant.ofEpochMilli(ms);
-        assertThat(jwt.getIssuedAt(), is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(equalTo(expectedInstant)));
+        assertThat(jwt.getExpiresAtInstant(), is(notNullValue()));
+        assertThat(jwt.getExpiresAtInstant(), is(equalTo(expectedInstant)));
+    }
+
+    @Test
+    public void shouldGetNotBeforeAsInstant() throws Exception {
+        DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0NzY3MjcwODZ9.tkpD3iCPQPVqjnjpDVp2bJMBAgpVCG9ZjlBuMitass0");
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getNotBeforeInstant(), is(instanceOf(Instant.class)));
+        long ms = 1476727086L * 1000;
+        Instant expectedInstant = Instant.ofEpochMilli(ms);
+        assertThat(jwt.getNotBeforeInstant(), is(notNullValue()));
+        assertThat(jwt.getNotBeforeInstant(), is(equalTo(expectedInstant)));
+    }
+
+    @Test
+    public void shouldGetIssuedAtAsInstant() throws Exception {
+        DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0NzY3MjcwODZ9.KPjGoW665E8V5_27Jugab8qSTxLk2cgquhPCBfAP0_w");
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getIssuedAtInstant(), is(instanceOf(Instant.class)));
+        long ms = 1476727086L * 1000;
+        Instant expectedInstant = Instant.ofEpochMilli(ms);
+        assertThat(jwt.getIssuedAtInstant(), is(notNullValue()));
+        assertThat(jwt.getIssuedAtInstant(), is(equalTo(expectedInstant)));
     }
 
     @Test
@@ -241,6 +275,15 @@ public class JWTDecoderTest {
     @Test
     public void shouldGetCustomClaimOfTypeDate() {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
+        Date date = new Date(1478891521000L);
+        DecodedJWT jwt = JWT.decode(token);
+        Assert.assertThat(jwt, is(notNullValue()));
+        Assert.assertThat(jwt.getClaim("name").asDate().getTime(), is(date.getTime()));
+    }
+
+    @Test
+    public void shouldGetCustomClaimOfTypeInstant() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
         Instant instant = Instant.ofEpochMilli(1478891521000L);
         DecodedJWT jwt = JWT.decode(token);
         Assert.assertThat(jwt, is(notNullValue()));
@@ -306,12 +349,12 @@ public class JWTDecoderTest {
         assertThat(originalJwt.getAlgorithm(), is(equalTo(deserializedJwt.getAlgorithm())));
         assertThat(originalJwt.getAudience(), is(equalTo(deserializedJwt.getAudience())));
         assertThat(originalJwt.getContentType(), is(equalTo(deserializedJwt.getContentType())));
-        assertThat(originalJwt.getExpiresAt(), is(equalTo(deserializedJwt.getExpiresAt())));
+        assertThat(originalJwt.getExpiresAtInstant(), is(equalTo(deserializedJwt.getExpiresAtInstant())));
         assertThat(originalJwt.getId(), is(equalTo(deserializedJwt.getId())));
-        assertThat(originalJwt.getIssuedAt(), is(equalTo(deserializedJwt.getIssuedAt())));
+        assertThat(originalJwt.getIssuedAtInstant(), is(equalTo(deserializedJwt.getIssuedAtInstant())));
         assertThat(originalJwt.getIssuer(), is(equalTo(deserializedJwt.getIssuer())));
         assertThat(originalJwt.getKeyId(), is(equalTo(deserializedJwt.getKeyId())));
-        assertThat(originalJwt.getNotBefore(), is(equalTo(deserializedJwt.getNotBefore())));
+        assertThat(originalJwt.getNotBeforeInstant(), is(equalTo(deserializedJwt.getNotBeforeInstant())));
         assertThat(originalJwt.getSubject(), is(equalTo(deserializedJwt.getSubject())));
         assertThat(originalJwt.getType(), is(equalTo(deserializedJwt.getType())));
         assertThat(originalJwt.getClaims().get("extraClaim").asString(),

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -14,7 +14,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -131,33 +131,33 @@ public class JWTDecoderTest {
     public void shouldGetExpirationTime() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0NzY3MjcwODZ9.L9dcPHEDQew2u9MkDCORFkfDGcSOsgoPqNY-LUMLEHg");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
+        assertThat(jwt.getExpiresAt(), is(instanceOf(Instant.class)));
         long ms = 1476727086L * 1000;
-        Date expectedDate = new Date(ms);
+        Instant expectedInstant = Instant.ofEpochMilli(ms);
         assertThat(jwt.getExpiresAt(), is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getExpiresAt(), is(equalTo(expectedInstant)));
     }
 
     @Test
     public void shouldGetNotBefore() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0NzY3MjcwODZ9.tkpD3iCPQPVqjnjpDVp2bJMBAgpVCG9ZjlBuMitass0");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
+        assertThat(jwt.getNotBefore(), is(instanceOf(Instant.class)));
         long ms = 1476727086L * 1000;
-        Date expectedDate = new Date(ms);
+        Instant expectedInstant = Instant.ofEpochMilli(ms);
         assertThat(jwt.getNotBefore(), is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
+        assertThat(jwt.getNotBefore(), is(equalTo(expectedInstant)));
     }
 
     @Test
     public void shouldGetIssuedAt() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0NzY3MjcwODZ9.KPjGoW665E8V5_27Jugab8qSTxLk2cgquhPCBfAP0_w");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
+        assertThat(jwt.getIssuedAt(), is(instanceOf(Instant.class)));
         long ms = 1476727086L * 1000;
-        Date expectedDate = new Date(ms);
+        Instant expectedInstant = Instant.ofEpochMilli(ms);
         assertThat(jwt.getIssuedAt(), is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getIssuedAt(), is(equalTo(expectedInstant)));
     }
 
     @Test
@@ -241,10 +241,10 @@ public class JWTDecoderTest {
     @Test
     public void shouldGetCustomClaimOfTypeDate() {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
-        Date date = new Date(1478891521000L);
+        Instant instant = Instant.ofEpochMilli(1478891521000L);
         DecodedJWT jwt = JWT.decode(token);
         Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asDate().getTime(), is(date.getTime()));
+        Assert.assertThat(jwt.getClaim("name").asInstant().getEpochSecond(), is(instant.getEpochSecond()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -26,7 +26,7 @@ public class JWTDecoderTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void getSubject() throws Exception {
+    public void getSubject() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ");
         assertThat(jwt.getSubject(), is(notNullValue()));
         assertThat(jwt.getSubject(), is("1234567890"));
@@ -162,7 +162,7 @@ public class JWTDecoderTest {
     }
 
     @Test
-    public void shouldGetExpirationTimeAsInstant() throws Exception {
+    public void shouldGetExpirationTimeAsInstant() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0NzY3MjcwODZ9.L9dcPHEDQew2u9MkDCORFkfDGcSOsgoPqNY-LUMLEHg");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getExpiresAtInstant(), is(instanceOf(Instant.class)));
@@ -173,7 +173,7 @@ public class JWTDecoderTest {
     }
 
     @Test
-    public void shouldGetNotBeforeAsInstant() throws Exception {
+    public void shouldGetNotBeforeAsInstant() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0NzY3MjcwODZ9.tkpD3iCPQPVqjnjpDVp2bJMBAgpVCG9ZjlBuMitass0");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getNotBeforeInstant(), is(instanceOf(Instant.class)));
@@ -184,7 +184,7 @@ public class JWTDecoderTest {
     }
 
     @Test
-    public void shouldGetIssuedAtAsInstant() throws Exception {
+    public void shouldGetIssuedAtAsInstant() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0NzY3MjcwODZ9.KPjGoW665E8V5_27Jugab8qSTxLk2cgquhPCBfAP0_w");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getIssuedAtInstant(), is(instanceOf(Instant.class)));
@@ -282,7 +282,7 @@ public class JWTDecoderTest {
     }
 
     @Test
-    public void shouldGetCustomClaimOfTypeInstant() throws Exception {
+    public void shouldGetCustomClaimOfTypeInstant() {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
         Instant instant = Instant.ofEpochMilli(1478891521000L);
         DecodedJWT jwt = JWT.decode(token);

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import java.time.Instant;
+import java.util.Date;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -268,9 +269,9 @@ public class JWTTest {
 
     @Test
     public void shouldGetExpirationTime() throws Exception {
-        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
+        Date expectedDate = new Date(1477592 * 1000);
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(expectedDate);
+        when(clock.getNow()).thenReturn(expectedDate.toInstant());
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTJ9.x_ZjkPkKYUV5tdvc0l8go6D_z2kez1MQcOxokXrDc3k";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -279,16 +280,16 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
         assertThat(jwt.getExpiresAt(), is(notNullValue()));
         assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
     }
 
     @Test
     public void shouldGetNotBefore() throws Exception {
-        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
+        Date expectedDate = new Date(1477592 * 1000);
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(expectedDate);
+        when(clock.getNow()).thenReturn(expectedDate.toInstant());
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0Nzc1OTJ9.mWYSOPoNXstjKbZkKrqgkwPOQWEx3F3gMm6PMcfuJd8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -297,16 +298,16 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
         assertThat(jwt.getNotBefore(), is(notNullValue()));
         assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
     }
 
     @Test
     public void shouldGetIssuedAt() throws Exception {
-        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
+        Date expectedDate = new Date(1477592 * 1000);
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(expectedDate);
+        when(clock.getNow()).thenReturn(expectedDate.toInstant());
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.5o1CKlLFjKKcddZzoarQ37pq7qZqNPav3sdZ_bsZaD4";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -315,13 +316,67 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
         assertThat(jwt.getIssuedAt(), is(notNullValue()));
         assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
     }
 
     @Test
-    public void shouldGetId() {
+    public void shouldGetExpirationTimeAsInstant() throws Exception {
+        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(expectedDate);
+
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTJ9.x_ZjkPkKYUV5tdvc0l8go6D_z2kez1MQcOxokXrDc3k";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getExpiresAtInstant(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getExpiresAtInstant(), is(notNullValue()));
+        assertThat(jwt.getExpiresAtInstant(), is(equalTo(expectedDate)));
+    }
+
+    @Test
+    public void shouldGetNotBeforeAsInstant() throws Exception {
+        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(expectedDate);
+
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0Nzc1OTJ9.mWYSOPoNXstjKbZkKrqgkwPOQWEx3F3gMm6PMcfuJd8";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getNotBeforeInstant(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getNotBeforeInstant(), is(notNullValue()));
+        assertThat(jwt.getNotBeforeInstant(), is(equalTo(expectedDate)));
+    }
+
+    @Test
+    public void shouldGetIssuedAtAsInstant() throws Exception {
+        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(expectedDate);
+
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.5o1CKlLFjKKcddZzoarQ37pq7qZqNPav3sdZ_bsZaD4";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getIssuedAtInstant(), is(instanceOf(Instant.class)));
+        assertThat(jwt.getIssuedAtInstant(), is(notNullValue()));
+        assertThat(jwt.getIssuedAtInstant(), is(equalTo(expectedDate)));
+    }
+
+    @Test
+    public void shouldGetId() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMjM0NTY3ODkwIn0.m3zgEfVUFOd-CvL3xG5BuOWLzb0zMQZCqiVNQQOPOvA";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
         DecodedJWT jwt = verification

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -13,7 +13,7 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
-import java.util.Date;
+import java.time.Instant;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -267,8 +267,8 @@ public class JWTTest {
     }
 
     @Test
-    public void shouldGetExpirationTime() {
-        Date expectedDate = new Date(1477592 * 1000);
+    public void shouldGetExpirationTime() throws Exception {
+        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(expectedDate);
 
@@ -279,14 +279,14 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
+        assertThat(jwt.getExpiresAt(), is(instanceOf(Instant.class)));
         assertThat(jwt.getExpiresAt(), is(notNullValue()));
         assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
     }
 
     @Test
-    public void shouldGetNotBefore() {
-        Date expectedDate = new Date(1477592 * 1000);
+    public void shouldGetNotBefore() throws Exception {
+        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(expectedDate);
 
@@ -297,14 +297,14 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
+        assertThat(jwt.getNotBefore(), is(instanceOf(Instant.class)));
         assertThat(jwt.getNotBefore(), is(notNullValue()));
         assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
     }
 
     @Test
-    public void shouldGetIssuedAt() {
-        Date expectedDate = new Date(1477592 * 1000);
+    public void shouldGetIssuedAt() throws Exception {
+        Instant expectedDate = Instant.ofEpochMilli(1477592 * 1000);
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(expectedDate);
 
@@ -315,7 +315,7 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
+        assertThat(jwt.getIssuedAt(), is(instanceOf(Instant.class)));
         assertThat(jwt.getIssuedAt(), is(notNullValue()));
         assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
     }

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -269,9 +269,10 @@ public class JWTTest {
 
     @Test
     public void shouldGetExpirationTime() throws Exception {
-        Date expectedDate = new Date(1477592 * 1000);
+        Instant expectedInstant = Instant.ofEpochSecond(1477592);
         Clock clock = mock(Clock.class);
-        when(clock.getNow()).thenReturn(expectedDate.toInstant());
+        // implementation uses getNow instead of getToday, so need to mock that call
+        when(clock.getNow()).thenReturn(expectedInstant);
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTJ9.x_ZjkPkKYUV5tdvc0l8go6D_z2kez1MQcOxokXrDc3k";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -282,14 +283,15 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
         assertThat(jwt.getExpiresAt(), is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getExpiresAt(), is(equalTo(Date.from(expectedInstant))));
     }
 
     @Test
     public void shouldGetNotBefore() throws Exception {
-        Date expectedDate = new Date(1477592 * 1000);
+        Instant expectedInstant = Instant.ofEpochSecond(1477592);
         Clock clock = mock(Clock.class);
-        when(clock.getNow()).thenReturn(expectedDate.toInstant());
+        // implementation uses getNow instead of getToday, so need to mock that call
+        when(clock.getNow()).thenReturn(expectedInstant);
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0Nzc1OTJ9.mWYSOPoNXstjKbZkKrqgkwPOQWEx3F3gMm6PMcfuJd8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -300,14 +302,15 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
         assertThat(jwt.getNotBefore(), is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
+        assertThat(jwt.getNotBefore(), is(equalTo(Date.from(expectedInstant))));
     }
 
     @Test
     public void shouldGetIssuedAt() throws Exception {
-        Date expectedDate = new Date(1477592 * 1000);
+        Instant expectedInstant = Instant.ofEpochSecond(1477592);
         Clock clock = mock(Clock.class);
-        when(clock.getNow()).thenReturn(expectedDate.toInstant());
+        // implementation uses getNow instead of getToday, so need to mock that call
+        when(clock.getNow()).thenReturn(expectedInstant);
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.5o1CKlLFjKKcddZzoarQ37pq7qZqNPav3sdZ_bsZaD4";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -318,7 +321,7 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
         assertThat(jwt.getIssuedAt(), is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getIssuedAt(), is(equalTo(Date.from(expectedInstant))));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -10,7 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -220,7 +220,7 @@ public class JWTVerifierTest {
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", new Date())
+                .withClaim("name", Instant.now())
                 .build()
                 .verify(token);
     }
@@ -294,9 +294,9 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateCustomClaimOfTypeDate() {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
-        Date date = new Date(1478891521000L);
+        Instant instant = Instant.ofEpochMilli(1478891521000L);
         DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
-                .withClaim("name", date)
+                .withClaim("name", instant)
                 .build()
                 .verify(token);
 
@@ -411,7 +411,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateExpiresAtWithLeeway() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
@@ -426,7 +426,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateExpiresAtIfPresent() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -442,7 +442,7 @@ public class JWTVerifierTest {
         exception.expect(TokenExpiredException.class);
         exception.expectMessage(startsWith("The Token has expired on"));
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE + 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -464,7 +464,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateNotBeforeWithLeeway() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
@@ -481,7 +481,7 @@ public class JWTVerifierTest {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -493,7 +493,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateNotBeforeIfPresent() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -513,11 +513,11 @@ public class JWTVerifierTest {
                 .acceptNotBefore(-1);
     }
 
-// Issued At with future date
+    // Issued At with future date
     @Test (expected = InvalidClaimException.class)
     public void shouldThrowOnFutureIssuedAt() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.CWq-6pUXl1bFg81vqOUZbZrheO2kUBd2Xr3FUZmvudE";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -530,7 +530,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldSkipIssuedAtVerificationWhenFlagIsPassed() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.CWq-6pUXl1bFg81vqOUZbZrheO2kUBd2Xr3FUZmvudE";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -545,7 +545,7 @@ public class JWTVerifierTest {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -557,7 +557,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtFlagPassedAndSkipTheVerification() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -571,7 +571,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateIssuedAtIfPresent() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE));
+        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -613,8 +613,11 @@ public class JWTVerifierTest {
     }
 
     // Issued At with future date
-    @Test(expected = InvalidClaimException.class)
+    @Test
     public void shouldThrowOnFutureIssuedAtDate() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Token can't be used before 1970-01-18T02:26:32Z.");
+
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -625,8 +628,11 @@ public class JWTVerifierTest {
         assertThat(jwt, is(notNullValue()));
     }
 
-    @Test (expected = InvalidClaimException.class)
+    @Test
     public void shouldThrowOnFutureIssuedAtInstant() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Token can't be used before 1970-01-18T02:26:32Z.");
+
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -226,7 +226,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidCustomClaimValueOfTypeInstant() throws Exception {
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeInstant() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
@@ -420,7 +420,7 @@ public class JWTVerifierTest {
 
     // Expires At
     @Test
-    public void shouldValidateExpiresDateAtWithLeeway() throws Exception {
+    public void shouldValidateExpiresDateAtWithLeeway() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
@@ -436,7 +436,7 @@ public class JWTVerifierTest {
 
 
     @Test
-    public void shouldValidateExpiresInstantAtWithLeeway() throws Exception {
+    public void shouldValidateExpiresInstantAtWithLeeway() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
@@ -451,7 +451,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateExpiresAtDateIfPresent() throws Exception {
+    public void shouldValidateExpiresAtDateIfPresent() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -465,7 +465,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateExpiresAtInstantIfPresent() throws Exception {
+    public void shouldValidateExpiresAtInstantIfPresent() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -479,7 +479,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidExpiresAtDateIfPresent() throws Exception {
+    public void shouldThrowOnInvalidExpiresAtDateIfPresent() {
         exception.expect(TokenExpiredException.class);
         exception.expectMessage(startsWith("The Token has expired on"));
         Clock clock = mock(Clock.class);
@@ -493,7 +493,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidExpiresAtInstantIfPresent() throws Exception {
+    public void shouldThrowOnInvalidExpiresAtInstantIfPresent() {
         exception.expect(TokenExpiredException.class);
         exception.expectMessage(startsWith("The Token has expired on"));
         Clock clock = mock(Clock.class);
@@ -517,7 +517,7 @@ public class JWTVerifierTest {
 
     // Not before
     @Test
-    public void shouldValidateNotBeforeDateWithLeeway() throws Exception {
+    public void shouldValidateNotBeforeDateWithLeeway() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -533,7 +533,7 @@ public class JWTVerifierTest {
 
 
     @Test
-    public void shouldValidateNotBeforeInstantWithLeeway() throws Exception {
+    public void shouldValidateNotBeforeInstantWithLeeway() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -548,7 +548,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidNotBeforeDateIfPresent() throws Exception {
+    public void shouldThrowOnInvalidNotBeforeDateIfPresent() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
@@ -562,7 +562,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidNotBeforeInstantIfPresent() throws Exception {
+    public void shouldThrowOnInvalidNotBeforeInstantIfPresent() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
@@ -576,7 +576,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateNotBeforeDateIfPresent() throws Exception {
+    public void shouldValidateNotBeforeDateIfPresent() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -590,7 +590,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateNotBeforeInstantIfPresent() throws Exception {
+    public void shouldValidateNotBeforeInstantIfPresent() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -614,7 +614,7 @@ public class JWTVerifierTest {
 
     // Issued At with future date
     @Test
-    public void shouldThrowOnFutureIssuedAtDate() throws Exception {
+    public void shouldThrowOnFutureIssuedAtDate() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Token can't be used before 1970-01-18T02:26:32Z.");
 
@@ -629,7 +629,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnFutureIssuedAtInstant() throws Exception {
+    public void shouldThrowOnFutureIssuedAtInstant() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Token can't be used before 1970-01-18T02:26:32Z.");
 
@@ -645,7 +645,7 @@ public class JWTVerifierTest {
 
     // Issued At with future date and ignore flag
     @Test
-    public void shouldSkipIssuedAtDateVerificationWhenFlagIsPassed() throws Exception {
+    public void shouldSkipIssuedAtDateVerificationWhenFlagIsPassed() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -658,7 +658,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldSkipIssuedAtInstantVerificationWhenFlagIsPassed() throws Exception {
+    public void shouldSkipIssuedAtInstantVerificationWhenFlagIsPassed() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -671,7 +671,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidIssuedAtDateIfPresent() throws Exception {
+    public void shouldThrowOnInvalidIssuedAtDateIfPresent() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
@@ -685,7 +685,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidIssuedAtInstantIfPresent() throws Exception {
+    public void shouldThrowOnInvalidIssuedAtInstantIfPresent() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
@@ -699,7 +699,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtDateFlagPassedAndSkipTheVerification() throws Exception {
+    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtDateFlagPassedAndSkipTheVerification() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -713,7 +713,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtInstantFlagPassedAndSkipTheVerification() throws Exception {
+    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtInstantFlagPassedAndSkipTheVerification() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -727,7 +727,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateIssuedAtDateIfPresent() throws Exception {
+    public void shouldValidateIssuedAtDateIfPresent() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -741,7 +741,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateIssuedAtInstantIfPresent() throws Exception {
+    public void shouldValidateIssuedAtInstantIfPresent() {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -213,9 +214,19 @@ public class JWTVerifierTest {
                 .verify(token);
     }
 
-
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", new Date())
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidCustomClaimValueOfTypeInstant() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
@@ -409,7 +420,23 @@ public class JWTVerifierTest {
 
     // Expires At
     @Test
-    public void shouldValidateExpiresAtWithLeeway() {
+    public void shouldValidateExpiresDateAtWithLeeway() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .acceptExpiresAt(2);
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+
+    @Test
+    public void shouldValidateExpiresInstantAtWithLeeway() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
@@ -424,7 +451,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateExpiresAtIfPresent() {
+    public void shouldValidateExpiresAtDateIfPresent() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -438,7 +465,35 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidExpiresAtIfPresent() {
+    public void shouldValidateExpiresAtInstantIfPresent() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnInvalidExpiresAtDateIfPresent() throws Exception {
+        exception.expect(TokenExpiredException.class);
+        exception.expectMessage(startsWith("The Token has expired on"));
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification
+                .build(clock)
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowOnInvalidExpiresAtInstantIfPresent() throws Exception {
         exception.expect(TokenExpiredException.class);
         exception.expectMessage(startsWith("The Token has expired on"));
         Clock clock = mock(Clock.class);
@@ -462,7 +517,23 @@ public class JWTVerifierTest {
 
     // Not before
     @Test
-    public void shouldValidateNotBeforeWithLeeway() {
+    public void shouldValidateNotBeforeDateWithLeeway() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .acceptNotBefore(2);
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+
+    @Test
+    public void shouldValidateNotBeforeInstantWithLeeway() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -477,7 +548,7 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidNotBeforeIfPresent() {
+    public void shouldThrowOnInvalidNotBeforeDateIfPresent() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
@@ -491,7 +562,35 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateNotBeforeIfPresent() {
+    public void shouldThrowOnInvalidNotBeforeInstantIfPresent() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage(startsWith("The Token can't be used before"));
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification
+                .build(clock)
+                .verify(token);
+    }
+
+    @Test
+    public void shouldValidateNotBeforeDateIfPresent() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateNotBeforeInstantIfPresent() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
@@ -514,8 +613,20 @@ public class JWTVerifierTest {
     }
 
     // Issued At with future date
+    @Test(expected = InvalidClaimException.class)
+    public void shouldThrowOnFutureIssuedAtDate() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.CWq-6pUXl1bFg81vqOUZbZrheO2kUBd2Xr3FUZmvudE";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+
+        DecodedJWT jwt = verification.build(clock).verify(token);
+        assertThat(jwt, is(notNullValue()));
+    }
+
     @Test (expected = InvalidClaimException.class)
-    public void shouldThrowOnFutureIssuedAt() {
+    public void shouldThrowOnFutureIssuedAtInstant() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -528,7 +639,7 @@ public class JWTVerifierTest {
 
     // Issued At with future date and ignore flag
     @Test
-    public void shouldSkipIssuedAtVerificationWhenFlagIsPassed() {
+    public void shouldSkipIssuedAtDateVerificationWhenFlagIsPassed() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -541,7 +652,20 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldThrowOnInvalidIssuedAtIfPresent() {
+    public void shouldSkipIssuedAtInstantVerificationWhenFlagIsPassed() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.CWq-6pUXl1bFg81vqOUZbZrheO2kUBd2Xr3FUZmvudE";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification.ignoreIssuedAt();
+
+        DecodedJWT jwt = verification.build(clock).verify(token);
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnInvalidIssuedAtDateIfPresent() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
@@ -555,7 +679,21 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtFlagPassedAndSkipTheVerification() {
+    public void shouldThrowOnInvalidIssuedAtInstantIfPresent() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage(startsWith("The Token can't be used before"));
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        verification
+                .build(clock)
+                .verify(token);
+    }
+
+    @Test
+    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtDateFlagPassedAndSkipTheVerification() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -569,7 +707,35 @@ public class JWTVerifierTest {
     }
 
     @Test
-    public void shouldValidateIssuedAtIfPresent() {
+    public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtInstantFlagPassedAndSkipTheVerification() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification.acceptIssuedAt(20).ignoreIssuedAt()
+                .build()
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateIssuedAtDateIfPresent() throws Exception {
+        Clock clock = mock(Clock.class);
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
+
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = verification
+                .build(clock)
+                .verify(token);
+
+        assertThat(jwt, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateIssuedAtInstantIfPresent() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -411,7 +411,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateExpiresAtWithLeeway() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
@@ -426,7 +426,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateExpiresAtIfPresent() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -442,7 +442,7 @@ public class JWTVerifierTest {
         exception.expect(TokenExpiredException.class);
         exception.expectMessage(startsWith("The Token has expired on"));
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE + 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -464,7 +464,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateNotBeforeWithLeeway() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
@@ -481,7 +481,7 @@ public class JWTVerifierTest {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0Nzc1OTJ9.wq4ZmnSF2VOxcQBxPLfeh1J2Ozy1Tj5iUaERm3FKaw8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -493,7 +493,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateNotBeforeIfPresent() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -517,7 +517,7 @@ public class JWTVerifierTest {
     @Test (expected = InvalidClaimException.class)
     public void shouldThrowOnFutureIssuedAt() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.CWq-6pUXl1bFg81vqOUZbZrheO2kUBd2Xr3FUZmvudE";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -530,7 +530,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldSkipIssuedAtVerificationWhenFlagIsPassed() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.CWq-6pUXl1bFg81vqOUZbZrheO2kUBd2Xr3FUZmvudE";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -545,7 +545,7 @@ public class JWTVerifierTest {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -557,7 +557,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtFlagPassedAndSkipTheVerification() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE - 1000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
@@ -571,7 +571,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateIssuedAtIfPresent() {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
+        when(clock.getNow()).thenReturn(Instant.ofEpochMilli(DATE_TOKEN_MS_VALUE));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -20,6 +20,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatchers;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
@@ -119,16 +120,16 @@ public class JsonNodeClaimTest {
         JsonNode value = mapper.valueToTree(1476824844L);
         Claim claim = claimFromNode(value);
 
-        assertThat(claim.asDate(), is(notNullValue()));
-        assertThat(claim.asDate(), is(new Date(1476824844L * 1000)));
+        assertThat(claim.asInstant(), is(notNullValue()));
+        assertThat(claim.asInstant(), is(Instant.ofEpochSecond(1476824844L)));
     }
 
     @Test
     public void shouldGetNullDateIfNotDateValue() {
         JsonNode objectValue = mapper.valueToTree(new Object());
-        assertThat(claimFromNode(objectValue).asDate(), is(nullValue()));
+        assertThat(claimFromNode(objectValue).asInstant(), is(nullValue()));
         JsonNode stringValue = mapper.valueToTree("1476824844");
-        assertThat(claimFromNode(stringValue).asDate(), is(nullValue()));
+        assertThat(claimFromNode(stringValue).asInstant(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -120,6 +120,8 @@ public class JsonNodeClaimTest {
         JsonNode value = mapper.valueToTree(1476824844L);
         Claim claim = claimFromNode(value);
 
+        assertThat(claim.asDate(), is(notNullValue()));
+        assertThat(claim.asDate(), is(new Date(1476824844L * 1000)));
         assertThat(claim.asInstant(), is(notNullValue()));
         assertThat(claim.asInstant(), is(Instant.ofEpochSecond(1476824844L)));
     }
@@ -127,8 +129,10 @@ public class JsonNodeClaimTest {
     @Test
     public void shouldGetNullDateIfNotDateValue() {
         JsonNode objectValue = mapper.valueToTree(new Object());
+        assertThat(claimFromNode(objectValue).asDate(), is(nullValue()));
         assertThat(claimFromNode(objectValue).asInstant(), is(nullValue()));
         JsonNode stringValue = mapper.valueToTree("1476824844");
+        assertThat(claimFromNode(stringValue).asDate(), is(nullValue()));
         assertThat(claimFromNode(stringValue).asInstant(), is(nullValue()));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -47,6 +47,11 @@ public class NullClaimTest {
 
     @Test
     public void shouldGetAsDate() throws Exception {
+        assertThat(claim.asDate(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAsInstant() throws Exception {
         assertThat(claim.asInstant(), is(nullValue()));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -46,8 +46,8 @@ public class NullClaimTest {
     }
 
     @Test
-    public void shouldGetAsDate() {
-        assertThat(claim.asDate(), is(nullValue()));
+    public void shouldGetAsDate() throws Exception {
+        assertThat(claim.asInstant(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -46,12 +46,12 @@ public class NullClaimTest {
     }
 
     @Test
-    public void shouldGetAsDate() throws Exception {
+    public void shouldGetAsDate() {
         assertThat(claim.asDate(), is(nullValue()));
     }
 
     @Test
-    public void shouldGetAsInstant() throws Exception {
+    public void shouldGetAsInstant() {
         assertThat(claim.asInstant(), is(nullValue()));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -94,9 +94,12 @@ public class PayloadDeserializerTest {
         assertThat(payload.getIssuer(), is("auth0"));
         assertThat(payload.getSubject(), is("emails"));
         assertThat(payload.getAudience(), is(IsCollectionContaining.hasItem("users")));
-        assertThat(payload.getIssuedAt().toEpochMilli(), is(10101010L * 1000));
-        assertThat(payload.getExpiresAt().toEpochMilli(), is(11111111L * 1000));
-        assertThat(payload.getNotBefore().toEpochMilli(), is(10101011L * 1000));
+        assertThat(payload.getIssuedAt().getTime(), is(10101010L * 1000));
+        assertThat(payload.getExpiresAt().getTime(), is(11111111L * 1000));
+        assertThat(payload.getNotBefore().getTime(), is(10101011L * 1000));
+        assertThat(payload.getIssuedAtInstant().toEpochMilli(), is(10101010L * 1000));
+        assertThat(payload.getExpiresAtInstant().toEpochMilli(), is(11111111L * 1000));
+        assertThat(payload.getNotBeforeInstant().toEpochMilli(), is(10101011L * 1000));
         assertThat(payload.getId(), is("idid"));
 
         assertThat(payload.getClaim("roles").asString(), is("admin"));

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -183,7 +183,7 @@ public class PayloadDeserializerTest {
 
 
     @Test
-    public void shouldGetNullInstantWhenParsingNullNode() throws Exception {
+    public void shouldGetNullInstantWhenParsingNullNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         NullNode node = NullNode.getInstance();
         tree.put("key", node);
@@ -193,7 +193,7 @@ public class PayloadDeserializerTest {
     }
 
     @Test
-    public void shouldGetNullInstantWhenParsingNull() throws Exception {
+    public void shouldGetNullInstantWhenParsingNull() {
         Map<String, JsonNode> tree = new HashMap<>();
         tree.put("key", null);
 
@@ -214,7 +214,7 @@ public class PayloadDeserializerTest {
     }
 
     @Test
-    public void shouldGetInstantWhenParsingNumericNode() throws Exception {
+    public void shouldGetInstantWhenParsingNumericNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         long seconds = 1478627949 / 1000;
         LongNode node = new LongNode(seconds);
@@ -226,7 +226,7 @@ public class PayloadDeserializerTest {
     }
 
     @Test
-    public void shouldGetLargeInstantWhenParsingNumericNode() throws Exception {
+    public void shouldGetLargeInstantWhenParsingNumericNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         long seconds = Integer.MAX_VALUE + 10000L;
         LongNode node = new LongNode(seconds);

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
@@ -93,9 +94,9 @@ public class PayloadDeserializerTest {
         assertThat(payload.getIssuer(), is("auth0"));
         assertThat(payload.getSubject(), is("emails"));
         assertThat(payload.getAudience(), is(IsCollectionContaining.hasItem("users")));
-        assertThat(payload.getIssuedAt().getTime(), is(10101010L * 1000));
-        assertThat(payload.getExpiresAt().getTime(), is(11111111L * 1000));
-        assertThat(payload.getNotBefore().getTime(), is(10101011L * 1000));
+        assertThat(payload.getIssuedAt().toEpochMilli(), is(10101010L * 1000));
+        assertThat(payload.getExpiresAt().toEpochMilli(), is(11111111L * 1000));
+        assertThat(payload.getNotBefore().toEpochMilli(), is(10101011L * 1000));
         assertThat(payload.getId(), is("idid"));
 
         assertThat(payload.getClaim("roles").asString(), is("admin"));
@@ -179,22 +180,22 @@ public class PayloadDeserializerTest {
 
 
     @Test
-    public void shouldGetNullDateWhenParsingNullNode() {
+    public void shouldGetNullInstantWhenParsingNullNode() throws Exception {
         Map<String, JsonNode> tree = new HashMap<>();
         NullNode node = NullNode.getInstance();
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(nullValue()));
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(nullValue()));
     }
 
     @Test
-    public void shouldGetNullDateWhenParsingNull() {
+    public void shouldGetNullInstantWhenParsingNull() throws Exception {
         Map<String, JsonNode> tree = new HashMap<>();
         tree.put("key", null);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(nullValue()));
+        Instant instant  = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(nullValue()));
     }
 
     @Test
@@ -206,32 +207,32 @@ public class PayloadDeserializerTest {
         TextNode node = new TextNode("123456789");
         tree.put("key", node);
 
-        deserializer.getDateFromSeconds(tree, "key");
+        deserializer.getInstantFromSeconds(tree, "key");
     }
 
     @Test
-    public void shouldGetDateWhenParsingNumericNode() {
+    public void shouldGetInstantWhenParsingNumericNode() throws Exception {
         Map<String, JsonNode> tree = new HashMap<>();
         long seconds = 1478627949 / 1000;
         LongNode node = new LongNode(seconds);
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(notNullValue()));
-        assertThat(date.getTime(), is(seconds * 1000));
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(notNullValue()));
+        assertThat(instant.toEpochMilli(), is(seconds * 1000));
     }
 
     @Test
-    public void shouldGetLargeDateWhenParsingNumericNode() {
+    public void shouldGetLargeInstantWhenParsingNumericNode() throws Exception {
         Map<String, JsonNode> tree = new HashMap<>();
         long seconds = Integer.MAX_VALUE + 10000L;
         LongNode node = new LongNode(seconds);
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(notNullValue()));
-        assertThat(date.getTime(), is(seconds * 1000));
-        assertThat(date.getTime(), is(2147493647L * 1000));
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(notNullValue()));
+        assertThat(instant.toEpochMilli(), is(seconds * 1000));
+        assertThat(instant.toEpochMilli(), is(2147493647L * 1000));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -11,10 +11,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +26,9 @@ public class PayloadImplTest {
     public ExpectedException exception = ExpectedException.none();
 
     private PayloadImpl payload;
-    private Date expiresAt;
-    private Date notBefore;
-    private Date issuedAt;
+    private Instant expiresAt;
+    private Instant notBefore;
+    private Instant issuedAt;
 
     private ObjectMapper mapper;
     private ObjectReader objectReader;
@@ -38,10 +37,10 @@ public class PayloadImplTest {
     public void setUp() {
         mapper = getDefaultObjectMapper();
         objectReader = mapper.reader();
-        
-        expiresAt = Mockito.mock(Date.class);
-        notBefore = Mockito.mock(Date.class);
-        issuedAt = Mockito.mock(Date.class);
+
+        expiresAt = Instant.now();
+        notBefore = Instant.now();
+        issuedAt = Instant.now();
         Map<String, JsonNode> tree = new HashMap<>();
         tree.put("extraClaim", new TextNode("extraValue"));
         payload = new PayloadImpl("issuer", "subject", Collections.singletonList("audience"), expiresAt, notBefore, issuedAt, "jwtId", tree, objectReader);

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -12,6 +12,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.sql.Date;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -98,7 +99,8 @@ public class PayloadImplTest {
     @Test
     public void shouldGetExpiresAt() {
         assertThat(payload, is(notNullValue()));
-        assertThat(payload.getExpiresAt(), is(expiresAt));
+        assertThat(payload.getExpiresAt(), is(Date.from(expiresAt)));
+        assertThat(payload.getExpiresAtInstant(), is(expiresAt));
     }
 
     @Test
@@ -106,12 +108,14 @@ public class PayloadImplTest {
         PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectReader);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getExpiresAt(), is(nullValue()));
+        assertThat(payload.getExpiresAtInstant(), is(nullValue()));
     }
 
     @Test
     public void shouldGetNotBefore() {
         assertThat(payload, is(notNullValue()));
-        assertThat(payload.getNotBefore(), is(notBefore));
+        assertThat(payload.getNotBefore(), is(Date.from(notBefore)));
+        assertThat(payload.getNotBeforeInstant(), is(notBefore));
     }
 
     @Test
@@ -119,12 +123,14 @@ public class PayloadImplTest {
         PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectReader);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getNotBefore(), is(nullValue()));
+        assertThat(payload.getNotBeforeInstant(), is(nullValue()));
     }
 
     @Test
     public void shouldGetIssuedAt() {
         assertThat(payload, is(notNullValue()));
-        assertThat(payload.getIssuedAt(), is(issuedAt));
+        assertThat(payload.getIssuedAt(), is(Date.from(issuedAt)));
+        assertThat(payload.getIssuedAtInstant(), is(issuedAt));
     }
 
     @Test
@@ -132,6 +138,7 @@ public class PayloadImplTest {
         PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectReader);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getIssuedAt(), is(nullValue()));
+        assertThat(payload.getIssuedAtInstant(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -9,8 +9,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -80,8 +80,8 @@ public class PayloadSerializerTest {
     }
 
     @Test
-    public void shouldSerializeNotBeforeDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("nbf", new Date(1478874000));
+    public void shouldSerializeNotBeforeInstantInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("nbf", Instant.ofEpochMilli(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -89,8 +89,8 @@ public class PayloadSerializerTest {
     }
 
     @Test
-    public void shouldSerializeIssuedAtDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("iat", new Date(1478874000));
+    public void shouldSerializeIssuedAtInstantInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("iat", Instant.ofEpochMilli(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -98,8 +98,8 @@ public class PayloadSerializerTest {
     }
 
     @Test
-    public void shouldSerializeExpiresAtDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("exp", new Date(1478874000));
+    public void shouldSerializeExpiresAtInstantInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("exp", Instant.ofEpochMilli(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -107,8 +107,8 @@ public class PayloadSerializerTest {
     }
 
     @Test
-    public void shouldSerializeCustomDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("birthdate", new Date(1478874000));
+    public void shouldSerializeCustomInstantInSeconds() throws Exception {
+        ClaimsHolder holder = holderFor("birthdate", Instant.ofEpochMilli(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -116,14 +116,14 @@ public class PayloadSerializerTest {
     }
 
     @Test
-    public void shouldSerializeDatesUsingLong() throws Exception {
+    public void shouldSerializeInstantsUsingLong() throws Exception {
         long secs = Integer.MAX_VALUE + 10000L;
-        Date date = new Date(secs * 1000L);
-        Map<String, Object> claims = new HashMap<>();
-        claims.put("iat", date);
-        claims.put("nbf", date);
-        claims.put("exp", date);
-        claims.put("ctm", date);
+        Instant instant = Instant.ofEpochSecond(secs);
+        Map<String, Object> claims = new HashMap<String, Object>();
+        claims.put("iat", instant);
+        claims.put("nbf", instant);
+        claims.put("exp", instant);
+        claims.put("ctm", instant);
         ClaimsHolder holder = new ClaimsHolder(claims);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();


### PR DESCRIPTION
### Changes

Adds new APIs for DateTime claims using [java.time.Instant](https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html)

**Motivations:**
- JDK8 introduced new Date/time classes to address issues with the legacy Date functionality. Over time developers have transitioned to the new APIs.
- Some of the improvements of `Instant` over date are immutability (thread-safe), better API design allowing for more natural time-based calculations, and nanosecond precision (as opposed to millisecond precision with `java.util.Date`).

This change adds the following new public APIs:

**Claim.java:**
- `Instant asInstant()`

**Clock.java:**
- `Instant getNow()`

**JWTCreator.java:**
- `Builder withNotBefore(Instant notBefore)`
- `Builder withIssuedAt(Instant issuedAt)`
- `Builder withClaim(String name, Instant value)`

**Payload.java:**
> Note that these methods are all post-fixed with `Instant`. This is to allow both the existing `java.util.Date` APIs to exist alongside the new APIs.
- `Instant getExpiresAtInstant()`
- `Instant getNotBeforeInstant()`
- `Instant getIssuedAtInstant()`

**Verification.java:**
- `Verification withClaim(String name, Instant value)`

A separate later PR will deprecate the `java.util.Date` APIs in favor of these new ones.

### References

There are many articles and resources regarding the new date/time APIs introduced in JDK8. [This article](https://www.baeldung.com/migrating-to-java-8-date-time-api) discusses it at a high level.

### Testing

Tests updated to use the new Date/Time APIs.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
