### PR TITLE
Handle missing expected array claim

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -307,81 +307,81 @@ public final class JWTCreator {
 
         /**
          * Add a custom Map Claim with the given items.
-         * 
+         * <p>
          * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
          * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
          * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
          * {@linkplain List}s can contain null elements.
          *
-         * @param name  the Claim's name.
-         * @param map the Claim's key-values.
+         * @param name the Claim's name.
+         * @param map  the Claim's key-values.
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null, or if the map contents does not validate.
          */
         public Builder withClaim(String name, Map<String, ?> map) throws IllegalArgumentException {
             assertNonNull(name);
             // validate map contents
-            if(!validateClaim(map)) {
+            if (!validateClaim(map)) {
                 throw new IllegalArgumentException("Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, map);
             return this;
-        }      
-        
+        }
+
         /**
          * Add a custom List Claim with the given items.
-         *
+         * <p>
          * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
          * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
          * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
          * {@linkplain List}s can contain null elements.
          *
-         * @param name  the Claim's name.
+         * @param name the Claim's name.
          * @param list the Claim's list of values.
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null, or if the list contents does not validate.
          */
-        
+
         public Builder withClaim(String name, List<?> list) throws IllegalArgumentException {
             assertNonNull(name);
             // validate list contents
-            if(!validateClaim(list)) {
+            if (!validateClaim(list)) {
                 throw new IllegalArgumentException("Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, list);
             return this;
-        }         
+        }
 
         private static boolean validateClaim(Map<?, ?> map) {
             // do not accept null values in maps
             for (Entry<?, ?> entry : map.entrySet()) {
                 Object value = entry.getValue();
-                if(value == null || !isSupportedType(value)) {
+                if (value == null || !isSupportedType(value)) {
                     return false;
                 }
-                
-                if(entry.getKey() == null || !(entry.getKey() instanceof String)) {
+
+                if (entry.getKey() == null || !(entry.getKey() instanceof String)) {
                     return false;
                 }
             }
             return true;
         }
-        
+
         private static boolean validateClaim(List<?> list) {
             // accept null values in list
             for (Object object : list) {
-                if(object != null && !isSupportedType(object)) {
+                if (object != null && !isSupportedType(object)) {
                     return false;
                 }
             }
             return true;
-        }        
+        }
 
         private static boolean isSupportedType(Object value) {
-            if(value instanceof List) {
-                return validateClaim((List<?>)value);
-            } else if(value instanceof Map) {
-                return validateClaim((Map<?, ?>)value);
+            if (value instanceof List) {
+                return validateClaim((List<?>) value);
+            } else if (value instanceof Map) {
+                return validateClaim((Map<?, ?>) value);
             } else {
                 return isBasicType(value);
             }
@@ -389,8 +389,8 @@ public final class JWTCreator {
 
         private static boolean isBasicType(Object value) {
             Class<?> c = value.getClass();
-            
-            if(c.isArray()) {
+
+            if (c.isArray()) {
                 return c == Integer[].class || c == Long[].class || c == String[].class;
             }
             return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Boolean.class;

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -168,7 +168,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             requireClaim(name, items);
             return this;
         }
-        
+
         /**
          * Require a specific Array Claim to contain at least the given items.
          *
@@ -178,11 +178,11 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
          * @throws IllegalArgumentException if the name is null.
          */
         @Override
-        public Verification withArrayClaim(String name, Long ... items) throws IllegalArgumentException {
+        public Verification withArrayClaim(String name, Long... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
             return this;
-        }        
+        }
 
         @Override
         public JWTVerifier build() {
@@ -220,7 +220,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             if (!claims.containsKey(PublicClaims.NOT_BEFORE)) {
                 claims.put(PublicClaims.NOT_BEFORE, defaultLeeway);
             }
-            if(ignoreIssuedAt) {
+            if (ignoreIssuedAt) {
                 claims.remove(PublicClaims.ISSUED_AT);
                 return;
             }
@@ -329,18 +329,18 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             Object[] claimAsObject = claim.as(Object[].class);
 
             // Jackson uses 'natural' mapping which uses Integer if value fits in 32 bits.
-            if(value instanceof Long[]) {
+            if (value instanceof Long[]) {
                 // convert Integers to Longs for comparison with equals
                 claimArr = new ArrayList<>(claimAsObject.length);
-                for(Object cao : claimAsObject) {
-                    if(cao instanceof Integer) {
-                        claimArr.add(((Integer)cao).longValue());
+                for (Object cao : claimAsObject) {
+                    if (cao instanceof Integer) {
+                        claimArr.add(((Integer) cao).longValue());
                     } else {
                         claimArr.add(cao);
                     }
                 }
             } else {
-                claimArr = Arrays.asList(claim.as(Object[].class));
+                claimArr = claim.isNull() ? Collections.emptyList() : Arrays.asList(claim.as(Object[].class));
             }
             List<Object> valueArr = Arrays.asList((Object[]) value);
             isValid = claimArr.containsAll(valueArr);

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -169,14 +169,6 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             return this;
         }
 
-        /**
-         * Require a specific Array Claim to contain at least the given items.
-         *
-         * @param name  the Claim's name.
-         * @param items the items the Claim must contain.
-         * @return this same Verification instance.
-         * @throws IllegalArgumentException if the name is null.
-         */
         @Override
         public Verification withArrayClaim(String name, Long... items) throws IllegalArgumentException {
             assertNonNull(name);

--- a/lib/src/main/java/com/auth0/jwt/interfaces/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/JWTVerifier.java
@@ -4,22 +4,22 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 
 
 public interface JWTVerifier {
-  
-  /**
-   * Performs the verification against the given Token
-   *
-   * @param token to verify.
-   * @return a verified and decoded JWT.
-   * @throws JWTVerificationException if any of the verification steps fail
-   */
-  DecodedJWT verify(String token) throws JWTVerificationException;
 
-  /**
-   * Performs the verification against the given decoded JWT
-   *
-   * @param jwt to verify.
-   * @return a verified and decoded JWT.
-   * @throws JWTVerificationException if any of the verification steps fail
-   */
-  DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException;
+    /**
+     * Performs the verification against the given Token
+     *
+     * @param token to verify.
+     * @return a verified and decoded JWT.
+     * @throws JWTVerificationException if any of the verification steps fail
+     */
+    DecodedJWT verify(String token) throws JWTVerificationException;
+
+    /**
+     * Performs the verification against the given decoded JWT
+     *
+     * @param jwt to verify.
+     * @return a verified and decoded JWT.
+     * @throws JWTVerificationException if any of the verification steps fail
+     */
+    DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException;
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -5,7 +5,6 @@ import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,13 +13,7 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -63,8 +56,8 @@ public class JWTCreatorTest {
     @Test
     public void shouldReturnBuilderIfNullMapIsProvided() throws Exception {
         String signed = JWTCreator.init()
-                                  .withHeader(null)
-                                  .sign(Algorithm.HMAC256("secret"));
+                .withHeader(null)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
     }
@@ -75,9 +68,9 @@ public class JWTCreatorTest {
         header.put(PublicClaims.KEY_ID, "xyz");
 
         String signed = JWTCreator.init()
-                                  .withKeyId("abc")
-                                  .withHeader(header)
-                                  .sign(Algorithm.HMAC256("secret"));
+                .withKeyId("abc")
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -91,9 +84,9 @@ public class JWTCreatorTest {
         header.put(PublicClaims.KEY_ID, "xyz");
 
         String signed = JWTCreator.init()
-                                  .withHeader(header)
-                                  .withKeyId("abc")
-                                  .sign(Algorithm.HMAC256("secret"));
+                .withHeader(header)
+                .withKeyId("abc")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -108,9 +101,9 @@ public class JWTCreatorTest {
         header.put("test2", "isSet");
 
         String signed = JWTCreator.init()
-                                  .withKeyId("test")
-                                  .withHeader(header)
-                                  .sign(Algorithm.HMAC256("secret"));
+                .withKeyId("test")
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -452,15 +445,15 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldRefuseCustomClaimOfTypeUserPojo() throws Exception{
+    public void shouldRefuseCustomClaimOfTypeUserPojo() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("test1", new UserPojo("Michael", 255));
 
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("pojo", data)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @SuppressWarnings("unchecked")
@@ -494,7 +487,7 @@ public class JWTCreatorTest {
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
-        
+
         String body = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> map = (Map<String, Object>) mapper.readValue(body, Map.class).get("data");
@@ -529,7 +522,7 @@ public class JWTCreatorTest {
         data.add(123.456d);
         data.add(new Date(123L));
         data.add(true);
-        
+
         // array types
         data.add(new Integer[]{3, 5});
         data.add(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE});
@@ -548,18 +541,18 @@ public class JWTCreatorTest {
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
-        
+
         String body = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
         ObjectMapper mapper = new ObjectMapper();
         List<Object> list = (List<Object>) mapper.readValue(body, Map.class).get("data");
-        
+
         assertThat(list.get(0), is("abc"));
         assertThat(list.get(1), is(1));
         assertThat(list.get(2), is(Long.MAX_VALUE));
         assertThat(list.get(3), is(123.456d));
         assertThat(list.get(4), is(123));
         assertThat(list.get(5), is(true));
-        
+
         // array types
         assertThat(list.get(6), is(Arrays.asList(new Integer[]{3, 5})));
         assertThat(list.get(7), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
@@ -572,87 +565,87 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldAcceptCustomClaimForNullListItem() throws Exception{
+    public void shouldAcceptCustomClaimForNullListItem() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("test1", Arrays.asList("a", null, "c"));
-        
+
         JWTCreator.init()
-                 .withClaim("pojo", data)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
-    public void shouldRefuseCustomClaimForNullMapValue() throws Exception{
+    public void shouldRefuseCustomClaimForNullMapValue() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("subKey", null);
-        
+
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("pojo", data)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
-    public void shouldRefuseCustomClaimForNullMapKey() throws Exception{
+    public void shouldRefuseCustomClaimForNullMapKey() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put(null, "subValue");
-        
+
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("pojo", data)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldRefuseCustomMapClaimForNonStringKey() throws Exception{
+    public void shouldRefuseCustomMapClaimForNonStringKey() throws Exception {
         Map data = new HashMap<>();
         data.put(new Object(), "value");
-        
+
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("pojo", (Map<String, Object>)data)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("pojo", (Map<String, Object>) data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
-    public void shouldRefuseCustomListClaimForUnknownListElement() throws Exception{
+    public void shouldRefuseCustomListClaimForUnknownListElement() throws Exception {
         List<Object> list = Arrays.asList(new UserPojo("Michael", 255));
 
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("list", list)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("list", list)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
-    public void shouldRefuseCustomListClaimForUnknownListElementWrappedInAMap() throws Exception{
+    public void shouldRefuseCustomListClaimForUnknownListElementWrappedInAMap() throws Exception {
         List<Object> list = Arrays.asList(new UserPojo("Michael", 255));
-        
+
         Map<String, Object> data = new HashMap<>();
         data.put("someList", list);
 
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("list", list)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("list", list)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
-    public void shouldRefuseCustomListClaimForUnknownArrayType() throws Exception{
+    public void shouldRefuseCustomListClaimForUnknownArrayType() throws Exception {
         List<Object> list = new ArrayList<>();
-        list.add(new Object[] {"test"});
+        list.add(new Object[]{"test"});
 
         exception.expect(IllegalArgumentException.class);
 
         JWTCreator.init()
-                 .withClaim("list", list)
-                 .sign(Algorithm.HMAC256("secret"));
+                .withClaim("list", list)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -171,6 +171,28 @@ public class JWTVerifierTest {
     }
 
     @Test
+    public void shouldThrowWhenExpectedArrayClaimIsMissing() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'missing' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcnJheSI6WzEsMiwzXX0.wKNFBcMdwIpdF9rXRxvexrzSM6umgSFqRO1WZj992YM";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withArrayClaim("missing", 1, 2, 3)
+                .build()
+                .verify(token);
+    }
+
+    @Test
+    public void shouldThrowWhenExpectedClaimIsMissing() throws Exception {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'missing' value doesn't match the required one.");
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGFpbSI6InRleHQifQ.aZ27Ze35VvTqxpaSIK5ZcnYHr4SrvANlUbDR8fw9qsQ";
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("missing", "text")
+                .build()
+                .verify(token);
+    }
+
+    @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeString() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
@@ -546,8 +568,8 @@ public class JWTVerifierTest {
                 .acceptNotBefore(-1);
     }
 
-// Issued At with future date
-    @Test (expected = InvalidClaimException.class)
+    // Issued At with future date
+    @Test(expected = InvalidClaimException.class)
     public void shouldThrowOnFutureIssuedAt() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -380,6 +380,7 @@ public class JWTVerifierTest {
 
         assertThat(jwt, is(notNullValue()));
     }
+
     // Generic Delta
     @SuppressWarnings("RedundantCast")
     @Test


### PR DESCRIPTION
### Changes
If an expectation was set with the `JWTVerifier.Builder#withArrayClaim` method, once a token was attempted to be verified and if it didn't include the given claim, the code would throw an unhandled NPE.

This change makes it throw the `InvalidClaimException` that is thrown on this very same scenario for the rest of the claims, stating that the claim doesn't match the expected value.

There are a few whitespace changes that can be ignored.

### References

Resolves https://github.com/auth0/java-jwt/issues/384

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
