### PR TITLE
Use java.util.Base64 for encoding and decoding

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -35,7 +35,6 @@ compileJava {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0.pr3'
-    implementation 'commons-codec:commons-codec:1.12'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     testImplementation 'junit:junit:4.12'
     testImplementation 'net.jodah:concurrentunit:0.4.3'

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -10,14 +10,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 /**
@@ -480,11 +476,11 @@ public final class JWTCreator {
     }
 
     private String sign() throws SignatureGenerationException {
-        String header = Base64.encodeBase64URLSafeString(headerJson.getBytes(StandardCharsets.UTF_8));
-        String payload = Base64.encodeBase64URLSafeString(payloadJson.getBytes(StandardCharsets.UTF_8));
+        String header = Base64.getUrlEncoder().withoutPadding().encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
+        String payload = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
 
         byte[] signatureBytes = algorithm.sign(header.getBytes(StandardCharsets.UTF_8), payload.getBytes(StandardCharsets.UTF_8));
-        String signature = Base64.encodeBase64URLSafeString((signatureBytes));
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString((signatureBytes));
 
         return String.format("%s.%s.%s", header, payload, signature);
     }

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -37,8 +37,8 @@ final class JWTDecoder implements DecodedJWT, Serializable {
         try {
             headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
             payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
-        } catch (NullPointerException e) {
-            throw new JWTDecodeException("The UTF-8 Charset isn't initialized.", e);
+        } catch (NullPointerException | IllegalArgumentException e) {
+            throw new JWTDecodeException("The UTF-8 Charset isn't initialized or the token is not valid Base64.", e);
         }
         header = converter.parseHeader(headerJson);
         payload = converter.parsePayload(payloadJson);

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -6,11 +6,11 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Header;
 import com.auth0.jwt.interfaces.Payload;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.StringUtils;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +35,8 @@ final class JWTDecoder implements DecodedJWT, Serializable {
         String headerJson;
         String payloadJson;
         try {
-            headerJson = StringUtils.newStringUtf8(Base64.decodeBase64(parts[0]));
-            payloadJson = StringUtils.newStringUtf8(Base64.decodeBase64(parts[1]));
+            headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
+            payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
         } catch (NullPointerException e) {
             throw new JWTDecodeException("The UTF-8 Charset isn't initialized.", e);
         }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -36,9 +36,8 @@ class ECDSAAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
-
         try {
+            byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
             ECPublicKey publicKey = keyProvider.getPublicKeyById(jwt.getKeyId());
             if (publicKey == null) {
                 throw new IllegalStateException("The given Public Key is null.");
@@ -48,7 +47,7 @@ class ECDSAAlgorithm extends Algorithm {
             if (!valid) {
                 throw new SignatureVerificationException(this);
             }
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
+        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException | IllegalArgumentException e) {
             throw new SignatureVerificationException(this, e);
         }
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -4,13 +4,13 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
-import org.apache.commons.codec.binary.Base64;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.util.Base64;
 
 class ECDSAAlgorithm extends Algorithm {
     private final ECDSAKeyProvider keyProvider;
@@ -36,7 +36,7 @@ class ECDSAAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
+        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
 
         try {
             ECPublicKey publicKey = keyProvider.getPublicKeyById(jwt.getKeyId());

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -3,11 +3,11 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 class HMACAlgorithm extends Algorithm {
     private final CryptoHelper crypto;
@@ -41,7 +41,7 @@ class HMACAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
+        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
 
         try {
             boolean valid = crypto.verifySignatureFor(getDescription(), secret, jwt.getHeader(), jwt.getPayload(), signatureBytes);

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -41,14 +41,13 @@ class HMACAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
-
         try {
+            byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
             boolean valid = crypto.verifySignatureFor(getDescription(), secret, jwt.getHeader(), jwt.getPayload(), signatureBytes);
             if (!valid) {
                 throw new SignatureVerificationException(this);
             }
-        } catch (IllegalStateException | InvalidKeyException | NoSuchAlgorithmException e) {
+        } catch (IllegalStateException | InvalidKeyException | NoSuchAlgorithmException | IllegalArgumentException e) {
             throw new SignatureVerificationException(this, e);
         }
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
@@ -14,9 +14,14 @@ class NoneAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
-        if (signatureBytes.length > 0) {
-            throw new SignatureVerificationException(this);
+        try {
+            byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
+
+            if (signatureBytes.length > 0) {
+                throw new SignatureVerificationException(this);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new SignatureVerificationException(this, e);
         }
     }
 

--- a/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
@@ -3,7 +3,8 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.apache.commons.codec.binary.Base64;
+
+import java.util.Base64;
 
 class NoneAlgorithm extends Algorithm {
 
@@ -13,7 +14,7 @@ class NoneAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
+        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
         if (signatureBytes.length > 0) {
             throw new SignatureVerificationException(this);
         }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -4,13 +4,13 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
-import org.apache.commons.codec.binary.Base64;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 
 class RSAAlgorithm extends Algorithm {
     private final RSAKeyProvider keyProvider;
@@ -32,7 +32,7 @@ class RSAAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
+        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
 
         try {
             RSAPublicKey publicKey = keyProvider.getPublicKeyById(jwt.getKeyId());

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -32,9 +32,8 @@ class RSAAlgorithm extends Algorithm {
 
     @Override
     public void verify(DecodedJWT jwt) throws SignatureVerificationException {
-        byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
-
         try {
+            byte[] signatureBytes = Base64.getUrlDecoder().decode(jwt.getSignature());
             RSAPublicKey publicKey = keyProvider.getPublicKeyById(jwt.getKeyId());
             if (publicKey == null) {
                 throw new IllegalStateException("The given Public Key is null.");
@@ -43,7 +42,7 @@ class RSAAlgorithm extends Algorithm {
             if (!valid) {
                 throw new SignatureVerificationException(this);
             }
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
+        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalArgumentException | IllegalStateException e) {
             throw new SignatureVerificationException(this, e);
         }
     }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -5,7 +5,7 @@ import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.codec.binary.Base64;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -48,7 +48,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("asd", 123));
     }
 
@@ -73,7 +73,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry(PublicClaims.KEY_ID, "xyz"));
     }
 
@@ -89,7 +89,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry(PublicClaims.KEY_ID, "abc"));
     }
 
@@ -106,7 +106,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.isNotPresent(PublicClaims.KEY_ID));
         assertThat(headerJson, JsonMatcher.hasEntry("test2", "isSet"));
     }
@@ -119,7 +119,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("kid", "56a8bd44da435300010000015f5ed"));
     }
 
@@ -135,7 +135,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("kid", "my-key-id"));
     }
 
@@ -152,7 +152,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("kid", "my-key-id"));
     }
 
@@ -168,7 +168,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("kid", "my-key-id"));
     }
 
@@ -185,7 +185,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("kid", "my-key-id"));
     }
 
@@ -315,7 +315,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "HS256"));
     }
 
@@ -326,7 +326,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
     }
 
@@ -339,7 +339,7 @@ public class JWTCreatorTest {
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "passport"));
     }
 
@@ -531,7 +531,7 @@ public class JWTCreatorTest {
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
         
-        String body = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        String body = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> map = (Map<String, Object>) mapper.readValue(body, Map.class).get("data");
 
@@ -593,7 +593,7 @@ public class JWTCreatorTest {
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
         
-        String body = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        String body = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
         ObjectMapper mapper = new ObjectMapper();
         List<Object> list = (List<Object>) mapper.readValue(body, Map.class).get("data");
         

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -65,6 +65,24 @@ public class JWTDecoderTest {
         customJWT(invalidJson, validJson, "signature");
     }
 
+    @Test
+    public void shouldThrowWhenHeaderNotValidBase64() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectCause(isA(IllegalArgumentException.class));
+
+        String jwt = "eyJhbGciOiJub25l+IiwiY3R5IjoiSldUIn0.eyJpc3MiOiJhdXRoMCJ9.Ox-WRXRaGAuWt2KfPvWiGcCrPqZtbp_4OnQzZXaTfss";
+        JWT.decode(jwt);
+    }
+
+    @Test
+    public void shouldThrowWhenPayloadNotValidBase64() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectCause(isA(IllegalArgumentException.class));
+
+        String jwt = "eyJhbGciOiJub25lIiwiY3R5IjoiSldUIn0.eyJpc3MiOiJhdXRo+MCJ9.Ox-WRXRaGAuWt2KfPvWiGcCrPqZtbp_4OnQzZXaTfss";
+        JWT.decode(jwt);
+    }
+
     // Parts
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -4,7 +4,6 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.impl.NullClaim;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.Assert;
@@ -15,6 +14,7 @@ import org.junit.rules.ExpectedException;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 
@@ -364,8 +364,8 @@ public class JWTDecoderTest {
     //Helper Methods
 
     private DecodedJWT customJWT(String jsonHeader, String jsonPayload, String signature) {
-        String header = Base64.encodeBase64URLSafeString(jsonHeader.getBytes(StandardCharsets.UTF_8));
-        String body = Base64.encodeBase64URLSafeString(jsonPayload.getBytes(StandardCharsets.UTF_8));
+        String header = Base64.getUrlEncoder().withoutPadding().encodeToString(jsonHeader.getBytes(StandardCharsets.UTF_8));
+        String body = Base64.getUrlEncoder().withoutPadding().encodeToString(jsonPayload.getBytes(StandardCharsets.UTF_8));
         return JWT.decode(String.format("%s.%s.%s", header, body, signature));
     }
 

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -3,7 +3,6 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.Rule;
@@ -14,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.*;
@@ -445,7 +445,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "HS256"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -461,7 +461,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "HS384"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -477,7 +477,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "HS512"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -493,7 +493,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "RS256"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -509,7 +509,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "RS384"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -525,7 +525,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "RS512"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -541,7 +541,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "ES256"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -557,7 +557,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "ES384"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));
@@ -573,7 +573,7 @@ public class JWTTest {
         assertThat(signed, is(notNullValue()));
 
         String[] parts = signed.split("\\.");
-        String headerJson = new String(Base64.decodeBase64(parts[0]), StandardCharsets.UTF_8);
+        String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
         assertThat(headerJson, JsonMatcher.hasEntry("alg", "ES512"));
         assertThat(headerJson, JsonMatcher.hasEntry("typ", "JWT"));
         assertThat(parts[1], is("e30"));

--- a/lib/src/test/java/com/auth0/jwt/algorithms/CryptoTestHelper.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/CryptoTestHelper.java
@@ -1,21 +1,20 @@
 package com.auth0.jwt.algorithms;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.codec.binary.Base64;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public abstract class CryptoTestHelper {
     private static final Pattern authHeaderPattern = Pattern.compile("^([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)");
 
 	public static String asJWT(Algorithm algorithm, String header, String payload) {
 	    byte[] signatureBytes = algorithm.sign(header.getBytes(StandardCharsets.UTF_8), payload.getBytes(StandardCharsets.UTF_8));
-	    String jwtSignature = Base64.encodeBase64URLSafeString(signatureBytes);
+	    String jwtSignature = Base64.getUrlEncoder().withoutPadding().encodeToString(signatureBytes);
 	    return String.format("%s.%s.%s", header, payload, jwtSignature);
 	}
 	

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -4,8 +4,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
-
-import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIn;
 import org.junit.Assert;
@@ -20,13 +18,15 @@ import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.Arrays;
+import java.util.Base64;
 
 import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
 import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.asJWT;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignaturePresent;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
@@ -150,7 +150,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[63];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -163,7 +163,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[64];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -177,7 +177,7 @@ public class ECDSAAlgorithmTest {
         byte[] bytes = new byte[64];
         bytes[0] = 0x30;
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -275,7 +275,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[95];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -288,7 +288,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[96];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -302,7 +302,7 @@ public class ECDSAAlgorithmTest {
         byte[] bytes = new byte[96];
         new SecureRandom().nextBytes(bytes);
         bytes[0] = 0x30;
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -400,7 +400,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[131];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -413,7 +413,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[132];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -427,7 +427,7 @@ public class ECDSAAlgorithmTest {
         byte[] bytes = new byte[132];
         new SecureRandom().nextBytes(bytes);
         bytes[0] = 0x30;
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -442,7 +442,7 @@ public class ECDSAAlgorithmTest {
 
         byte[] bytes = new byte[256];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
@@ -530,7 +530,7 @@ public class ECDSAAlgorithmTest {
     public void shouldDoECDSA256SigningWithBothKeys() throws Exception {
         Algorithm algorithm = Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
         byte[] signatureBytes = algorithm.sign(ES256HeaderBytes, auth0IssPayloadBytes);
-        String jwtSignature = Base64.encodeBase64URLSafeString(signatureBytes);
+        String jwtSignature = Base64.getUrlEncoder().withoutPadding().encodeToString(signatureBytes);
         String jwt = String.format("%s.%s.%s", ES256Header, auth0IssPayload, jwtSignature);
 
         assertSignaturePresent(jwt);
@@ -1154,12 +1154,12 @@ public class ECDSAAlgorithmTest {
         bout.write('.');
         bout.write(payloadBytes);
 
-        String jwtSignature1 = Base64.encodeBase64URLSafeString(algorithm.sign(bout.toByteArray()));
+        String jwtSignature1 = Base64.getUrlEncoder().withoutPadding().encodeToString(algorithm.sign(bout.toByteArray()));
         String jwt1 = String.format("%s.%s.%s", header, payload, jwtSignature1);
 
         algorithm.verify(JWT.decode(jwt1));
 
-        String jwtSignature2 = Base64.encodeBase64URLSafeString(algorithm.sign(headerBytes, payloadBytes));
+        String jwtSignature2 = Base64.getUrlEncoder().withoutPadding().encodeToString(algorithm.sign(headerBytes, payloadBytes));
         String jwt2 = String.format("%s.%s.%s", header, payload, jwtSignature2);
 
         algorithm.verify(JWT.decode(jwt2));

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -506,7 +506,18 @@ public class ECDSAAlgorithmTest {
         algorithm.verify(JWT.decode(jwt));
     }
 
-    //Sign
+    @Test
+    public void shouldThrowWhenSignatureNotValidBase64() throws Exception {
+        exception.expect(SignatureVerificationException.class);
+        exception.expectCause(isA(IllegalArgumentException.class));
+
+        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0UW726GsDVCsb4RTFeUTTrKaHZHtHPRoTuTEHCuerwvxo4+EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0mmWFhVCR1YNg";
+        ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
+        Algorithm algorithm = Algorithm.ECDSA512(key);
+        algorithm.verify(JWT.decode(jwt));
+    }
+
+        //Sign
     private static final String ES256Header = "eyJhbGciOiJFUzI1NiJ9";
     private static final String ES384Header = "eyJhbGciOiJFUzM4NCJ9";
     private static final String ES512Header = "eyJhbGciOiJFUzUxMiJ9";

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
@@ -1,11 +1,9 @@
 package com.auth0.jwt.algorithms;
-import static com.auth0.jwt.algorithms.CryptoTestHelper.*;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
-import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -18,9 +16,12 @@ import java.security.*;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.util.Base64;
 
 import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
 import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
+import static com.auth0.jwt.algorithms.CryptoTestHelper.asJWT;
+import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignaturePresent;
 import static com.auth0.jwt.algorithms.ECDSAAlgorithmTest.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
@@ -87,7 +88,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
         exception.expectCause(hasMessage(is("Invalid JOSE signature format.")));
 
-        String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.MEYCIQDiJWTf5jS/hFPj/0hpCWn7x1n/h+xPMjKWCs9MMusS9AIhAMcFPJVLe2A9uvb8hl8sRO2IpGoKDRpDmyH14ixNPAHW";
+        String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.MEYCIQDiJWTf5jShFPj0hpCWn7x1nhxPMjKWCs9MMusS9AIhAMcFPJVLe2A9uvb8hl8sRO2IpGoKDRpDmyH14ixNPAHW";
         ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         Algorithm algorithm = Algorithm.ECDSA256(key);
         algorithm.verify(JWT.decode(jwt));
@@ -107,7 +108,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
         exception.expectCause(hasMessage(is("Invalid JOSE signature format.")));
 
-        String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.MEYCIQDiJWTf5jS/hFPj/0hpCWn7x1n/h+xPMjKWCs9MMusS9AIhAMcFPJVLe2A9uvb8hl8sRO2IpGoKDRpDmyH14ixNPAHW";
+        String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9.MEYCIQDiJWTf5jShFPj0hpCWn7x1nhxPMjKWCs9MMusS9AIhAMcFPJVLe2A9uvb8hl8sRO2IpGoKDRpDmyH14ixNPAHW";
         Algorithm algorithm = Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
     }
@@ -164,7 +165,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[63];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -177,7 +178,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[64];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -191,7 +192,7 @@ public class ECDSABouncyCastleProviderTests {
         byte[] bytes = new byte[64];
         bytes[0] = 0x30;
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA256((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_256, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -212,7 +213,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
         exception.expectCause(hasMessage(is("Invalid JOSE signature format.")));
 
-        String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.MGUCMQDnRRTlUo10XXB/KRjyNAEqm+4dmh7ohkEmbk2+gHxtH6GdGDq2L4Idua+hG2Ut+ccCMH8CE2v/HCTMuk3pzAtoOtxkB8rXPK2KF6m8LUuEdCqPwF2yxVJn8ZxpzAur+DEv8w==";
+        String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.MGUCMQDnRRTlUo10XXBKRjyNAEqm4dmh7ohkEmbk2gHxtH6GdGDq2L4IduahG2UtccCMH8CE2vHCTMuk3pzAtoOtxkB8rXPK2KF6m8LUuEdCqPwF2yxVJn8ZxpzAurDEv8w";
         ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
         Algorithm algorithm = Algorithm.ECDSA384(key);
         algorithm.verify(JWT.decode(jwt));
@@ -232,7 +233,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
         exception.expectCause(hasMessage(is("Invalid JOSE signature format.")));
 
-        String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.MGUCMQDnRRTlUo10XXB/KRjyNAEqm+4dmh7ohkEmbk2+gHxtH6GdGDq2L4Idua+hG2Ut+ccCMH8CE2v/HCTMuk3pzAtoOtxkB8rXPK2KF6m8LUuEdCqPwF2yxVJn8ZxpzAur+DEv8w==";
+        String jwt = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJhdXRoMCJ9.MGUCMQDnRRTlUo10XXBKRjyNAEqm4dmh7ohkEmbk2gHxtH6GdGDq2L4IduahG2UtccCMH8CE2vHCTMuk3pzAtoOtxkB8rXPK2KF6m8LUuEdCqPwF2yxVJn8ZxpzAurDEv8w";
         Algorithm algorithm = Algorithm.ECDSA384((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
     }
@@ -289,7 +290,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[95];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -302,7 +303,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[96];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -316,7 +317,7 @@ public class ECDSABouncyCastleProviderTests {
         byte[] bytes = new byte[96];
         new SecureRandom().nextBytes(bytes);
         bytes[0] = 0x30;
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA384((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_384, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -337,7 +338,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
         exception.expectCause(hasMessage(is("Invalid JOSE signature format.")));
 
-        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0/UW726GsDVCsb4RTFeUTTrK+aHZHtHPRoTuTEHCuerwvxo4EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0/mmWFhVCR1YNg==";
+        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0UW726GsDVCsb4RTFeUTTrKaHZHtHPRoTuTEHCuerwvxo4EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0mmWFhVCR1YNg";
         ECKey key = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
         Algorithm algorithm = Algorithm.ECDSA512(key);
         algorithm.verify(JWT.decode(jwt));
@@ -357,7 +358,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
         exception.expectCause(hasMessage(is("Invalid JOSE signature format.")));
 
-        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0/UW726GsDVCsb4RTFeUTTrK+aHZHtHPRoTuTEHCuerwvxo4EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0/mmWFhVCR1YNg==";
+        String jwt = "eyJhbGciOiJFUzUxMiJ9.eyJpc3MiOiJhdXRoMCJ9.MIGIAkIB4Ik8MixIeHBFIZkJjquymLzN6Q7DQr2pgw2uJ0UW726GsDVCsb4RTFeUTTrKaHZHtHPRoTuTEHCuerwvxo4EICQgGALKocz3lL8qfH1444LNBLaOSNJp3RNkB5YHDEhQEsox21PMA9kau2TcxkOW9jGX6b9N9FhlGo0mmWFhVCR1YNg";
         Algorithm algorithm = Algorithm.ECDSA512((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
     }
@@ -414,7 +415,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[131];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -427,7 +428,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[132];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -441,7 +442,7 @@ public class ECDSABouncyCastleProviderTests {
         byte[] bytes = new byte[132];
         new SecureRandom().nextBytes(bytes);
         bytes[0] = 0x30;
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
         Algorithm algorithm = Algorithm.ECDSA512((ECKey) readPublicKeyFromFile(INVALID_PUBLIC_KEY_FILE_512, "EC"));
         algorithm.verify(JWT.decode(jwt));
@@ -456,7 +457,7 @@ public class ECDSABouncyCastleProviderTests {
 
         byte[] bytes = new byte[256];
         new SecureRandom().nextBytes(bytes);
-        String signature = Base64.encodeBase64URLSafeString(bytes);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         String jwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJhdXRoMCJ9." + signature;
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");

--- a/lib/src/test/java/com/auth0/jwt/algorithms/HMACAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/HMACAlgorithmTest.java
@@ -276,4 +276,18 @@ public class HMACAlgorithmTest {
 
         assertThat(algorithm.sign(bout.toByteArray()), is(algorithm.sign(header, payload)));
     }
+
+    @Test
+    public void shouldThrowWhenSignatureNotValidBase64() throws Exception {
+        exception.expect(SignatureVerificationException.class);
+        exception.expectCause(isA(IllegalArgumentException.class));
+
+        CryptoHelper crypto = mock(CryptoHelper.class);
+        when(crypto.verifySignatureFor(anyString(), any(byte[].class), any(String.class), any(String.class), any(byte[].class)))
+                .thenThrow(NoSuchAlgorithmException.class);
+
+        Algorithm algorithm = new HMACAlgorithm(crypto, "some-alg", "some-algorithm", "secret".getBytes(StandardCharsets.UTF_8));
+        String jwt = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWm+i903JuUoDRZDBPB7HwkS4nVyWH1M";
+        algorithm.verify(JWT.decode(jwt));
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/NoneAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/NoneAlgorithmTest.java
@@ -7,8 +7,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import java.security.interfaces.ECKey;
+
+import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class NoneAlgorithmTest {
@@ -43,5 +45,15 @@ public class NoneAlgorithmTest {
     @Test
     public void shouldReturnNullSigningKeyId() {
         assertThat(Algorithm.none().getSigningKeyId(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldThrowWhenSignatureNotValidBase64() {
+        exception.expect(SignatureVerificationException.class);
+        exception.expectCause(isA(IllegalArgumentException.class));
+
+        String jwt = "eyJhbGciOiJub25lIiwiY3R5IjoiSldUIn0.eyJpc3MiOiJhdXRoMCJ9.Ox-WRXRaGAuWt2KfPvW+iGcCrPqZtbp_4OnQzZXaTfss";
+        Algorithm algorithm = Algorithm.none();
+        algorithm.verify(JWT.decode(jwt));
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -568,4 +568,13 @@ public class RSAAlgorithmTest {
         algorithm.sign(new byte[0]);
     }
 
+    @Test
+    public void shouldThrowWhenSignatureNotValidBase64()  throws Exception {
+        exception.expect(SignatureVerificationException.class);
+        exception.expectCause(isA(IllegalArgumentException.class));
+
+        String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.dxXF3MdsyW-AuvwJpaQtrZ33fAde9xWxpLIg9cO2tMLH2GSRNu+LAe61KsJusZhqZB9Iy7DvflcmRz-9OZndm6cj_ThGeJH2LLc90K83UEvvRPo8l85RrQb8PcanxCgIs2RcZOLygERizB3pr5icGkzR7R2y6zgNCjKJ5_NJ6EiZsGN6_nc2PRK_DbyY-Wn0QDxIxKoA5YgQJ9qafe7IN980pXvQv2Z62c3XR8dYuaXBqhthBj-AbaFHEpZapN-V-TmuLNzR2MCB6Xr7BYMuCaqWf_XU8og4XNe8f_8w9Wv5vvgqMM1KhqVpG5VdMJv4o_L4NoCROHhtUQSLRh2M9cA";
+        Algorithm algorithm = Algorithm.RSA256((RSAKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA"));
+        algorithm.verify(JWT.decode(jwt));
+    }
 }


### PR DESCRIPTION
### Changes

These changes enable us to use standard Java Base64 encoding/decoding available since JDK8. This allows us to remove a third-party dependency, is more idiomatic Java, and may offer performance improvements over the Apache library.

- Use [java.util.Base64](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html) for Base64 encoding and decoding
- Throw appropriate exception when attempting to decode invalid Base64 token
- Remove `commons-codec` dependency

> NOTE: These changes are targeted at v4 of this library.

### References

- [java.util.Base64 JavaDoc](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html)
- [JavaWorld article on java.util.Base64 encoding and decoding](https://www.javaworld.com/article/3240006/base64-encoding-and-decoding-in-java-8.html)

### Testing

Tests updated to use `java.util.Base64` encoding and decoding.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
