### PR TITLE
Deprecate Date and array based claim methods

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -147,8 +147,9 @@ public final class JWTCreator {
          *
          * @param expiresAt the Expires At value.
          * @return this same Builder instance.
+         * @deprecated Use {@linkplain #withExpiresAt(Instant)} instead.
          */
-        // TODO - Deprecate this method in favor of withExpiresAtInstant
+        @Deprecated
         public Builder withExpiresAt(Date expiresAt) {
             return withExpiresAt(expiresAt.toInstant());
         }
@@ -169,8 +170,9 @@ public final class JWTCreator {
          *
          * @param notBefore the Not Before value.
          * @return this same Builder instance.
+         * @deprecated Use {@linkplain #withNotBefore(Instant)} instead.
          */
-        // TODO - Deprecate this method in favor of withNotBeforeInstant
+        @Deprecated
         public Builder withNotBefore(Date notBefore) {
             return withNotBefore(notBefore.toInstant());
         }
@@ -191,8 +193,9 @@ public final class JWTCreator {
          *
          * @param issuedAt the Issued At value.
          * @return this same Builder instance.
+         * @deprecated Use {@linkplain #withIssuedAt(Instant)} instead.
          */
-        // TODO - Deprecate this method in favor of withIssuedAtInstant
+        @Deprecated
         public Builder withIssuedAt(Date issuedAt) {
             return withIssuedAt(issuedAt.toInstant());
         }
@@ -299,8 +302,9 @@ public final class JWTCreator {
          * @param value the Claim's value.
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
+         * @deprecated Use {@linkplain #withClaim(String, Instant)} instead.
          */
-        // TODO - Deprecate this method in favor of withClaim(String name, Instant value)
+        @Deprecated
         public Builder withClaim(String name, Date value) throws IllegalArgumentException {
             return withClaim(name, value.toInstant());
         }
@@ -312,7 +316,9 @@ public final class JWTCreator {
          * @param items the Claim's value.
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
+         * @deprecated Use {@linkplain #withClaim(String, List)} instead.
          */
+        @Deprecated
         public Builder withArrayClaim(String name, String[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
@@ -326,7 +332,9 @@ public final class JWTCreator {
          * @param items the Claim's value.
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
+         * @deprecated Use {@linkplain #withClaim(String, List)} instead.
          */
+        @Deprecated
         public Builder withArrayClaim(String name, Integer[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
@@ -340,7 +348,9 @@ public final class JWTCreator {
          * @param items the Claim's value.
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null
+         * @deprecated Use {@linkplain #withClaim(String, List)} instead.
          */
+        @Deprecated
         public Builder withArrayClaim(String name, Long[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -71,8 +71,9 @@ public interface Claim {
      * If the value can't be converted to a Date, null will be returned.
      *
      * @return the value as a Date or null.
+     * @deprecated Use {@linkplain #asInstant()} instead.
      */
-    // TODO - Deprecate this method in favor of asInstant()
+    @Deprecated
     Date asDate();
 
     /**

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
@@ -18,7 +18,8 @@ public interface Clock {
      * Returns a new Date representing Today's time.
 
      * @return a new Date representing Today's time.
+     * @deprecated Use {@linkplain #getNow()} instead
      */
-    // TODO - Deprecate this method in favor of getNow()
+    @Deprecated
     Date getToday();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -55,24 +55,27 @@ public interface Payload {
      * Get the value of the "exp" claim, or null if it's not available.
      *
      * @return the Expiration Time value or null.
+     * @deprecated Use {@linkplain #getExpiresAtInstant()} instead.
      */
-    // TODO - deprecate in favor of getExpiresAtInstant
+    @Deprecated
     Date getExpiresAt();
 
     /**
      * Get the value of the "nbf" claim, or null if it's not available.
      *
      * @return the Not Before value or null.
+     * @deprecated Use {@linkplain #getNotBeforeInstant()} instead.
      */
-    // TODO - deprecate in favor of getNotBeforeInstant
+    @Deprecated
     Date getNotBefore();
 
     /**
      * Get the value of the "iat" claim, or null if it's not available.
      *
      * @return the Issued At value or null.
+     * @deprecated Use {@linkplain #getIssuedAtInstant()} instead.
      */
-    // TODO - deprecate in favor of getIssuedAtInstant
+    @Deprecated
     Date getIssuedAt();
 
     /**

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -148,8 +148,9 @@ public interface Verification {
      * @param value the Claim's value.
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
+     * @deprecated Use {@linkplain #withClaim(String, Instant)} instead.
      */
-    // TODO deprecate this in favor of withClaim(String name, Instant value)
+    @Deprecated
     Verification withClaim(String name, Date value) throws IllegalArgumentException;
 
     /**


### PR DESCRIPTION
### Changes

Deprecate `java.util.Date` methods (in favor of `java.time.Instant`) and array-based claims (in favor of List-based claims).

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
