### PR TITLE
Added additional conditions on varargs to make sure given varargs or …

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -57,7 +57,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withIssuer(String... issuer) {
-            requireClaim(PublicClaims.ISSUER, issuer == null ? null : Arrays.asList(issuer));
+            requireClaim(PublicClaims.ISSUER, issuer == null || issuer.length == 0 || (issuer.length == 1 && issuer[0] == null) ? null : Arrays.asList(issuer));
             return this;
         }
 
@@ -69,7 +69,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withAudience(String... audience) {
-            requireClaim(PublicClaims.AUDIENCE, audience == null ? null : Arrays.asList(audience));
+            requireClaim(PublicClaims.AUDIENCE, audience == null || audience.length == 0 || (audience.length == 1 && audience[0] == null)? null : Arrays.asList(audience));
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -57,7 +57,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withIssuer(String... issuer) {
-            requireClaim(PublicClaims.ISSUER, issuer == null || issuer.length == 0 || (issuer.length == 1 && issuer[0] == null) ? null : Arrays.asList(issuer));
+            requireClaim(PublicClaims.ISSUER, checkVarargNull(issuer) ? null : Arrays.asList(issuer));
             return this;
         }
 
@@ -69,7 +69,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withAudience(String... audience) {
-            requireClaim(PublicClaims.AUDIENCE, audience == null || audience.length == 0 || (audience.length == 1 && audience[0] == null)? null : Arrays.asList(audience));
+            requireClaim(PublicClaims.AUDIENCE, checkVarargNull(audience) ? null : Arrays.asList(audience));
             return this;
         }
 
@@ -228,6 +228,20 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             }
             claims.put(name, value);
         }
+    }
+
+    private static boolean checkVarargNull(String[] args) {
+        if (args == null || args.length == 0) {
+            return true;
+        }
+        boolean isAllNull = true;
+        for (String arg: args) {
+            if (arg != null && arg.trim().length() != 0) {
+                isAllNull = false;
+                break;
+            }
+        }
+        return isAllNull;
     }
 
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -702,6 +702,26 @@ public class JWTVerifierTest {
     }
 
     @Test
+    public void shouldRemoveIssuerWhenPassingNullReference() throws Exception {
+        String issuer = null;
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withIssuer(issuer)
+                .withIssuer(null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withIssuer()
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+    }
+
+    @Test
     public void shouldSkipClaimValidationsIfNoClaimsRequired() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M";
         DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -168,6 +168,13 @@ public class JWTVerifierTest {
 
         assertThat(verifier.claims, is(notNullValue()));
         assertThat(verifier.claims, not(hasKey("aud")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withAudience("   ")
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
     }
 
     @Test
@@ -715,6 +722,13 @@ public class JWTVerifierTest {
 
         verifier = JWTVerifier.init(algorithm)
                 .withIssuer()
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withIssuer("  ")
                 .build();
 
         assertThat(verifier.claims, is(notNullValue()));

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -125,7 +125,7 @@ public class JWTVerifierTest {
                 .verify(tokenArr);
 
         assertThat(jwtArr, is(notNullValue()));
-    }
+     }
 
     @Test
     public void shouldAcceptPartialAudience() throws Exception {
@@ -148,6 +148,26 @@ public class JWTVerifierTest {
                 .withAudience("nope")
                 .build()
                 .verify(token);
+    }
+
+    @Test
+    public void shouldRemoveAudienceWhenPassingNullReference() throws Exception {
+        String audience = null;
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withAudience(audience)
+                .withAudience(null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withAudience()
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
     }
 
     @Test


### PR DESCRIPTION
…not null

### Changes

Please describe both what is changing and why this is important. Include:

If there is no aud/iss field in token, its a breaking change for the apps. In my case, we do not maintain audience field in token. Let me know if this is ok.

### References

Please include relevant links supporting this change such as a:

- support ticket:  https://github.com/auth0/java-jwt/issues/404
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
