### PR TITLE
Fix date serialization for list/map claims

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -59,6 +60,8 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
     private void handleSerialization(Object value, JsonGenerator gen) throws IOException {
         if (value instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
             gen.writeNumber(instantToSeconds((Instant) value));
+        } else if (value instanceof Date) {
+            gen.writeNumber(dateToSeconds((Date) value));
         } else if (value instanceof Map) {
             serializeMap((Map<?, ?>) value, gen);
         } else if (value instanceof List) {
@@ -88,5 +91,9 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
 
     private long instantToSeconds(Instant instant) {
         return instant.getEpochSecond();
+    }
+
+    private long dateToSeconds(Date date) {
+        return date.getTime() / 1000;
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -2,6 +2,7 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.impl.PublicClaims;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -507,7 +508,7 @@ public class JWTCreatorTest {
         data.put("integer", 1);
         data.put("long", Long.MAX_VALUE);
         data.put("double", 123.456d);
-        data.put("date", new Date(123L));
+        data.put("date", new Date(123000));
         data.put("instant", Instant.ofEpochSecond(123L));
         data.put("boolean", true);
 
@@ -520,7 +521,7 @@ public class JWTCreatorTest {
 
         Map<String, Object> sub = new HashMap<>();
         sub.put("subKey", "subValue");
-        sub.put("subDate", new Date(567L));
+        sub.put("subDate", new Date(567000));
         sub.put("subInstant", Instant.ofEpochSecond(567L));
         data.put("map", sub);
 
@@ -530,10 +531,9 @@ public class JWTCreatorTest {
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
-        
-        String body = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> map = (Map<String, Object>) mapper.readValue(body, Map.class).get("data");
+
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+        Map<String, Object> map = decodedJWT.getClaim("data").asMap();
 
         assertThat(map.get("string"), is("abc"));
         assertThat(map.get("integer"), is(1));
@@ -568,7 +568,7 @@ public class JWTCreatorTest {
         data.add(1);
         data.add(Long.MAX_VALUE);
         data.add(123.456d);
-        data.add(new Date(123L));
+        data.add(new Date(123000));
         data.add(Instant.ofEpochSecond(123L));
         data.add(true);
         
@@ -581,7 +581,7 @@ public class JWTCreatorTest {
 
         Map<String, Object> sub = new HashMap<>();
         sub.put("subKey", "subValue");
-        sub.put("subDate", new Date(567L));
+        sub.put("subDate", new Date(567000));
         sub.put("subInstant", Instant.ofEpochSecond(567L));
 
         data.add(sub);
@@ -592,10 +592,9 @@ public class JWTCreatorTest {
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
-        
-        String body = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
-        ObjectMapper mapper = new ObjectMapper();
-        List<Object> list = (List<Object>) mapper.readValue(body, Map.class).get("data");
+
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+        List<Object> list = decodedJWT.getClaim("data").asList(Object.class);
         
         assertThat(list.get(0), is("abc"));
         assertThat(list.get(1), is(1));


### PR DESCRIPTION
### Changes

Custom list and map claims may include `java.util.Date` as well as `java.time.Instant` values for `NumericDate` values. When serializing these lists/maps, we need to account for `Date` values and serialize to the number of seconds since the epoch.

### References

[JWT Specification - NumericDate definition](https://tools.ietf.org/html/rfc7519#page-4)

### Testing

Relevant tests updated to expect `java.util.Date` claims to be serialized to the number of seconds since the epoch.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
