### PR TITLE
Check varargs null values in JWTVerifier

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -57,7 +57,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withIssuer(String... issuer) {
-            requireClaim(PublicClaims.ISSUER, issuer == null ? null : Arrays.asList(issuer));
+            requireClaim(PublicClaims.ISSUER, checkVarargNull(issuer) ? null : Arrays.asList(issuer));
             return this;
         }
 
@@ -69,7 +69,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withAudience(String... audience) {
-            requireClaim(PublicClaims.AUDIENCE, audience == null ? null : Arrays.asList(audience));
+            requireClaim(PublicClaims.AUDIENCE, checkVarargNull(audience) ? null : Arrays.asList(audience));
             return this;
         }
 
@@ -228,6 +228,20 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             }
             claims.put(name, value);
         }
+    }
+
+    private static boolean checkVarargNull(String[] args) {
+        if (args == null || args.length == 0) {
+            return true;
+        }
+        boolean isAllNull = true;
+        for (String arg: args) {
+            if (arg != null) {
+                isAllNull = false;
+                break;
+            }
+        }
+        return isAllNull;
     }
 
 

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -57,7 +57,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withIssuer(String... issuer) {
-            requireClaim(PublicClaims.ISSUER, checkVarargNull(issuer) ? null : Arrays.asList(issuer));
+            requireClaim(PublicClaims.ISSUER, isNullOrEmpty(issuer) ? null : Arrays.asList(issuer));
             return this;
         }
 
@@ -69,7 +69,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withAudience(String... audience) {
-            requireClaim(PublicClaims.AUDIENCE, checkVarargNull(audience) ? null : Arrays.asList(audience));
+            requireClaim(PublicClaims.AUDIENCE, isNullOrEmpty(audience) ? null : Arrays.asList(audience));
             return this;
         }
 
@@ -230,7 +230,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         }
     }
 
-    private static boolean checkVarargNull(String[] args) {
+    private static boolean isNullOrEmpty(String[] args) {
         if (args == null || args.length == 0) {
             return true;
         }

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -125,7 +126,7 @@ public class JWTVerifierTest {
                 .verify(tokenArr);
 
         assertThat(jwtArr, is(notNullValue()));
-    }
+     }
 
     @Test
     public void shouldAcceptPartialAudience() throws Exception {
@@ -151,11 +152,52 @@ public class JWTVerifierTest {
     }
 
     @Test
+    public void shouldRemoveAudienceWhenPassingNullReference() throws Exception {
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withAudience((String) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withAudience((String[]) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withAudience()
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
+
+        String emptyAud = "   ";
+        verifier = JWTVerifier.init(algorithm)
+                .withAudience(emptyAud)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, hasEntry("aud", Collections.singletonList(emptyAud)));
+    }
+
+    @Test
     public void shouldRemoveAudienceWhenPassingNull() throws Exception {
         Algorithm algorithm = mock(Algorithm.class);
         JWTVerifier verifier = JWTVerifier.init(algorithm)
                 .withAudience("John")
-                .withAudience(null)
+                .withAudience((String) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("aud")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withAudience("John")
+                .withAudience((String[]) null)
                 .build();
 
         assertThat(verifier.claims, is(notNullValue()));
@@ -674,11 +716,52 @@ public class JWTVerifierTest {
         Algorithm algorithm = mock(Algorithm.class);
         JWTVerifier verifier = JWTVerifier.init(algorithm)
                 .withIssuer("iss")
-                .withIssuer(null)
+                .withIssuer((String) null)
                 .build();
 
         assertThat(verifier.claims, is(notNullValue()));
         assertThat(verifier.claims, not(hasKey("iss")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withIssuer("iss")
+                .withIssuer((String[]) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+    }
+
+    @Test
+    public void shouldRemoveIssuerWhenPassingNullReference() throws Exception {
+        Algorithm algorithm = mock(Algorithm.class);
+        JWTVerifier verifier = JWTVerifier.init(algorithm)
+                .withIssuer((String) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withIssuer((String[]) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+
+        verifier = JWTVerifier.init(algorithm)
+                .withIssuer()
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+
+        String emptyIss = "  ";
+        verifier = JWTVerifier.init(algorithm)
+                .withIssuer(emptyIss)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, hasEntry("iss", Collections.singletonList(emptyIss)));
     }
 
     @Test


### PR DESCRIPTION
# Changes

Fixes #404 

- Check for null values on issuer and audience varargs arguments.
- Also fixes test compile warnings for ambiguous null to vararg APIs.

### References

- #404
- #405 

### Testing

- [X] This change adds test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
