### PR TITLE
JavaDoc fix

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -173,6 +173,8 @@ public interface Verification {
 
     /**
      * Skip the Issued At ("iat") date verification. By default, the verification is performed.
+     *
+     * @return this same Verification instance.
      */
     Verification ignoreIssuedAt();
 


### PR DESCRIPTION
### Changes

Add `@return` JavaDoc for `ignoreIssuedAt` method.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
