### PR TITLE
Fixed an NPE on null map and list claims

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -321,7 +321,7 @@ public final class JWTCreator {
         public Builder withClaim(String name, Map<String, ?> map) throws IllegalArgumentException {
             assertNonNull(name);
             // validate map contents
-            if (!validateClaim(map)) {
+            if (map != null && !validateClaim(map)) {
                 throw new IllegalArgumentException("Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, map);
@@ -345,7 +345,7 @@ public final class JWTCreator {
         public Builder withClaim(String name, List<?> list) throws IllegalArgumentException {
             assertNonNull(name);
             // validate list contents
-            if (!validateClaim(list)) {
+            if (list != null && !validateClaim(list)) {
                 throw new IllegalArgumentException("Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, list);

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -15,6 +15,7 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -572,6 +573,40 @@ public class JWTCreatorTest {
         JWTCreator.init()
                 .withClaim("pojo", data)
                 .sign(Algorithm.HMAC256("secret"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldAcceptCustomClaimWithNullMapAndRemoveClaim() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("map", "stubValue")
+                .withClaim("map", (Map<String, ?>) null)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+
+        String body = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> map = (Map<String, Object>) mapper.readValue(body, Map.class);
+        assertThat(map, anEmptyMap());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldAcceptCustomClaimWithNullListAndRemoveClaim() throws Exception {
+        String jwt = JWTCreator.init()
+                .withClaim("list", "stubValue")
+                .withClaim("list", (List<String>) null)
+                .sign(Algorithm.HMAC256("secret"));
+
+        assertThat(jwt, is(notNullValue()));
+        String[] parts = jwt.split("\\.");
+
+        String body = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> map = (Map<String, Object>) mapper.readValue(body, Map.class);
+        assertThat(map, anEmptyMap());
     }
 
     @Test


### PR DESCRIPTION
### Changes

Added a null-check before map and list validation in `withClaim` methods to support the same behavior, like other `withClaim` methods (remove a claim on a not-null key but null value)

### References

https://github.com/auth0/java-jwt/issues/416

### Testing

- Added unit tests for `null` list and map claims
- Built library locally, imported it to the testing project  and run the following code

```
String jwt = JWT.create()
    .withClaim("mapClaim", (Map<String, ?>) null)
    .withClaim("listClaim", (List<String>) null)
    .sign(Algorithm.HMAC256("secret"));
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
