### PR TITLE
Wrap IllegalArgumentException into JWTDecodeException

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -39,6 +39,8 @@ final class JWTDecoder implements DecodedJWT, Serializable {
             payloadJson = StringUtils.newStringUtf8(Base64.decodeBase64(parts[1]));
         } catch (NullPointerException e) {
             throw new JWTDecodeException("The UTF-8 Charset isn't initialized.", e);
+        } catch (IllegalArgumentException e){
+            throw new JWTDecodeException("The input is not a valid base 64 encoded string.", e);
         }
         header = converter.parseHeader(headerJson);
         payload = converter.parsePayload(payloadJson);

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -33,6 +33,13 @@ public class JWTDecoderTest {
 
     // Exceptions
     @Test
+    public void shouldThrowIfTheContentIsNotProperlyEncoded() throws Exception {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage("The input is not a valid base 64 encoded string.");
+        JWT.decode("eyJ0eXAiOiJKV1QiLCJhbGciO-corrupted.eyJ0ZXN0IjoxMjN9.sLtFC2rLAzN0-UJ13OLQX6ezNptAQzespaOGwCnpqk");
+    }
+
+    @Test
     public void shouldThrowIfLessThan3Parts() throws Exception {
         exception.expect(JWTDecodeException.class);
         exception.expectMessage("The token was expected to have 3 parts, but got 2.");


### PR DESCRIPTION
### Changes
Bumping commons-codec to 1.14 introduced a runtime exception when the input was not valid base 64. This PR bumps the commons-codec dependency to the latest version and handles internally that exception, wrapping it into a JWTDecodeException (which is what it represents).

### References

Closes https://github.com/auth0/java-jwt/issues/415

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
