### PR TITLE
add many nullability annotations

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -36,6 +36,7 @@ compileJava {
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.3'
     implementation 'commons-codec:commons-codec:1.14'
+    implementation 'org.jetbrains:annotations:19.0.0'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     testImplementation 'junit:junit:4.12'
     testImplementation 'net.jodah:concurrentunit:0.4.3'

--- a/lib/src/main/java/com/auth0/jwt/ClockImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/ClockImpl.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt;
 
 import com.auth0.jwt.interfaces.Clock;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Date;
 
@@ -17,6 +18,7 @@ final class ClockImpl implements Clock {
     ClockImpl() {
     }
 
+    @NotNull
     @Override
     public Date getToday() {
         return new Date();

--- a/lib/src/main/java/com/auth0/jwt/JWT.java
+++ b/lib/src/main/java/com/auth0/jwt/JWT.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.impl.JWTParser;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("WeakerAccess")
 public class JWT {
@@ -28,7 +29,8 @@ public class JWT {
      * @return a decoded JWT.
      * @throws JWTDecodeException if any part of the token contained an invalid jwt or JSON format of each of the jwt parts.
      */
-    public DecodedJWT decodeJwt(String token) throws JWTDecodeException {
+    @NotNull
+    public DecodedJWT decodeJwt(@NotNull String token) throws JWTDecodeException {
         return new JWTDecoder(parser, token);
     }
 
@@ -41,7 +43,8 @@ public class JWT {
      * @return a decoded JWT.
      * @throws JWTDecodeException if any part of the token contained an invalid jwt or JSON format of each of the jwt parts.
      */
-    public static DecodedJWT decode(String token) throws JWTDecodeException {
+    @NotNull
+    public static DecodedJWT decode(@NotNull String token) throws JWTDecodeException {
         return new JWTDecoder(token);
     }
 
@@ -52,7 +55,8 @@ public class JWT {
      * @return {@link JWTVerifier} builder
      * @throws IllegalArgumentException if the provided algorithm is null.
      */
-    public static Verification require(Algorithm algorithm) {
+    @NotNull
+    public static Verification require(@NotNull Algorithm algorithm) {
         return JWTVerifier.init(algorithm);
     }
 
@@ -61,6 +65,7 @@ public class JWT {
      *
      * @return a token builder.
      */
+    @NotNull
     public static JWTCreator.Builder create() {
         return JWTCreator.init();
     }

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.codec.binary.Base64;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -52,6 +54,7 @@ public final class JWTCreator {
      *
      * @return a JWTCreator.Builder instance to configure.
      */
+    @NotNull
     static JWTCreator.Builder init() {
         return new Builder();
     }
@@ -76,7 +79,8 @@ public final class JWTCreator {
          * @param headerClaims the values to use as Claims in the token's Header.
          * @return this same Builder instance.
          */
-        public Builder withHeader(Map<String, Object> headerClaims) {
+        @NotNull
+        public Builder withHeader(@Nullable Map<String, Object> headerClaims) {
             if (headerClaims == null) {
                 return this;
             }
@@ -99,7 +103,8 @@ public final class JWTCreator {
          * @param keyId the Key Id value.
          * @return this same Builder instance.
          */
-        public Builder withKeyId(String keyId) {
+        @NotNull
+        public Builder withKeyId(@Nullable String keyId) {
             this.headerClaims.put(PublicClaims.KEY_ID, keyId);
             return this;
         }
@@ -110,7 +115,8 @@ public final class JWTCreator {
          * @param issuer the Issuer value.
          * @return this same Builder instance.
          */
-        public Builder withIssuer(String issuer) {
+        @NotNull
+        public Builder withIssuer(@Nullable String issuer) {
             addClaim(PublicClaims.ISSUER, issuer);
             return this;
         }
@@ -121,7 +127,8 @@ public final class JWTCreator {
          * @param subject the Subject value.
          * @return this same Builder instance.
          */
-        public Builder withSubject(String subject) {
+        @NotNull
+        public Builder withSubject(@Nullable String subject) {
             addClaim(PublicClaims.SUBJECT, subject);
             return this;
         }
@@ -132,7 +139,8 @@ public final class JWTCreator {
          * @param audience the Audience value.
          * @return this same Builder instance.
          */
-        public Builder withAudience(String... audience) {
+        @NotNull
+        public Builder withAudience(@Nullable String... audience) {
             addClaim(PublicClaims.AUDIENCE, audience);
             return this;
         }
@@ -143,7 +151,8 @@ public final class JWTCreator {
          * @param expiresAt the Expires At value.
          * @return this same Builder instance.
          */
-        public Builder withExpiresAt(Date expiresAt) {
+        @NotNull
+        public Builder withExpiresAt(@Nullable Date expiresAt) {
             addClaim(PublicClaims.EXPIRES_AT, expiresAt);
             return this;
         }
@@ -154,7 +163,8 @@ public final class JWTCreator {
          * @param notBefore the Not Before value.
          * @return this same Builder instance.
          */
-        public Builder withNotBefore(Date notBefore) {
+        @NotNull
+        public Builder withNotBefore(@Nullable Date notBefore) {
             addClaim(PublicClaims.NOT_BEFORE, notBefore);
             return this;
         }
@@ -165,7 +175,8 @@ public final class JWTCreator {
          * @param issuedAt the Issued At value.
          * @return this same Builder instance.
          */
-        public Builder withIssuedAt(Date issuedAt) {
+        @NotNull
+        public Builder withIssuedAt(@Nullable Date issuedAt) {
             addClaim(PublicClaims.ISSUED_AT, issuedAt);
             return this;
         }
@@ -176,7 +187,8 @@ public final class JWTCreator {
          * @param jwtId the Token Id value.
          * @return this same Builder instance.
          */
-        public Builder withJWTId(String jwtId) {
+        @NotNull
+        public Builder withJWTId(@Nullable String jwtId) {
             addClaim(PublicClaims.JWT_ID, jwtId);
             return this;
         }
@@ -189,7 +201,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Boolean value) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable Boolean value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -203,7 +216,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Integer value) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable Integer value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -217,7 +231,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Long value) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable Long value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -231,7 +246,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Double value) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable Double value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -245,7 +261,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, String value) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable String value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -259,7 +276,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withClaim(String name, Date value) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable Date value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -273,7 +291,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withArrayClaim(String name, String[] items) throws IllegalArgumentException {
+        @NotNull
+        public Builder withArrayClaim(@NotNull String name, @Nullable String[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
             return this;
@@ -287,7 +306,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null.
          */
-        public Builder withArrayClaim(String name, Integer[] items) throws IllegalArgumentException {
+        @NotNull
+        public Builder withArrayClaim(@NotNull String name, @Nullable Integer[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
             return this;
@@ -301,7 +321,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null
          */
-        public Builder withArrayClaim(String name, Long[] items) throws IllegalArgumentException {
+        @NotNull
+        public Builder withArrayClaim(@NotNull String name, @Nullable Long[] items) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, items);
             return this;
@@ -320,7 +341,8 @@ public final class JWTCreator {
          * @return this same Builder instance.
          * @throws IllegalArgumentException if the name is null, or if the map contents does not validate.
          */
-        public Builder withClaim(String name, Map<String, ?> map) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable Map<String, ?> map) throws IllegalArgumentException {
             assertNonNull(name);
             // validate map contents
             if (map != null && !validateClaim(map)) {
@@ -344,7 +366,8 @@ public final class JWTCreator {
          * @throws IllegalArgumentException if the name is null, or if the list contents does not validate.
          */
 
-        public Builder withClaim(String name, List<?> list) throws IllegalArgumentException {
+        @NotNull
+        public Builder withClaim(@NotNull String name, @Nullable List<?> list) throws IllegalArgumentException {
             assertNonNull(name);
             // validate list contents
             if (list != null && !validateClaim(list)) {
@@ -354,7 +377,7 @@ public final class JWTCreator {
             return this;
         }
 
-        private static boolean validateClaim(Map<?, ?> map) {
+        private static boolean validateClaim(@NotNull Map<?, ?> map) {
             // do not accept null values in maps
             for (Entry<?, ?> entry : map.entrySet()) {
                 Object value = entry.getValue();
@@ -369,7 +392,7 @@ public final class JWTCreator {
             return true;
         }
 
-        private static boolean validateClaim(List<?> list) {
+        private static boolean validateClaim(@NotNull List<?> list) {
             // accept null values in list
             for (Object object : list) {
                 if (object != null && !isSupportedType(object)) {
@@ -379,7 +402,7 @@ public final class JWTCreator {
             return true;
         }
 
-        private static boolean isSupportedType(Object value) {
+        private static boolean isSupportedType(@NotNull Object value) {
             if (value instanceof List) {
                 return validateClaim((List<?>) value);
             } else if (value instanceof Map) {
@@ -389,7 +412,7 @@ public final class JWTCreator {
             }
         }
 
-        private static boolean isBasicType(Object value) {
+        private static boolean isBasicType(@NotNull Object value) {
             Class<?> c = value.getClass();
 
             if (c.isArray()) {
@@ -406,7 +429,7 @@ public final class JWTCreator {
          * @throws IllegalArgumentException if the provided algorithm is null.
          * @throws JWTCreationException     if the claims could not be converted to a valid JSON or there was a problem with the signing key.
          */
-        public String sign(Algorithm algorithm) throws IllegalArgumentException, JWTCreationException {
+        public String sign(@NotNull Algorithm algorithm) throws IllegalArgumentException, JWTCreationException {
             if (algorithm == null) {
                 throw new IllegalArgumentException("The Algorithm cannot be null.");
             }
@@ -421,13 +444,13 @@ public final class JWTCreator {
             return new JWTCreator(algorithm, headerClaims, payloadClaims).sign();
         }
 
-        private void assertNonNull(String name) {
+        private void assertNonNull(@NotNull String name) {
             if (name == null) {
                 throw new IllegalArgumentException("The Custom Claim's name can't be null.");
             }
         }
 
-        private void addClaim(String name, Object value) {
+        private void addClaim(@NotNull String name, @Nullable Object value) {
             if (value == null) {
                 payloadClaims.remove(name);
                 return;

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -8,6 +8,8 @@ import com.auth0.jwt.interfaces.Header;
 import com.auth0.jwt.interfaces.Payload;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -28,11 +30,11 @@ final class JWTDecoder implements DecodedJWT, Serializable {
     private final Header header;
     private final Payload payload;
 
-    JWTDecoder(String jwt) throws JWTDecodeException {
+    JWTDecoder(@NotNull String jwt) throws JWTDecodeException {
         this(new JWTParser(), jwt);
     }
 
-    JWTDecoder(JWTParser converter, String jwt) throws JWTDecodeException {
+    JWTDecoder(@NotNull JWTParser converter, @NotNull String jwt) throws JWTDecodeException {
         parts = TokenUtils.splitToken(jwt);
         String headerJson;
         String payloadJson;
@@ -48,91 +50,109 @@ final class JWTDecoder implements DecodedJWT, Serializable {
         payload = converter.parsePayload(payloadJson);
     }
 
+    @Nullable
     @Override
     public String getAlgorithm() {
         return header.getAlgorithm();
     }
 
+    @Nullable
     @Override
     public String getType() {
         return header.getType();
     }
 
+    @Nullable
     @Override
     public String getContentType() {
         return header.getContentType();
     }
 
+    @Nullable
     @Override
     public String getKeyId() {
         return header.getKeyId();
     }
 
+    @NotNull
     @Override
-    public Claim getHeaderClaim(String name) {
+    public Claim getHeaderClaim(@NotNull String name) {
         return header.getHeaderClaim(name);
     }
 
+    @Nullable
     @Override
     public String getIssuer() {
         return payload.getIssuer();
     }
 
+    @Nullable
     @Override
     public String getSubject() {
         return payload.getSubject();
     }
 
+    @Nullable
     @Override
     public List<String> getAudience() {
         return payload.getAudience();
     }
 
+    @Nullable
     @Override
     public Date getExpiresAt() {
         return payload.getExpiresAt();
     }
 
+    @Nullable
     @Override
     public Date getNotBefore() {
         return payload.getNotBefore();
     }
 
+    @Nullable
     @Override
     public Date getIssuedAt() {
         return payload.getIssuedAt();
     }
 
+    @Nullable
     @Override
     public String getId() {
         return payload.getId();
     }
 
+    @NotNull
     @Override
-    public Claim getClaim(String name) {
+    public Claim getClaim(@NotNull String name) {
         return payload.getClaim(name);
     }
 
+    @NotNull
     @Override
     public Map<String, Claim> getClaims() {
         return payload.getClaims();
     }
 
+    @NotNull
     @Override
     public String getHeader() {
         return parts[0];
     }
 
+    @NotNull
     @Override
     public String getPayload() {
         return parts[1];
     }
 
+    @NotNull
     @Override
     public String getSignature() {
         return parts[2];
     }
 
+    @NotNull
     @Override
     public String getToken() {
         return String.format("%s.%s.%s", parts[0], parts[1], parts[2]);

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -8,6 +8,8 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
 
 import java.util.*;
 
@@ -37,7 +39,8 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
      * @return a JWTVerifier.Verification instance to configure.
      * @throws IllegalArgumentException if the provided algorithm is null.
      */
-    static Verification init(Algorithm algorithm) throws IllegalArgumentException {
+    @NotNull
+    static Verification init(@NotNull Algorithm algorithm) throws IllegalArgumentException {
         return new BaseVerification(algorithm);
     }
 
@@ -47,7 +50,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         private long defaultLeeway;
         private boolean ignoreIssuedAt;
 
-        BaseVerification(Algorithm algorithm) throws IllegalArgumentException {
+        BaseVerification(@NotNull Algorithm algorithm) throws IllegalArgumentException {
             if (algorithm == null) {
                 throw new IllegalArgumentException("The Algorithm cannot be null.");
             }
@@ -57,127 +60,146 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             this.defaultLeeway = 0;
         }
 
+        @NotNull
         @Override
         public Verification withIssuer(String... issuer) {
             requireClaim(PublicClaims.ISSUER, isNullOrEmpty(issuer) ? null : Arrays.asList(issuer));
             return this;
         }
 
+        @NotNull
         @Override
         public Verification withSubject(String subject) {
             requireClaim(PublicClaims.SUBJECT, subject);
             return this;
         }
 
+        @NotNull
         @Override
         public Verification withAudience(String... audience) {
             requireClaim(PublicClaims.AUDIENCE, isNullOrEmpty(audience) ? null : Arrays.asList(audience));
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification acceptLeeway(long leeway) throws IllegalArgumentException {
+        public Verification acceptLeeway(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             this.defaultLeeway = leeway;
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification acceptExpiresAt(long leeway) throws IllegalArgumentException {
+        public Verification acceptExpiresAt(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             requireClaim(PublicClaims.EXPIRES_AT, leeway);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification acceptNotBefore(long leeway) throws IllegalArgumentException {
+        public Verification acceptNotBefore(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             requireClaim(PublicClaims.NOT_BEFORE, leeway);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification acceptIssuedAt(long leeway) throws IllegalArgumentException {
+        public Verification acceptIssuedAt(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException {
             assertPositive(leeway);
             requireClaim(PublicClaims.ISSUED_AT, leeway);
             return this;
         }
 
+        @NotNull
         @Override
         public Verification ignoreIssuedAt() {
             this.ignoreIssuedAt = true;
             return this;
         }
 
+        @NotNull
         @Override
         public Verification withJWTId(String jwtId) {
             requireClaim(PublicClaims.JWT_ID, jwtId);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withClaim(String name, Boolean value) throws IllegalArgumentException {
+        public Verification withClaim(@NotNull String name, Boolean value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withClaim(String name, Integer value) throws IllegalArgumentException {
+        public Verification withClaim(@NotNull String name, Integer value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withClaim(String name, Long value) throws IllegalArgumentException {
+        public Verification withClaim(@NotNull String name, Long value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withClaim(String name, Double value) throws IllegalArgumentException {
+        public Verification withClaim(@NotNull String name, Double value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withClaim(String name, String value) throws IllegalArgumentException {
+        public Verification withClaim(@NotNull String name, String value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withClaim(String name, Date value) throws IllegalArgumentException {
+        public Verification withClaim(@NotNull String name, Date value) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, value);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withArrayClaim(String name, String... items) throws IllegalArgumentException {
+        public Verification withArrayClaim(@NotNull String name, String... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException {
+        public Verification withArrayClaim(@NotNull String name, Integer... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
             return this;
         }
 
+        @NotNull
         @Override
-        public Verification withArrayClaim(String name, Long... items) throws IllegalArgumentException {
+        public Verification withArrayClaim(@NotNull String name, Long... items) throws IllegalArgumentException {
             assertNonNull(name);
             requireClaim(name, items);
             return this;
         }
 
+        @NotNull
         @Override
         public JWTVerifier build() {
             return this.build(new ClockImpl());
@@ -257,8 +279,9 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
      * @throws TokenExpiredException          if the token has expired.
      * @throws InvalidClaimException          if a claim contained a different value than the expected one.
      */
+    @NotNull
     @Override
-    public DecodedJWT verify(String token) throws JWTVerificationException {
+    public DecodedJWT verify(@NotNull String token) throws JWTVerificationException {
         DecodedJWT jwt = new JWTDecoder(parser, token);
         return verify(jwt);
     }
@@ -273,8 +296,9 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
      * @throws TokenExpiredException          if the token has expired.
      * @throws InvalidClaimException          if a claim contained a different value than the expected one.
      */
+    @NotNull
     @Override
-    public DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException {
+    public DecodedJWT verify(@NotNull DecodedJWT jwt) throws JWTVerificationException {
         verifyAlgorithm(jwt, algorithm);
         algorithm.verify(jwt);
         verifyClaims(jwt, claims);

--- a/lib/src/main/java/com/auth0/jwt/TokenUtils.java
+++ b/lib/src/main/java/com/auth0/jwt/TokenUtils.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import org.jetbrains.annotations.NotNull;
 
 abstract class TokenUtils {
 
@@ -11,7 +12,8 @@ abstract class TokenUtils {
      * @return the array representing the 3 parts of the token.
      * @throws JWTDecodeException if the Token doesn't have 3 parts.
      */
-    static String[] splitToken(String token) throws JWTDecodeException {
+    @NotNull
+    static String[] splitToken(@NotNull String token) throws JWTDecodeException {
         String[] parts = token.split("\\.");
         if (parts.length == 2 && token.endsWith(".")) {
             //Tokens with alg='none' have empty String as Signature.

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
+import org.jetbrains.annotations.NotNull;
 
 import java.security.interfaces.*;
 
@@ -361,7 +362,7 @@ public abstract class Algorithm {
      * @param jwt the already decoded JWT that it's going to be verified.
      * @throws SignatureVerificationException if the Token's Signature is invalid, meaning that it doesn't match the signatureBytes, or if the Key is invalid.
      */
-    public abstract void verify(DecodedJWT jwt) throws SignatureVerificationException;
+    public abstract void verify(@NotNull DecodedJWT jwt) throws SignatureVerificationException;
 
     /**
      * Sign the given content using this Algorithm instance.
@@ -371,7 +372,8 @@ public abstract class Algorithm {
      * @return the signature in a base64 encoded array of bytes
      * @throws SignatureGenerationException if the Key is invalid.
      */
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    @NotNull
+    public byte[] sign(@NotNull byte[] headerBytes, @NotNull byte[] payloadBytes) throws SignatureGenerationException {
         // default implementation; keep around until sign(byte[]) method is removed
         byte[] contentBytes = new byte[headerBytes.length + 1 + payloadBytes.length];
 
@@ -392,6 +394,7 @@ public abstract class Algorithm {
      */
 
     @Deprecated
-    public abstract byte[] sign(byte[] contentBytes) throws SignatureGenerationException;
+    @NotNull
+    public abstract byte[] sign(@NotNull byte[] contentBytes) throws SignatureGenerationException;
 
 }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -5,6 +5,9 @@ import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import org.apache.commons.codec.binary.Base64;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -24,7 +27,7 @@ class ECDSAAlgorithm extends Algorithm {
     private final int ecNumberSize;
 
     //Visible for testing
-    ECDSAAlgorithm(CryptoHelper crypto, String id, String algorithm, int ecNumberSize, ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
+    ECDSAAlgorithm(CryptoHelper crypto, String id, String algorithm, int ecNumberSize, @NotNull ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
         super(id, algorithm);
         if (keyProvider == null) {
             throw new IllegalArgumentException("The Key Provider cannot be null.");
@@ -39,7 +42,7 @@ class ECDSAAlgorithm extends Algorithm {
     }
 
     @Override
-    public void verify(DecodedJWT jwt) throws SignatureVerificationException {
+    public void verify(@NotNull DecodedJWT jwt) throws SignatureVerificationException {
         byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
 
         try {
@@ -57,8 +60,9 @@ class ECDSAAlgorithm extends Algorithm {
         }
     }
 
+    @NotNull
     @Override
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] headerBytes, @NotNull byte[] payloadBytes) throws SignatureGenerationException {
         try {
             ECPrivateKey privateKey = keyProvider.getPrivateKey();
             if (privateKey == null) {
@@ -71,9 +75,10 @@ class ECDSAAlgorithm extends Algorithm {
         }
     }
 
+    @NotNull
     @Override
     @Deprecated
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] contentBytes) throws SignatureGenerationException {
         try {
             ECPrivateKey privateKey = keyProvider.getPrivateKey();
             if (privateKey == null) {
@@ -215,21 +220,25 @@ class ECDSAAlgorithm extends Algorithm {
     }
 
     //Visible for testing
+    @Contract("null,null -> fail")
     static ECDSAKeyProvider providerForKeys(final ECPublicKey publicKey, final ECPrivateKey privateKey) {
         if (publicKey == null && privateKey == null) {
             throw new IllegalArgumentException("Both provided Keys cannot be null.");
         }
         return new ECDSAKeyProvider() {
+            @Nullable
             @Override
             public ECPublicKey getPublicKeyById(String keyId) {
                 return publicKey;
             }
 
+            @Nullable
             @Override
             public ECPrivateKey getPrivateKey() {
                 return privateKey;
             }
 
+            @Nullable
             @Override
             public String getPrivateKeyId() {
                 return null;

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.commons.codec.binary.Base64;
+import org.jetbrains.annotations.NotNull;
 
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -21,7 +22,7 @@ class HMACAlgorithm extends Algorithm {
     private final byte[] secret;
 
     //Visible for testing
-    HMACAlgorithm(CryptoHelper crypto, String id, String algorithm, byte[] secretBytes) throws IllegalArgumentException {
+    HMACAlgorithm(CryptoHelper crypto, String id, String algorithm, @NotNull byte[] secretBytes) throws IllegalArgumentException {
         super(id, algorithm);
         if (secretBytes == null) {
             throw new IllegalArgumentException("The Secret cannot be null");
@@ -30,16 +31,16 @@ class HMACAlgorithm extends Algorithm {
         this.crypto = crypto;
     }
 
-    HMACAlgorithm(String id, String algorithm, byte[] secretBytes) throws IllegalArgumentException {
+    HMACAlgorithm(String id, String algorithm, @NotNull byte[] secretBytes) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, secretBytes);
     }
 
-    HMACAlgorithm(String id, String algorithm, String secret) throws IllegalArgumentException {
+    HMACAlgorithm(String id, String algorithm, @NotNull String secret) throws IllegalArgumentException {
         this(new CryptoHelper(), id, algorithm, getSecretBytes(secret));
     }
 
     //Visible for testing
-    static byte[] getSecretBytes(String secret) throws IllegalArgumentException {
+    static byte[] getSecretBytes(@NotNull String secret) throws IllegalArgumentException {
         if (secret == null) {
             throw new IllegalArgumentException("The Secret cannot be null");
         }
@@ -47,7 +48,7 @@ class HMACAlgorithm extends Algorithm {
     }
 
     @Override
-    public void verify(DecodedJWT jwt) throws SignatureVerificationException {
+    public void verify(@NotNull DecodedJWT jwt) throws SignatureVerificationException {
         byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
 
         try {
@@ -60,8 +61,9 @@ class HMACAlgorithm extends Algorithm {
         }
     }
 
+    @NotNull
     @Override
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] headerBytes, @NotNull byte[] payloadBytes) throws SignatureGenerationException {
         try {
             return crypto.createSignatureFor(getDescription(), secret, headerBytes, payloadBytes);
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
@@ -69,9 +71,10 @@ class HMACAlgorithm extends Algorithm {
         }
     }
 
+    @NotNull
     @Override
     @Deprecated
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] contentBytes) throws SignatureGenerationException {
         try {
             return crypto.createSignatureFor(getDescription(), secret, contentBytes);
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {

--- a/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.commons.codec.binary.Base64;
+import org.jetbrains.annotations.NotNull;
 
 class NoneAlgorithm extends Algorithm {
 
@@ -12,21 +13,23 @@ class NoneAlgorithm extends Algorithm {
     }
 
     @Override
-    public void verify(DecodedJWT jwt) throws SignatureVerificationException {
+    public void verify(@NotNull DecodedJWT jwt) throws SignatureVerificationException {
         byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
         if (signatureBytes.length > 0) {
             throw new SignatureVerificationException(this);
         }
     }
 
+    @NotNull
     @Override
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] headerBytes, @NotNull byte[] payloadBytes) throws SignatureGenerationException {
         return new byte[0];
     }
 
+    @NotNull
     @Override
     @Deprecated
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] contentBytes) throws SignatureGenerationException {
         return new byte[0];
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -5,8 +5,9 @@ import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.apache.commons.codec.binary.Base64;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
@@ -38,7 +39,7 @@ class RSAAlgorithm extends Algorithm {
     }
 
     @Override
-    public void verify(DecodedJWT jwt) throws SignatureVerificationException {
+    public void verify(@NotNull DecodedJWT jwt) throws SignatureVerificationException {
         byte[] signatureBytes = Base64.decodeBase64(jwt.getSignature());
 
         try {
@@ -55,9 +56,9 @@ class RSAAlgorithm extends Algorithm {
         }
     }
 
+    @NotNull
     @Override
-    @Deprecated
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] headerBytes, @NotNull byte[] payloadBytes) throws SignatureGenerationException {
         try {
             RSAPrivateKey privateKey = keyProvider.getPrivateKey();
             if (privateKey == null) {
@@ -69,8 +70,10 @@ class RSAAlgorithm extends Algorithm {
         }
     }
     
+    @Deprecated
+    @NotNull
     @Override
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+    public byte[] sign(@NotNull byte[] contentBytes) throws SignatureGenerationException {
         try {
             RSAPrivateKey privateKey = keyProvider.getPrivateKey();
             if (privateKey == null) {
@@ -93,16 +96,19 @@ class RSAAlgorithm extends Algorithm {
             throw new IllegalArgumentException("Both provided Keys cannot be null.");
         }
         return new RSAKeyProvider() {
+            @Nullable
             @Override
             public RSAPublicKey getPublicKeyById(String keyId) {
                 return publicKey;
             }
 
+            @Nullable
             @Override
             public RSAPrivateKey getPrivateKey() {
                 return privateKey;
             }
 
+            @Nullable
             @Override
             public String getPrivateKeyId() {
                 return null;

--- a/lib/src/main/java/com/auth0/jwt/impl/BasicHeader.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/BasicHeader.java
@@ -4,6 +4,8 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.Header;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -38,28 +40,33 @@ class BasicHeader implements Header, Serializable {
         return tree;
     }
 
+    @Nullable
     @Override
     public String getAlgorithm() {
         return algorithm;
     }
 
+    @Nullable
     @Override
     public String getType() {
         return type;
     }
 
+    @Nullable
     @Override
     public String getContentType() {
         return contentType;
     }
 
+    @Nullable
     @Override
     public String getKeyId() {
         return keyId;
     }
 
+    @NotNull
     @Override
-    public Claim getHeaderClaim(String name) {
+    public Claim getHeaderClaim(@NotNull String name) {
         return extractClaim(name, tree, objectReader);
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
@@ -20,14 +21,15 @@ public class JWTParser implements JWTPartsParser {
         this(getDefaultObjectMapper());
     }
 
-    JWTParser(ObjectMapper mapper) {
+    JWTParser(@NotNull ObjectMapper mapper) {
         addDeserializers(mapper);
         this.payloadReader = mapper.readerFor(Payload.class);
         this.headerReader = mapper.readerFor(Header.class);
     }
 
+    @NotNull
     @Override
-    public Payload parsePayload(String json) throws JWTDecodeException {
+    public Payload parsePayload(@NotNull String json) throws JWTDecodeException {
         if (json == null) {
             throw decodeException();
         }
@@ -39,8 +41,9 @@ public class JWTParser implements JWTPartsParser {
         }
     }
 
+    @NotNull
     @Override
-    public Header parseHeader(String json) throws JWTDecodeException {
+    public Header parseHeader(@NotNull String json) throws JWTDecodeException {
         if (json == null) {
             throw decodeException();
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
@@ -29,31 +31,37 @@ class JsonNodeClaim implements Claim {
         this.objectReader = objectReader;
     }
 
+    @Nullable
     @Override
     public Boolean asBoolean() {
         return !data.isBoolean() ? null : data.asBoolean();
     }
 
+    @Nullable
     @Override
     public Integer asInt() {
         return !data.isNumber() ? null : data.asInt();
     }
 
+    @Nullable
     @Override
     public Long asLong() {
         return !data.isNumber() ? null : data.asLong();
     }
 
+    @Nullable
     @Override
     public Double asDouble() {
         return !data.isNumber() ? null : data.asDouble();
     }
 
+    @Nullable
     @Override
     public String asString() {
         return !data.isTextual() ? null : data.asText();
     }
 
+    @Nullable
     @Override
     public Date asDate() {
         if (!data.canConvertToLong()) {
@@ -63,9 +71,10 @@ class JsonNodeClaim implements Claim {
         return new Date(seconds * 1000);
     }
 
+    @Nullable
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T[] asArray(Class<T> tClazz) throws JWTDecodeException {
+    public <T> T[] asArray(@NotNull Class<T> tClazz) throws JWTDecodeException {
         if (!data.isArray()) {
             return null;
         }
@@ -81,8 +90,9 @@ class JsonNodeClaim implements Claim {
         return arr;
     }
 
+    @Nullable
     @Override
-    public <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException {
+    public <T> List<T> asList(@NotNull Class<T> tClazz) throws JWTDecodeException {
         if (!data.isArray()) {
             return null;
         }
@@ -98,6 +108,7 @@ class JsonNodeClaim implements Claim {
         return list;
     }
 
+    @Nullable
     @Override
     public Map<String, Object> asMap() throws JWTDecodeException {
         if (!data.isObject()) {
@@ -114,8 +125,9 @@ class JsonNodeClaim implements Claim {
         }
     }
 
+    @Nullable
     @Override
-    public <T> T as(Class<T> tClazz) throws JWTDecodeException {
+    public <T> T as(@NotNull Class<T> tClazz) throws JWTDecodeException {
         try {
             return objectReader.treeAsTokens(data).readValueAs(tClazz);
         } catch (IOException e) {
@@ -135,7 +147,8 @@ class JsonNodeClaim implements Claim {
      * @param tree      the JsonNode tree to search the Claim in.
      * @return a valid non-null Claim.
      */
-    static Claim extractClaim(String claimName, Map<String, JsonNode> tree, ObjectReader objectReader) {
+    @NotNull
+    static Claim extractClaim(@NotNull String claimName, @NotNull Map<String, JsonNode> tree, @NotNull ObjectReader objectReader) {
         JsonNode node = tree.get(claimName);
         return claimFromNode(node, objectReader);
     }
@@ -146,7 +159,8 @@ class JsonNodeClaim implements Claim {
      * @param node the JsonNode to convert into a Claim.
      * @return a valid Claim instance. If the node is null or missing, a NullClaim will be returned.
      */
-    static Claim claimFromNode(JsonNode node, ObjectReader objectReader) {
+    @NotNull
+    static Claim claimFromNode(@Nullable JsonNode node, @NotNull ObjectReader objectReader) {
         if (node == null || node.isNull() || node.isMissingNode()) {
             return new NullClaim();
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -2,6 +2,8 @@ package com.auth0.jwt.impl;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Date;
 import java.util.List;
@@ -16,53 +18,63 @@ public class NullClaim implements Claim {
         return true;
     }
 
+    @Nullable
     @Override
     public Boolean asBoolean() {
         return null;
     }
 
+    @Nullable
     @Override
     public Integer asInt() {
         return null;
     }
 
+    @Nullable
     @Override
     public Long asLong() {
         return null;
     }
 
+    @Nullable
     @Override
     public Double asDouble() {
         return null;
     }
 
+    @Nullable
     @Override
     public String asString() {
         return null;
     }
 
+    @Nullable
     @Override
     public Date asDate() {
         return null;
     }
 
+    @Nullable
     @Override
-    public <T> T[] asArray(Class<T> tClazz) throws JWTDecodeException {
+    public <T> T [] asArray(@NotNull Class<T> tClazz) throws JWTDecodeException {
         return null;
     }
 
+    @Nullable
     @Override
-    public <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException {
+    public <T> List<T> asList(@NotNull Class<T> tClazz) throws JWTDecodeException {
         return null;
     }
 
+    @Nullable
     @Override
     public Map<String, Object> asMap() throws JWTDecodeException {
         return null;
     }
 
+    @Nullable
     @Override
-    public <T> T as(Class<T> tClazz) throws JWTDecodeException {
+    public <T> T as(@NotNull Class<T> tClazz) throws JWTDecodeException {
         return null;
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
@@ -4,6 +4,8 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.Payload;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.*;
@@ -47,46 +49,55 @@ class PayloadImpl implements Payload, Serializable {
         return tree;
     }
 
+    @Nullable
     @Override
     public String getIssuer() {
         return issuer;
     }
 
+    @Nullable
     @Override
     public String getSubject() {
         return subject;
     }
 
+    @Nullable
     @Override
     public List<String> getAudience() {
         return audience;
     }
 
+    @Nullable
     @Override
     public Date getExpiresAt() {
         return expiresAt;
     }
 
+    @Nullable
     @Override
     public Date getNotBefore() {
         return notBefore;
     }
 
+    @Nullable
     @Override
     public Date getIssuedAt() {
         return issuedAt;
     }
 
+    @Nullable
     @Override
     public String getId() {
         return jwtId;
     }
 
+    @NotNull
     @Override
-    public Claim getClaim(String name) {
+    public Claim getClaim(@NotNull String name) {
         return extractClaim(name, tree, objectReader);
     }
 
+    @NotNull
     @Override
     public Map<String, Claim> getClaims() {
         Map<String, Claim> claims = new HashMap<>(tree.size() * 2);

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -1,6 +1,8 @@
 package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Date;
 import java.util.List;
@@ -24,6 +26,7 @@ public interface Claim {
      *
      * @return the value as a Boolean or null.
      */
+    @Nullable
     Boolean asBoolean();
 
     /**
@@ -32,6 +35,7 @@ public interface Claim {
      *
      * @return the value as an Integer or null.
      */
+    @Nullable
     Integer asInt();
 
     /**
@@ -40,6 +44,7 @@ public interface Claim {
      *
      * @return the value as an Long or null.
      */
+    @Nullable
     Long asLong();
 
     /**
@@ -48,6 +53,7 @@ public interface Claim {
      *
      * @return the value as a Double or null.
      */
+    @Nullable
     Double asDouble();
 
     /**
@@ -56,6 +62,7 @@ public interface Claim {
      *
      * @return the value as a String or null.
      */
+    @Nullable
     String asString();
 
     /**
@@ -64,6 +71,7 @@ public interface Claim {
      *
      * @return the value as a Date or null.
      */
+    @Nullable
     Date asDate();
 
     /**
@@ -74,7 +82,8 @@ public interface Claim {
      * @return the value as an Array or null.
      * @throws JWTDecodeException if the values inside the Array can't be converted to a class T.
      */
-    <T> T[] asArray(Class<T> tClazz) throws JWTDecodeException;
+    @Nullable
+    <T> T[] asArray(@NotNull Class<T> tClazz) throws JWTDecodeException;
 
     /**
      * Get this Claim as a List of type T.
@@ -85,7 +94,8 @@ public interface Claim {
      * @return the value as a List or null.
      * @throws JWTDecodeException if the values inside the List can't be converted to a class T.
      */
-    <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException;
+    @Nullable
+    <T> List<T> asList(@NotNull Class<T> tClazz) throws JWTDecodeException;
 
     /**
      * Get this Claim as a generic Map of values.
@@ -93,6 +103,7 @@ public interface Claim {
      * @return the value as instance of Map.
      * @throws JWTDecodeException if the value can't be converted to a Map.
      */
+    @Nullable
     Map<String, Object> asMap() throws JWTDecodeException;
 
     /**
@@ -103,5 +114,6 @@ public interface Claim {
      * @return the value as instance of T.
      * @throws JWTDecodeException if the value can't be converted to a class T.
      */
-    <T> T as(Class<T> tClazz) throws JWTDecodeException;
+    @Nullable
+    <T> T as(@NotNull Class<T> tClazz) throws JWTDecodeException;
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Clock.java
@@ -1,5 +1,7 @@
 package com.auth0.jwt.interfaces;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Date;
 
 /**
@@ -12,5 +14,6 @@ public interface Clock {
      *
      * @return a new Date representing Today's time.
      */
+    @NotNull
     Date getToday();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/DecodedJWT.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/DecodedJWT.java
@@ -1,5 +1,7 @@
 package com.auth0.jwt.interfaces;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Class that represents a Json Web Token that was decoded from it's string representation.
  */
@@ -9,6 +11,7 @@ public interface DecodedJWT extends Payload, Header {
      *
      * @return the String Token.
      */
+    @NotNull
     String getToken();
 
     /**
@@ -17,6 +20,7 @@ public interface DecodedJWT extends Payload, Header {
      *
      * @return the Header of the JWT.
      */
+    @NotNull
     String getHeader();
 
     /**
@@ -25,6 +29,7 @@ public interface DecodedJWT extends Payload, Header {
      *
      * @return the Payload of the JWT.
      */
+    @NotNull
     String getPayload();
 
     /**
@@ -33,5 +38,6 @@ public interface DecodedJWT extends Payload, Header {
      *
      * @return the Signature of the JWT.
      */
+    @NotNull
     String getSignature();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Header.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Header.java
@@ -1,5 +1,8 @@
 package com.auth0.jwt.interfaces;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * The Header class represents the 1st part of the JWT, where the Header value is hold.
  */
@@ -10,6 +13,7 @@ public interface Header {
      *
      * @return the Algorithm defined or null.
      */
+    @Nullable
     String getAlgorithm();
 
     /**
@@ -17,6 +21,7 @@ public interface Header {
      *
      * @return the Type defined or null.
      */
+    @Nullable
     String getType();
 
     /**
@@ -24,6 +29,7 @@ public interface Header {
      *
      * @return the Content Type defined or null.
      */
+    @Nullable
     String getContentType();
 
     /**
@@ -31,6 +37,7 @@ public interface Header {
      *
      * @return the Key ID value or null.
      */
+    @Nullable
     String getKeyId();
 
     /**
@@ -39,5 +46,6 @@ public interface Header {
      * @param name the name of the Claim to retrieve.
      * @return a non-null Claim.
      */
-    Claim getHeaderClaim(String name);
+    @NotNull
+    Claim getHeaderClaim(@NotNull String name);
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/JWTPartsParser.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/JWTPartsParser.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The JWTPartsParser class defines which parts of the JWT should be converted to it's specific Object representation instance.
@@ -14,7 +15,8 @@ public interface JWTPartsParser {
      * @return the Payload.
      * @throws JWTDecodeException if the json doesn't have a proper JSON format.
      */
-    Payload parsePayload(String json) throws JWTDecodeException;
+    @NotNull
+    Payload parsePayload(@NotNull String json) throws JWTDecodeException;
 
     /**
      * Parses the given JSON into a Header instance.
@@ -23,5 +25,6 @@ public interface JWTPartsParser {
      * @return the Header.
      * @throws JWTDecodeException if the json doesn't have a proper JSON format.
      */
-    Header parseHeader(String json) throws JWTDecodeException;
+    @NotNull
+    Header parseHeader(@NotNull String json) throws JWTDecodeException;
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/JWTVerifier.java
@@ -1,6 +1,7 @@
 package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import org.jetbrains.annotations.NotNull;
 
 
 public interface JWTVerifier {
@@ -12,6 +13,7 @@ public interface JWTVerifier {
      * @return a verified and decoded JWT.
      * @throws JWTVerificationException if any of the verification steps fail
      */
+    @NotNull
     DecodedJWT verify(String token) throws JWTVerificationException;
 
     /**
@@ -21,5 +23,6 @@ public interface JWTVerifier {
      * @return a verified and decoded JWT.
      * @throws JWTVerificationException if any of the verification steps fail
      */
+    @NotNull
     DecodedJWT verify(DecodedJWT jwt) throws JWTVerificationException;
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
@@ -1,5 +1,7 @@
 package com.auth0.jwt.interfaces;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.security.PrivateKey;
 import java.security.PublicKey;
 
@@ -17,6 +19,7 @@ interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
      * @param keyId the Key Id specified in the Token's Header or null if none is available. Provides a hint on which Public Key to use to verify the token's signature.
      * @return the Public Key instance
      */
+    @Nullable
     U getPublicKeyById(String keyId);
 
     /**
@@ -24,6 +27,7 @@ interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
      *
      * @return the Private Key instance
      */
+    @Nullable
     R getPrivateKey();
 
     /**
@@ -31,5 +35,6 @@ interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
      *
      * @return the Key Id that identifies the Private Key or null if it's not specified.
      */
+    @Nullable
     String getPrivateKeyId();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -1,5 +1,9 @@
 package com.auth0.jwt.interfaces;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +18,7 @@ public interface Payload {
      *
      * @return the Issuer value or null.
      */
+    @Nullable
     String getIssuer();
 
     /**
@@ -21,6 +26,7 @@ public interface Payload {
      *
      * @return the Subject value or null.
      */
+    @Nullable
     String getSubject();
 
     /**
@@ -28,6 +34,7 @@ public interface Payload {
      *
      * @return the Audience value or null.
      */
+    @Nullable
     List<String> getAudience();
 
     /**
@@ -35,6 +42,7 @@ public interface Payload {
      *
      * @return the Expiration Time value or null.
      */
+    @Nullable
     Date getExpiresAt();
 
     /**
@@ -42,6 +50,7 @@ public interface Payload {
      *
      * @return the Not Before value or null.
      */
+    @Nullable
     Date getNotBefore();
 
     /**
@@ -49,6 +58,7 @@ public interface Payload {
      *
      * @return the Issued At value or null.
      */
+    @Nullable
     Date getIssuedAt();
 
     /**
@@ -56,6 +66,7 @@ public interface Payload {
      *
      * @return the JWT ID value or null.
      */
+    @Nullable
     String getId();
 
     /**
@@ -64,12 +75,15 @@ public interface Payload {
      * @param name the name of the Claim to retrieve.
      * @return a non-null Claim.
      */
-    Claim getClaim(String name);
+    @NotNull
+    Claim getClaim(@NotNull String name);
 
     /**
      * Get the Claims defined in the Token.
      *
      * @return a non-null Map containing the Claims defined in the Token.
      */
+    @NotNull
+    @Unmodifiable
     Map<String, Claim> getClaims();
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -1,6 +1,9 @@
 package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.JWTVerifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 import java.util.Date;
 
@@ -14,7 +17,8 @@ public interface Verification {
      * @param issuer the required Issuer value. If multiple values are given, the claim must at least match one of them
      * @return this same Verification instance.
      */
-    Verification withIssuer(String... issuer);
+    @NotNull
+    Verification withIssuer(@Nullable String... issuer);
 
     /**
      * Require a specific Subject ("sub") claim.
@@ -22,7 +26,8 @@ public interface Verification {
      * @param subject the required Subject value
      * @return this same Verification instance.
      */
-    Verification withSubject(String subject);
+    @NotNull
+    Verification withSubject(@Nullable String subject);
 
     /**
      * Require a specific Audience ("aud") claim.
@@ -30,7 +35,8 @@ public interface Verification {
      * @param audience the required Audience value
      * @return this same Verification instance.
      */
-    Verification withAudience(String... audience);
+    @NotNull
+    Verification withAudience(@Nullable String... audience);
 
     /**
      * Define the default window in seconds in which the Not Before, Issued At and Expires At Claims will still be valid.
@@ -40,7 +46,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if leeway is negative.
      */
-    Verification acceptLeeway(long leeway) throws IllegalArgumentException;
+    @NotNull
+    Verification acceptLeeway(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException;
 
     /**
      * Set a specific leeway window in seconds in which the Expires At ("exp") Claim will still be valid.
@@ -50,7 +57,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if leeway is negative.
      */
-    Verification acceptExpiresAt(long leeway) throws IllegalArgumentException;
+    @NotNull
+    Verification acceptExpiresAt(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException;
 
     /**
      * Set a specific leeway window in seconds in which the Not Before ("nbf") Claim will still be valid.
@@ -60,7 +68,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if leeway is negative.
      */
-    Verification acceptNotBefore(long leeway) throws IllegalArgumentException;
+    @NotNull
+    Verification acceptNotBefore(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException;
 
     /**
      * Set a specific leeway window in seconds in which the Issued At ("iat") Claim will still be valid.
@@ -70,7 +79,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if leeway is negative.
      */
-    Verification acceptIssuedAt(long leeway) throws IllegalArgumentException;
+    @NotNull
+    Verification acceptIssuedAt(@Range(from = 0, to = Long.MAX_VALUE) long leeway) throws IllegalArgumentException;
 
     /**
      * Require a specific JWT Id ("jti") claim.
@@ -78,7 +88,8 @@ public interface Verification {
      * @param jwtId the required Id value
      * @return this same Verification instance.
      */
-    Verification withJWTId(String jwtId);
+    @NotNull
+    Verification withJWTId(@Nullable String jwtId);
 
     /**
      * Require a specific Claim value.
@@ -88,7 +99,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, Boolean value) throws IllegalArgumentException;
+    @NotNull
+    Verification withClaim(@NotNull String name, @Nullable Boolean value) throws IllegalArgumentException;
 
     /**
      * Require a specific Claim value.
@@ -98,7 +110,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, Integer value) throws IllegalArgumentException;
+    @NotNull
+    Verification withClaim(@NotNull String name, @Nullable Integer value) throws IllegalArgumentException;
 
     /**
      * Require a specific Claim value.
@@ -108,7 +121,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, Long value) throws IllegalArgumentException;
+    @NotNull
+    Verification withClaim(@NotNull String name, @Nullable Long value) throws IllegalArgumentException;
 
     /**
      * Require a specific Claim value.
@@ -118,7 +132,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, Double value) throws IllegalArgumentException;
+    @NotNull
+    Verification withClaim(@NotNull String name, @Nullable Double value) throws IllegalArgumentException;
 
     /**
      * Require a specific Claim value.
@@ -128,7 +143,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, String value) throws IllegalArgumentException;
+    @NotNull
+    Verification withClaim(@NotNull String name, @Nullable String value) throws IllegalArgumentException;
 
     /**
      * Require a specific Claim value.
@@ -138,7 +154,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withClaim(String name, Date value) throws IllegalArgumentException;
+    @NotNull
+    Verification withClaim(@NotNull String name, @Nullable Date value) throws IllegalArgumentException;
 
     /**
      * Require a specific Array Claim to contain at least the given items.
@@ -148,7 +165,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withArrayClaim(String name, String... items) throws IllegalArgumentException;
+    @NotNull
+    Verification withArrayClaim(@NotNull String name, @Nullable String... items) throws IllegalArgumentException;
 
     /**
      * Require a specific Array Claim to contain at least the given items.
@@ -158,7 +176,8 @@ public interface Verification {
      * @return this same Verification instance.
      * @throws IllegalArgumentException if the name is null.
      */
-    Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException;
+    @NotNull
+    Verification withArrayClaim(@NotNull String name, @Nullable Integer... items) throws IllegalArgumentException;
 
     /**
      * Require a specific Array Claim to contain at least the given items.
@@ -169,13 +188,15 @@ public interface Verification {
      * @throws IllegalArgumentException if the name is null.
      */
 
-    Verification withArrayClaim(String name, Long ... items) throws IllegalArgumentException;
+    @NotNull
+    Verification withArrayClaim(@NotNull String name, @Nullable Long ... items) throws IllegalArgumentException;
 
     /**
      * Skip the Issued At ("iat") date verification. By default, the verification is performed.
      *
      * @return this same Verification instance.
      */
+    @NotNull
     Verification ignoreIssuedAt();
 
     /**
@@ -183,5 +204,6 @@ public interface Verification {
      *
      * @return a new JWTVerifier instance.
      */
+    @NotNull
     JWTVerifier build();
 }


### PR DESCRIPTION
### Changes

- No executable code changed
- Added `@Nullable` and `@NotNull` annotations to most public API methods (and some internal where nulls were checked for)
- Added `@Contact` to `com.auth0.jwt.algorithms.ECDSAAlgorithm#providerForKeys` as its null requirements are a little more complex
- Added `@Range` to `com.auth0.jwt.interfaces.Verification` leeway parameters

### References

Primarily useful for IDEs & static analysis, and also super helpful for Kotlin, where nullability is built into the type system.
This project is used in [Ktor](https://ktor.io/)

https://www.jetbrains.com/help/idea/nullable-and-notnull-annotations.html
https://kotlinlang.org/docs/reference/java-interop.html#nullability-annotations

### Testing

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java 

Gradle tests ran on OpenJDK 11.0.5

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
