### PR TITLE
Add ability to verify claim presence

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -300,33 +300,37 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             if (entry.getValue() instanceof NonEmptyClaim) {
                 assertClaimPresent(jwt.getClaim(entry.getKey()), entry.getKey());
             } else {
-                switch (entry.getKey()) {
-                    case PublicClaims.AUDIENCE:
-                        assertValidAudienceClaim(jwt.getAudience(), (List<String>) entry.getValue());
-                        break;
-                    case PublicClaims.EXPIRES_AT:
-                        assertValidDateClaim(jwt.getExpiresAt(), (Long) entry.getValue(), true);
-                        break;
-                    case PublicClaims.ISSUED_AT:
-                        assertValidDateClaim(jwt.getIssuedAt(), (Long) entry.getValue(), false);
-                        break;
-                    case PublicClaims.NOT_BEFORE:
-                        assertValidDateClaim(jwt.getNotBefore(), (Long) entry.getValue(), false);
-                        break;
-                    case PublicClaims.ISSUER:
-                        assertValidIssuerClaim(jwt.getIssuer(), (List<String>) entry.getValue());
-                        break;
-                    case PublicClaims.JWT_ID:
-                        assertValidStringClaim(entry.getKey(), jwt.getId(), (String) entry.getValue());
-                        break;
-                    case PublicClaims.SUBJECT:
-                        assertValidStringClaim(entry.getKey(), jwt.getSubject(), (String) entry.getValue());
-                        break;
-                    default:
-                        assertValidClaim(jwt.getClaim(entry.getKey()), entry.getKey(), entry.getValue());
-                        break;
-                }
+                verifyClaimValues(jwt, entry);
             }
+        }
+    }
+
+    private void verifyClaimValues(DecodedJWT jwt, Map.Entry<String, Object> entry) {
+        switch (entry.getKey()) {
+            case PublicClaims.AUDIENCE:
+                assertValidAudienceClaim(jwt.getAudience(), (List<String>) entry.getValue());
+                break;
+            case PublicClaims.EXPIRES_AT:
+                assertValidDateClaim(jwt.getExpiresAt(), (Long) entry.getValue(), true);
+                break;
+            case PublicClaims.ISSUED_AT:
+                assertValidDateClaim(jwt.getIssuedAt(), (Long) entry.getValue(), false);
+                break;
+            case PublicClaims.NOT_BEFORE:
+                assertValidDateClaim(jwt.getNotBefore(), (Long) entry.getValue(), false);
+                break;
+            case PublicClaims.ISSUER:
+                assertValidIssuerClaim(jwt.getIssuer(), (List<String>) entry.getValue());
+                break;
+            case PublicClaims.JWT_ID:
+                assertValidStringClaim(entry.getKey(), jwt.getId(), (String) entry.getValue());
+                break;
+            case PublicClaims.SUBJECT:
+                assertValidStringClaim(entry.getKey(), jwt.getSubject(), (String) entry.getValue());
+                break;
+            default:
+                assertValidClaim(jwt.getClaim(entry.getKey()), entry.getKey(), entry.getValue());
+                break;
         }
     }
 

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -119,7 +119,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         @Override
         public Verification withClaimPresence(String name) throws IllegalArgumentException {
             assertNonNull(name);
-            requireClaim(name, new NonEmptyClaim(){});
+            requireClaim(name, NonEmptyClaim.getInstance());
             return this;
         }
 
@@ -420,7 +420,18 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
     }
 
     /**
-     * Marker interface used to verify a claim is present, regardless of the claim's value.
+     * Simple singleton used to mark that a claim should only be verified for presence.
      */
-    private interface NonEmptyClaim {}
+    private static class NonEmptyClaim {
+        private static NonEmptyClaim nonEmptyClaim;
+
+        private NonEmptyClaim() {}
+
+        public static NonEmptyClaim getInstance() {
+            if (nonEmptyClaim == null) {
+                nonEmptyClaim = new NonEmptyClaim();
+            }
+            return nonEmptyClaim;
+        }
+    }
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -88,8 +88,6 @@ public interface Verification {
      */
     Verification withClaimPresence(String name) throws IllegalArgumentException;
 
-//    Verification withClaimPresence(String name, Class<?> clazz) throws IllegalArgumentException;
-
     /**
      * Require a specific Claim value.
      *

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -81,6 +81,16 @@ public interface Verification {
     Verification withJWTId(String jwtId);
 
     /**
+     * Require a claim to be present, with any value.
+     * @param name the Claim's name.
+     * @return this same Verification instance
+     * @throws IllegalArgumentException if the name is null.
+     */
+    Verification withClaimPresence(String name) throws IllegalArgumentException;
+
+//    Verification withClaimPresence(String name, Class<?> clazz) throws IllegalArgumentException;
+
+    /**
      * Require a specific Claim value.
      *
      * @param name  the Claim's name.

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -790,4 +790,132 @@ public class JWTVerifierTest {
 
         assertThat(jwt, is(notNullValue()));
     }
+
+    @Test
+    public void shouldThrowWhenVerifyingClaimPresenceButClaimNotPresent() {
+        exception.expect(InvalidClaimException.class);
+        exception.expectMessage("The Claim 'missing' is not present in the JWT.");
+
+        String jwt = JWTCreator.init()
+                .withClaim("custom", "")
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("missing")
+                .build();
+
+        verifier.verify(jwt);
+    }
+
+    @Test
+    public void shouldVerifyStringClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", "")
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyBooleanClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", true)
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyIntegerClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", 123)
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyLongClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", 922337203685477600L)
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyDoubleClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", 12.34)
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyListClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", Collections.singletonList("item"))
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyMapClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("custom", Collections.singletonMap("key", "value"))
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("custom")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldVerifyStandardClaimPresence() {
+        String jwt = JWTCreator.init()
+                .withClaim("aud", "any value")
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence("aud")
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(jwt);
+        assertThat(decodedJWT, is(notNullValue()));
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -808,6 +808,19 @@ public class JWTVerifierTest {
     }
 
     @Test
+    public void shouldThrowWhenVerifyingClaimPresenceWhenClaimNameIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The Custom Claim's name can't be null.");
+
+        String jwt = JWTCreator.init()
+                .withClaim("custom", "value")
+                .sign(Algorithm.HMAC256("secret"));
+
+        JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaimPresence(null);
+    }
+
+    @Test
     public void shouldVerifyStringClaimPresence() {
         String jwt = JWTCreator.init()
                 .withClaim("custom", "")


### PR DESCRIPTION
### Changes

As raised in #360, we should provide the ability to verify a claim's presence, regardless of value.

This change adds a new `Verification` method, `withClaimPresence(String name)`. It will throw an `InvalidClaimException` if the JWT does not contain the specified claim.

This change does **not** add the ability to verify a claim is present and of a specific type. That may be a feature we wish to add at some point, but we'd need to consider how best to surface that without exposing any of Jackson's node types. Such a change wouldn't impact the new method added in this PR, so we can still provide value here with the new presence check method.

### References

#360 

### Testing

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
