### PR TITLE
Feature/#445 - withPayload(Map<String, Object> payloadClaims) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ implementation 'com.auth0:java-jwt:3.11.0'
 
 The library implements JWT Verification and Signing using the following algorithms:
 
-| JWS | Algorithm | Description |
-| :-------------: | :-------------: | :----- |
-| HS256 | HMAC256 | HMAC with SHA-256 |
-| HS384 | HMAC384 | HMAC with SHA-384 |
-| HS512 | HMAC512 | HMAC with SHA-512 |
-| RS256 | RSA256 | RSASSA-PKCS1-v1_5 with SHA-256 |
-| RS384 | RSA384 | RSASSA-PKCS1-v1_5 with SHA-384 |
-| RS512 | RSA512 | RSASSA-PKCS1-v1_5 with SHA-512 |
-| ES256 | ECDSA256 | ECDSA with curve P-256 and SHA-256 |
-| ES256K | ECDSA256 | ECDSA with curve secp256k1 and SHA-256 |
-| ES384 | ECDSA384 | ECDSA with curve P-384 and SHA-384 |
-| ES512 | ECDSA512 | ECDSA with curve P-521 and SHA-512 |
+|  JWS   | Algorithm | Description                            |
+| :----: | :-------: | :------------------------------------- |
+| HS256  |  HMAC256  | HMAC with SHA-256                      |
+| HS384  |  HMAC384  | HMAC with SHA-384                      |
+| HS512  |  HMAC512  | HMAC with SHA-512                      |
+| RS256  |  RSA256   | RSASSA-PKCS1-v1_5 with SHA-256         |
+| RS384  |  RSA384   | RSASSA-PKCS1-v1_5 with SHA-384         |
+| RS512  |  RSA512   | RSASSA-PKCS1-v1_5 with SHA-512         |
+| ES256  | ECDSA256  | ECDSA with curve P-256 and SHA-256     |
+| ES256K | ECDSA256  | ECDSA with curve secp256k1 and SHA-256 |
+| ES384  | ECDSA384  | ECDSA with curve P-384 and SHA-384     |
+| ES512  | ECDSA512  | ECDSA with curve P-521 and SHA-512     |
 
 ## Usage
 
@@ -367,6 +367,16 @@ When creating a Token with the `JWT.create()` you can specify a custom Claim by 
 String token = JWT.create()
         .withClaim("name", 123)
         .withArrayClaim("array", new Integer[]{1, 2, 3})
+        .sign(algorithm);
+```
+
+Or using `withPayload()` and passing a map of claims.
+
+```java
+Map<String, Object> payloadClaims = new HashMap();
+payloadClaims.put("@context", "https://auth0.com/");
+String token = JWT.create()
+        .withPayload(payloadClaims)
         .sign(algorithm);
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're looking for an **Android** version of the JWT Decoder take a look at o
 ## Installation
 
 The library is available on both Maven Central and Bintray, and the Javadoc is published [here](https://javadoc.io/doc/com.auth0/java-jwt/latest/index.html).
- 
+
 ### Maven
 
 ```xml
@@ -34,18 +34,18 @@ implementation 'com.auth0:java-jwt:3.11.0'
 
 The library implements JWT Verification and Signing using the following algorithms:
 
-| JWS | Algorithm | Description |
-| :-------------: | :-------------: | :----- |
-| HS256 | HMAC256 | HMAC with SHA-256 |
-| HS384 | HMAC384 | HMAC with SHA-384 |
-| HS512 | HMAC512 | HMAC with SHA-512 |
-| RS256 | RSA256 | RSASSA-PKCS1-v1_5 with SHA-256 |
-| RS384 | RSA384 | RSASSA-PKCS1-v1_5 with SHA-384 |
-| RS512 | RSA512 | RSASSA-PKCS1-v1_5 with SHA-512 |
-| ES256 | ECDSA256 | ECDSA with curve P-256 and SHA-256 |
-| ES256K | ECDSA256 | ECDSA with curve secp256k1 and SHA-256 |
-| ES384 | ECDSA384 | ECDSA with curve P-384 and SHA-384 |
-| ES512 | ECDSA512 | ECDSA with curve P-521 and SHA-512 |
+|  JWS   | Algorithm | Description                            |
+| :----: | :-------: | :------------------------------------- |
+| HS256  |  HMAC256  | HMAC with SHA-256                      |
+| HS384  |  HMAC384  | HMAC with SHA-384                      |
+| HS512  |  HMAC512  | HMAC with SHA-512                      |
+| RS256  |  RSA256   | RSASSA-PKCS1-v1_5 with SHA-256         |
+| RS384  |  RSA384   | RSASSA-PKCS1-v1_5 with SHA-384         |
+| RS512  |  RSA512   | RSASSA-PKCS1-v1_5 with SHA-512         |
+| ES256  | ECDSA256  | ECDSA with curve P-256 and SHA-256     |
+| ES256K | ECDSA256  | ECDSA with curve secp256k1 and SHA-256 |
+| ES384  | ECDSA384  | ECDSA with curve P-384 and SHA-384     |
+| ES512  | ECDSA512  | ECDSA with curve P-521 and SHA-512     |
 
 ## Usage
 
@@ -54,7 +54,6 @@ The library implements JWT Verification and Signing using the following algorith
 The Algorithm defines how a token is signed and verified. It can be instantiated with the raw value of the secret in the case of HMAC algorithms, or the key pairs or `KeyProvider` in the case of RSA and ECDSA algorithms. Once created, the instance is reusable for token signing and verification operations.
 
 When using RSA or ECDSA algorithms and you just need to **sign** JWTs you can avoid specifying a Public Key by passing a `null` value. The same can be done with the Private Key when you just need to **verify** JWTs.
-
 
 #### Using static secrets or keys:
 
@@ -77,7 +76,6 @@ By using a `KeyProvider` you can change in runtime the key used either to verify
 - `getPublicKeyById(String kid)`: Its called during token signature verification and it should return the key used to verify the token. If key rotation is being used, e.g. [JWK](https://tools.ietf.org/html/rfc7517) it can fetch the correct rotation key using the id. (Or just return the same key all the time).
 - `getPrivateKey()`: Its called during token signing and it should return the key that will be used to sign the JWT.
 - `getPrivateKeyId()`: Its called during token signing and it should return the id of the key that identifies the one returned by `getPrivateKey()`. This value is preferred over the one set in the `JWTCreator.Builder#withKeyId(String)` method. If you don't need to set a `kid` value avoid instantiating an Algorithm using a `KeyProvider`.
-
 
 The following example shows how this would work with `JwkStore`, an imaginary [JWK Set](https://auth0.com/docs/jwks) implementation. For simple key rotation using JWKS, try the [jwks-rsa-java](https://github.com/auth0/jwks-rsa-java) library.
 
@@ -113,7 +111,7 @@ Algorithm algorithm = Algorithm.RSA256(keyProvider);
 
 You'll first need to create a `JWTCreator` instance by calling `JWT.create()`. Use the builder to define the custom Claims your token needs to have. Finally to get the String token call `sign()` and pass the `Algorithm` instance.
 
-* Example using `HS256`
+- Example using `HS256`
 
 ```java
 try {
@@ -126,7 +124,7 @@ try {
 }
 ```
 
-* Example using `RS256`
+- Example using `RS256`
 
 ```java
 RSAPublicKey publicKey = //Get the key instance
@@ -143,12 +141,11 @@ try {
 
 If a Claim couldn't be converted to JSON or the Key used in the signing process was invalid a `JWTCreationException` will raise.
 
-
 ### Verify a Token
 
 You'll first need to create a `JWTVerifier` instance by calling `JWT.require()` and passing the `Algorithm` instance. If you require the token to have specific Claim values, use the builder to define them. The instance returned by the method `build()` is reusable, so you can define it once and use it to verify different tokens. Finally call `verifier.verify()` passing the token.
 
-* Example using `HS256`
+- Example using `HS256`
 
 ```java
 String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
@@ -163,7 +160,7 @@ try {
 }
 ```
 
-* Example using `RS256`
+- Example using `RS256`
 
 ```java
 String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
@@ -182,13 +179,13 @@ try {
 
 If the token has an invalid signature or the Claim requirement is not met, a `JWTVerificationException` will raise.
 
-
 #### Time Validation
 
 The JWT token may include DateNumber fields that can be used to validate that:
-* The token was issued in a past date `"iat" < TODAY`
-* The token hasn't expired yet `"exp" > TODAY` and
-* The token can already be used. `"nbf" < TODAY`
+
+- The token was issued in a past date `"iat" < TODAY`
+- The token hasn't expired yet `"exp" > TODAY` and
+- The token can already be used. `"nbf" < TODAY`
 
 When verifying a token the time validation occurs automatically, resulting in a `JWTVerificationException` being throw when the values are invalid. If any of the previous fields are missing they won't be considered in this validation.
 
@@ -231,7 +228,6 @@ try {
 ```
 
 If the token has an invalid syntax or the header or payload are not JSONs, a `JWTDecodeException` will raise.
-
 
 ### Header Claims
 
@@ -286,7 +282,6 @@ String token = JWT.create()
 ```
 
 > The `alg` and `typ` values will always be included in the Header after the signing process.
-
 
 ### Payload Claims
 
@@ -370,6 +365,16 @@ String token = JWT.create()
         .sign(algorithm);
 ```
 
+Or using `withPayload()` and passing the map of claims.
+
+```java
+Map<String, Object> payloadClaims = new HashMap();
+payloadClaims.put("@context", "https://auth0.com/");
+String token = JWT.create()
+        .withPayload(payloadClaims)
+        .sign(algorithm);
+```
+
 You can also verify custom Claims on the `JWT.require()` by calling `withClaim()` and passing both the name and the required value.
 
 ```java
@@ -382,40 +387,40 @@ DecodedJWT jwt = verifier.verify("my.jwt.token");
 
 > Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Date and Arrays of type String and Integer.
 
-
 ### Claim Class
+
 The Claim class is a wrapper for the Claim values. It allows you to get the Claim as different class types. The available helpers are:
 
 #### Primitives
-* **asBoolean()**: Returns the Boolean value or null if it can't be converted.
-* **asInt()**: Returns the Integer value or null if it can't be converted.
-* **asDouble()**: Returns the Double value or null if it can't be converted.
-* **asLong()**: Returns the Long value or null if it can't be converted.
-* **asString()**: Returns the String value or null if it can't be converted.
-* **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
+
+- **asBoolean()**: Returns the Boolean value or null if it can't be converted.
+- **asInt()**: Returns the Integer value or null if it can't be converted.
+- **asDouble()**: Returns the Double value or null if it can't be converted.
+- **asLong()**: Returns the Long value or null if it can't be converted.
+- **asString()**: Returns the String value or null if it can't be converted.
+- **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the _NumericDate_ values must be in seconds.
 
 #### Custom Classes and Collections
+
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.
 
-* **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.
-* **asMap()**: Returns the value parsed as **Map<String, Object>**.
-* **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
-* **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
+- **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.
+- **asMap()**: Returns the value parsed as **Map<String, Object>**.
+- **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
+- **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
 
 If the values can't be converted to the given **Class Type** a `JWTDecodeException` will raise.
-
-
 
 ## What is Auth0?
 
 Auth0 helps you to:
 
-* Add authentication with [multiple authentication sources](https://docs.auth0.com/identityproviders), either social like **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce, among others**, or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS or any SAML Identity Provider**.
-* Add authentication through more traditional **[username/password databases](https://docs.auth0.com/mysql-connection-tutorial)**.
-* Add support for **[linking different user accounts](https://docs.auth0.com/link-accounts)** with the same user.
-* Support for generating signed [Json Web Tokens](https://docs.auth0.com/jwt) to call your APIs and **flow the user identity** securely.
-* Analytics of how, when and where users are logging in.
-* Pull data from other sources and add it to the user profile, through [JavaScript rules](https://docs.auth0.com/rules).
+- Add authentication with [multiple authentication sources](https://docs.auth0.com/identityproviders), either social like **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce, among others**, or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS or any SAML Identity Provider**.
+- Add authentication through more traditional **[username/password databases](https://docs.auth0.com/mysql-connection-tutorial)**.
+- Add support for **[linking different user accounts](https://docs.auth0.com/link-accounts)** with the same user.
+- Support for generating signed [Json Web Tokens](https://docs.auth0.com/jwt) to call your APIs and **flow the user identity** securely.
+- Analytics of how, when and where users are logging in.
+- Pull data from other sources and add it to the user profile, through [JavaScript rules](https://docs.auth0.com/rules).
 
 ## Create a free account in Auth0
 
@@ -433,6 +438,5 @@ If you have found a bug or if you have a feature request, please report them at 
 ## License
 
 This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
-
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2Fjava-jwt.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2Fjava-jwt?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're looking for an **Android** version of the JWT Decoder take a look at o
 ## Installation
 
 The library is available on both Maven Central and Bintray, and the Javadoc is published [here](https://javadoc.io/doc/com.auth0/java-jwt/latest/index.html).
-
+ 
 ### Maven
 
 ```xml
@@ -34,18 +34,18 @@ implementation 'com.auth0:java-jwt:3.11.0'
 
 The library implements JWT Verification and Signing using the following algorithms:
 
-|  JWS   | Algorithm | Description                            |
-| :----: | :-------: | :------------------------------------- |
-| HS256  |  HMAC256  | HMAC with SHA-256                      |
-| HS384  |  HMAC384  | HMAC with SHA-384                      |
-| HS512  |  HMAC512  | HMAC with SHA-512                      |
-| RS256  |  RSA256   | RSASSA-PKCS1-v1_5 with SHA-256         |
-| RS384  |  RSA384   | RSASSA-PKCS1-v1_5 with SHA-384         |
-| RS512  |  RSA512   | RSASSA-PKCS1-v1_5 with SHA-512         |
-| ES256  | ECDSA256  | ECDSA with curve P-256 and SHA-256     |
-| ES256K | ECDSA256  | ECDSA with curve secp256k1 and SHA-256 |
-| ES384  | ECDSA384  | ECDSA with curve P-384 and SHA-384     |
-| ES512  | ECDSA512  | ECDSA with curve P-521 and SHA-512     |
+| JWS | Algorithm | Description |
+| :-------------: | :-------------: | :----- |
+| HS256 | HMAC256 | HMAC with SHA-256 |
+| HS384 | HMAC384 | HMAC with SHA-384 |
+| HS512 | HMAC512 | HMAC with SHA-512 |
+| RS256 | RSA256 | RSASSA-PKCS1-v1_5 with SHA-256 |
+| RS384 | RSA384 | RSASSA-PKCS1-v1_5 with SHA-384 |
+| RS512 | RSA512 | RSASSA-PKCS1-v1_5 with SHA-512 |
+| ES256 | ECDSA256 | ECDSA with curve P-256 and SHA-256 |
+| ES256K | ECDSA256 | ECDSA with curve secp256k1 and SHA-256 |
+| ES384 | ECDSA384 | ECDSA with curve P-384 and SHA-384 |
+| ES512 | ECDSA512 | ECDSA with curve P-521 and SHA-512 |
 
 ## Usage
 
@@ -54,6 +54,7 @@ The library implements JWT Verification and Signing using the following algorith
 The Algorithm defines how a token is signed and verified. It can be instantiated with the raw value of the secret in the case of HMAC algorithms, or the key pairs or `KeyProvider` in the case of RSA and ECDSA algorithms. Once created, the instance is reusable for token signing and verification operations.
 
 When using RSA or ECDSA algorithms and you just need to **sign** JWTs you can avoid specifying a Public Key by passing a `null` value. The same can be done with the Private Key when you just need to **verify** JWTs.
+
 
 #### Using static secrets or keys:
 
@@ -76,6 +77,7 @@ By using a `KeyProvider` you can change in runtime the key used either to verify
 - `getPublicKeyById(String kid)`: Its called during token signature verification and it should return the key used to verify the token. If key rotation is being used, e.g. [JWK](https://tools.ietf.org/html/rfc7517) it can fetch the correct rotation key using the id. (Or just return the same key all the time).
 - `getPrivateKey()`: Its called during token signing and it should return the key that will be used to sign the JWT.
 - `getPrivateKeyId()`: Its called during token signing and it should return the id of the key that identifies the one returned by `getPrivateKey()`. This value is preferred over the one set in the `JWTCreator.Builder#withKeyId(String)` method. If you don't need to set a `kid` value avoid instantiating an Algorithm using a `KeyProvider`.
+
 
 The following example shows how this would work with `JwkStore`, an imaginary [JWK Set](https://auth0.com/docs/jwks) implementation. For simple key rotation using JWKS, try the [jwks-rsa-java](https://github.com/auth0/jwks-rsa-java) library.
 
@@ -111,7 +113,7 @@ Algorithm algorithm = Algorithm.RSA256(keyProvider);
 
 You'll first need to create a `JWTCreator` instance by calling `JWT.create()`. Use the builder to define the custom Claims your token needs to have. Finally to get the String token call `sign()` and pass the `Algorithm` instance.
 
-- Example using `HS256`
+* Example using `HS256`
 
 ```java
 try {
@@ -124,7 +126,7 @@ try {
 }
 ```
 
-- Example using `RS256`
+* Example using `RS256`
 
 ```java
 RSAPublicKey publicKey = //Get the key instance
@@ -141,11 +143,12 @@ try {
 
 If a Claim couldn't be converted to JSON or the Key used in the signing process was invalid a `JWTCreationException` will raise.
 
+
 ### Verify a Token
 
 You'll first need to create a `JWTVerifier` instance by calling `JWT.require()` and passing the `Algorithm` instance. If you require the token to have specific Claim values, use the builder to define them. The instance returned by the method `build()` is reusable, so you can define it once and use it to verify different tokens. Finally call `verifier.verify()` passing the token.
 
-- Example using `HS256`
+* Example using `HS256`
 
 ```java
 String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
@@ -160,7 +163,7 @@ try {
 }
 ```
 
-- Example using `RS256`
+* Example using `RS256`
 
 ```java
 String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
@@ -179,13 +182,13 @@ try {
 
 If the token has an invalid signature or the Claim requirement is not met, a `JWTVerificationException` will raise.
 
+
 #### Time Validation
 
 The JWT token may include DateNumber fields that can be used to validate that:
-
-- The token was issued in a past date `"iat" < TODAY`
-- The token hasn't expired yet `"exp" > TODAY` and
-- The token can already be used. `"nbf" < TODAY`
+* The token was issued in a past date `"iat" < TODAY`
+* The token hasn't expired yet `"exp" > TODAY` and
+* The token can already be used. `"nbf" < TODAY`
 
 When verifying a token the time validation occurs automatically, resulting in a `JWTVerificationException` being throw when the values are invalid. If any of the previous fields are missing they won't be considered in this validation.
 
@@ -228,6 +231,7 @@ try {
 ```
 
 If the token has an invalid syntax or the header or payload are not JSONs, a `JWTDecodeException` will raise.
+
 
 ### Header Claims
 
@@ -282,6 +286,7 @@ String token = JWT.create()
 ```
 
 > The `alg` and `typ` values will always be included in the Header after the signing process.
+
 
 ### Payload Claims
 
@@ -365,16 +370,6 @@ String token = JWT.create()
         .sign(algorithm);
 ```
 
-Or using `withPayload()` and passing the map of claims.
-
-```java
-Map<String, Object> payloadClaims = new HashMap();
-payloadClaims.put("@context", "https://auth0.com/");
-String token = JWT.create()
-        .withPayload(payloadClaims)
-        .sign(algorithm);
-```
-
 You can also verify custom Claims on the `JWT.require()` by calling `withClaim()` and passing both the name and the required value.
 
 ```java
@@ -387,40 +382,40 @@ DecodedJWT jwt = verifier.verify("my.jwt.token");
 
 > Currently supported classes for custom JWT Claim creation and verification are: Boolean, Integer, Double, String, Date and Arrays of type String and Integer.
 
-### Claim Class
 
+### Claim Class
 The Claim class is a wrapper for the Claim values. It allows you to get the Claim as different class types. The available helpers are:
 
 #### Primitives
-
-- **asBoolean()**: Returns the Boolean value or null if it can't be converted.
-- **asInt()**: Returns the Integer value or null if it can't be converted.
-- **asDouble()**: Returns the Double value or null if it can't be converted.
-- **asLong()**: Returns the Long value or null if it can't be converted.
-- **asString()**: Returns the String value or null if it can't be converted.
-- **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the _NumericDate_ values must be in seconds.
+* **asBoolean()**: Returns the Boolean value or null if it can't be converted.
+* **asInt()**: Returns the Integer value or null if it can't be converted.
+* **asDouble()**: Returns the Double value or null if it can't be converted.
+* **asLong()**: Returns the Long value or null if it can't be converted.
+* **asString()**: Returns the String value or null if it can't be converted.
+* **asDate()**: Returns the Date value or null if it can't be converted. This must be a NumericDate (Unix Epoch/Timestamp). Note that the [JWT Standard](https://tools.ietf.org/html/rfc7519#section-2) specified that all the *NumericDate* values must be in seconds.
 
 #### Custom Classes and Collections
-
 To obtain a Claim as a Collection you'll need to provide the **Class Type** of the contents to convert from.
 
-- **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.
-- **asMap()**: Returns the value parsed as **Map<String, Object>**.
-- **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
-- **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
+* **as(class)**: Returns the value parsed as **Class Type**. For collections you should use the `asArray` and `asList` methods.
+* **asMap()**: Returns the value parsed as **Map<String, Object>**.
+* **asArray(class)**: Returns the value parsed as an Array of elements of type **Class Type**, or null if the value isn't a JSON Array.
+* **asList(class)**: Returns the value parsed as a List of elements of type **Class Type**, or null if the value isn't a JSON Array.
 
 If the values can't be converted to the given **Class Type** a `JWTDecodeException` will raise.
+
+
 
 ## What is Auth0?
 
 Auth0 helps you to:
 
-- Add authentication with [multiple authentication sources](https://docs.auth0.com/identityproviders), either social like **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce, among others**, or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS or any SAML Identity Provider**.
-- Add authentication through more traditional **[username/password databases](https://docs.auth0.com/mysql-connection-tutorial)**.
-- Add support for **[linking different user accounts](https://docs.auth0.com/link-accounts)** with the same user.
-- Support for generating signed [Json Web Tokens](https://docs.auth0.com/jwt) to call your APIs and **flow the user identity** securely.
-- Analytics of how, when and where users are logging in.
-- Pull data from other sources and add it to the user profile, through [JavaScript rules](https://docs.auth0.com/rules).
+* Add authentication with [multiple authentication sources](https://docs.auth0.com/identityproviders), either social like **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce, among others**, or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS or any SAML Identity Provider**.
+* Add authentication through more traditional **[username/password databases](https://docs.auth0.com/mysql-connection-tutorial)**.
+* Add support for **[linking different user accounts](https://docs.auth0.com/link-accounts)** with the same user.
+* Support for generating signed [Json Web Tokens](https://docs.auth0.com/jwt) to call your APIs and **flow the user identity** securely.
+* Analytics of how, when and where users are logging in.
+* Pull data from other sources and add it to the user profile, through [JavaScript rules](https://docs.auth0.com/rules).
 
 ## Create a free account in Auth0
 
@@ -438,5 +433,6 @@ If you have found a bug or if you have a feature request, please report them at 
 ## License
 
 This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
+
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2Fjava-jwt.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2Fjava-jwt?ref=badge_large)

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -354,6 +354,30 @@ public final class JWTCreator {
             return this;
         }
 
+        /**
+         * Add specific Claims to set as the Payload. If provided map is null then
+         * nothing is changed If provided map contains a claim with null value then that
+         * claim will be removed from the payload
+         *
+         * @param payloadClaims the values to use as Claims in the token's payload.
+         * @return this same Builder instance.
+         */
+        public Builder withPayload(Map<String, Object> payloadClaims) {
+            if (payloadClaims == null) {
+                return this;
+            }
+
+            for (Map.Entry<String, Object> entry : payloadClaims.entrySet()) {
+                if (entry.getValue() == null) {
+                    this.payloadClaims.remove(entry.getKey());
+                } else {
+                    this.payloadClaims.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            return this;
+        }
+
         private static boolean validateClaim(Map<?, ?> map) {
             // do not accept null values in maps
             for (Entry<?, ?> entry : map.entrySet()) {

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -20,7 +20,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * The JWTCreator class holds the sign method to generate a complete JWT (with Signature) from a given Header and Payload content.
+ * The JWTCreator class holds the sign method to generate a complete JWT (with
+ * Signature) from a given Header and Payload content.
  * <p>
  * This class is thread-safe.
  */
@@ -31,7 +32,8 @@ public final class JWTCreator {
     private final String headerJson;
     private final String payloadJson;
 
-    private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims) throws JWTCreationException {
+    private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims)
+            throws JWTCreationException {
         this.algorithm = algorithm;
         try {
             ObjectMapper mapper = new ObjectMapper();
@@ -45,7 +47,6 @@ public final class JWTCreator {
             throw new JWTCreationException("Some of the Claims couldn't be converted to a valid JSON format.", e);
         }
     }
-
 
     /**
      * Initialize a JWTCreator instance.
@@ -69,9 +70,9 @@ public final class JWTCreator {
         }
 
         /**
-         * Add specific Claims to set as the Header.
-         * If provided map is null then nothing is changed
-         * If provided map contains a claim with null value then that claim will be removed from the header
+         * Add specific Claims to set as the Header. If provided map is null then
+         * nothing is changed If provided map contains a claim with null value then that
+         * claim will be removed from the header
          *
          * @param headerClaims the values to use as Claims in the token's Header.
          * @return this same Builder instance.
@@ -93,8 +94,9 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Key Id ("kid") claim to the Header.
-         * If the {@link Algorithm} used to sign this token was instantiated with a KeyProvider, the 'kid' value will be taken from that provider and this one will be ignored.
+         * Add a specific Key Id ("kid") claim to the Header. If the {@link Algorithm}
+         * used to sign this token was instantiated with a KeyProvider, the 'kid' value
+         * will be taken from that provider and this one will be ignored.
          *
          * @param keyId the Key Id value.
          * @return this same Builder instance.
@@ -310,21 +312,24 @@ public final class JWTCreator {
         /**
          * Add a custom Map Claim with the given items.
          * <p>
-         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
-         * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
-         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
-         * {@linkplain List}s can contain null elements.
+         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic
+         * types {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long},
+         * {@linkplain Double}, {@linkplain String} and {@linkplain Date}.
+         * {@linkplain Map}s cannot contain null keys or values. {@linkplain List}s can
+         * contain null elements.
          *
          * @param name the Claim's name.
          * @param map  the Claim's key-values.
          * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null, or if the map contents does not validate.
+         * @throws IllegalArgumentException if the name is null, or if the map contents
+         *                                  does not validate.
          */
         public Builder withClaim(String name, Map<String, ?> map) throws IllegalArgumentException {
             assertNonNull(name);
             // validate map contents
             if (map != null && !validateClaim(map)) {
-                throw new IllegalArgumentException("Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
+                throw new IllegalArgumentException(
+                        "Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, map);
             return this;
@@ -333,24 +338,51 @@ public final class JWTCreator {
         /**
          * Add a custom List Claim with the given items.
          * <p>
-         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
-         * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
-         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
-         * {@linkplain List}s can contain null elements.
+         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic
+         * types {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long},
+         * {@linkplain Double}, {@linkplain String} and {@linkplain Date}.
+         * {@linkplain Map}s cannot contain null keys or values. {@linkplain List}s can
+         * contain null elements.
          *
          * @param name the Claim's name.
          * @param list the Claim's list of values.
          * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null, or if the list contents does not validate.
+         * @throws IllegalArgumentException if the name is null, or if the list contents
+         *                                  does not validate.
          */
 
         public Builder withClaim(String name, List<?> list) throws IllegalArgumentException {
             assertNonNull(name);
             // validate list contents
             if (list != null && !validateClaim(list)) {
-                throw new IllegalArgumentException("Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
+                throw new IllegalArgumentException(
+                        "Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, list);
+            return this;
+        }
+
+        /**
+         * Add specific Claims to set as the Payload. If provided map is null then
+         * nothing is changed If provided map contains a claim with null value then that
+         * claim will be removed from the payload
+         *
+         * @param payloadClaims the values to use as Claims in the token's payload.
+         * @return this same Builder instance.
+         */
+        public Builder withPayload(Map<String, Object> payloadClaims) {
+            if (payloadClaims == null) {
+                return this;
+            }
+
+            for (Map.Entry<String, Object> entry : payloadClaims.entrySet()) {
+                if (entry.getValue() == null) {
+                    this.payloadClaims.remove(entry.getKey());
+                } else {
+                    this.payloadClaims.put(entry.getKey(), entry.getValue());
+                }
+            }
+
             return this;
         }
 
@@ -395,7 +427,8 @@ public final class JWTCreator {
             if (c.isArray()) {
                 return c == Integer[].class || c == Long[].class || c == String[].class;
             }
-            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Boolean.class;
+            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class
+                    || c == Boolean.class;
         }
 
         /**
@@ -404,7 +437,9 @@ public final class JWTCreator {
          * @param algorithm used to sign the JWT
          * @return a new JWT token
          * @throws IllegalArgumentException if the provided algorithm is null.
-         * @throws JWTCreationException     if the claims could not be converted to a valid JSON or there was a problem with the signing key.
+         * @throws JWTCreationException     if the claims could not be converted to a
+         *                                  valid JSON or there was a problem with the
+         *                                  signing key.
          */
         public String sign(Algorithm algorithm) throws IllegalArgumentException, JWTCreationException {
             if (algorithm == null) {
@@ -440,7 +475,8 @@ public final class JWTCreator {
         String header = Base64.encodeBase64URLSafeString(headerJson.getBytes(StandardCharsets.UTF_8));
         String payload = Base64.encodeBase64URLSafeString(payloadJson.getBytes(StandardCharsets.UTF_8));
 
-        byte[] signatureBytes = algorithm.sign(header.getBytes(StandardCharsets.UTF_8), payload.getBytes(StandardCharsets.UTF_8));
+        byte[] signatureBytes = algorithm.sign(header.getBytes(StandardCharsets.UTF_8),
+                payload.getBytes(StandardCharsets.UTF_8));
         String signature = Base64.encodeBase64URLSafeString((signatureBytes));
 
         return String.format("%s.%s.%s", header, payload, signature);

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -356,23 +356,25 @@ public final class JWTCreator {
 
         /**
          * Add specific Claims to set as the Payload. If provided map is null then
-         * nothing is changed If provided map contains a claim with null value then that
+         * nothing is changed. If provided map contains a claim with null value then that
          * claim will be removed from the payload
          *
          * @param payloadClaims the values to use as Claims in the token's payload.
+         * @throws IllegalArgumentException if payloadClaims is not well-formed and not having null values
          * @return this same Builder instance.
          */
-        public Builder withPayload(Map<String, Object> payloadClaims) {
+        public Builder withPayload(Map<?, ?> payloadClaims) throws IllegalArgumentException {
             if (payloadClaims == null) {
                 return this;
             }
 
+            // Checks that all the key-value pairs are valid and neither of them are null
+            if(!validateClaim(payloadClaims)) {
+                throw new IllegalArgumentException("The Custom Payload Claim is not valid.");
+            }
+
             for (Map.Entry<String, Object> entry : payloadClaims.entrySet()) {
-                if (entry.getValue() == null) {
-                    this.payloadClaims.remove(entry.getKey());
-                } else {
-                    this.payloadClaims.put(entry.getKey(), entry.getValue());
-                }
+                this.payloadClaims.put(entry.getKey(), entry.getValue());
             }
 
             return this;

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -20,8 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * The JWTCreator class holds the sign method to generate a complete JWT (with
- * Signature) from a given Header and Payload content.
+ * The JWTCreator class holds the sign method to generate a complete JWT (with Signature) from a given Header and Payload content.
  * <p>
  * This class is thread-safe.
  */
@@ -32,8 +31,7 @@ public final class JWTCreator {
     private final String headerJson;
     private final String payloadJson;
 
-    private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims)
-            throws JWTCreationException {
+    private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims) throws JWTCreationException {
         this.algorithm = algorithm;
         try {
             ObjectMapper mapper = new ObjectMapper();
@@ -47,6 +45,7 @@ public final class JWTCreator {
             throw new JWTCreationException("Some of the Claims couldn't be converted to a valid JSON format.", e);
         }
     }
+
 
     /**
      * Initialize a JWTCreator instance.
@@ -70,9 +69,9 @@ public final class JWTCreator {
         }
 
         /**
-         * Add specific Claims to set as the Header. If provided map is null then
-         * nothing is changed If provided map contains a claim with null value then that
-         * claim will be removed from the header
+         * Add specific Claims to set as the Header.
+         * If provided map is null then nothing is changed
+         * If provided map contains a claim with null value then that claim will be removed from the header
          *
          * @param headerClaims the values to use as Claims in the token's Header.
          * @return this same Builder instance.
@@ -94,9 +93,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Key Id ("kid") claim to the Header. If the {@link Algorithm}
-         * used to sign this token was instantiated with a KeyProvider, the 'kid' value
-         * will be taken from that provider and this one will be ignored.
+         * Add a specific Key Id ("kid") claim to the Header.
+         * If the {@link Algorithm} used to sign this token was instantiated with a KeyProvider, the 'kid' value will be taken from that provider and this one will be ignored.
          *
          * @param keyId the Key Id value.
          * @return this same Builder instance.
@@ -312,24 +310,21 @@ public final class JWTCreator {
         /**
          * Add a custom Map Claim with the given items.
          * <p>
-         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic
-         * types {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long},
-         * {@linkplain Double}, {@linkplain String} and {@linkplain Date}.
-         * {@linkplain Map}s cannot contain null keys or values. {@linkplain List}s can
-         * contain null elements.
+         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
+         * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
+         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain List}s can contain null elements.
          *
          * @param name the Claim's name.
          * @param map  the Claim's key-values.
          * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null, or if the map contents
-         *                                  does not validate.
+         * @throws IllegalArgumentException if the name is null, or if the map contents does not validate.
          */
         public Builder withClaim(String name, Map<String, ?> map) throws IllegalArgumentException {
             assertNonNull(name);
             // validate map contents
             if (map != null && !validateClaim(map)) {
-                throw new IllegalArgumentException(
-                        "Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
+                throw new IllegalArgumentException("Expected map containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, map);
             return this;
@@ -338,51 +333,24 @@ public final class JWTCreator {
         /**
          * Add a custom List Claim with the given items.
          * <p>
-         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic
-         * types {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long},
-         * {@linkplain Double}, {@linkplain String} and {@linkplain Date}.
-         * {@linkplain Map}s cannot contain null keys or values. {@linkplain List}s can
-         * contain null elements.
+         * Accepted nested types are {@linkplain Map} and {@linkplain List} with basic types
+         * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
+         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain List}s can contain null elements.
          *
          * @param name the Claim's name.
          * @param list the Claim's list of values.
          * @return this same Builder instance.
-         * @throws IllegalArgumentException if the name is null, or if the list contents
-         *                                  does not validate.
+         * @throws IllegalArgumentException if the name is null, or if the list contents does not validate.
          */
 
         public Builder withClaim(String name, List<?> list) throws IllegalArgumentException {
             assertNonNull(name);
             // validate list contents
             if (list != null && !validateClaim(list)) {
-                throw new IllegalArgumentException(
-                        "Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
+                throw new IllegalArgumentException("Expected list containing Map, List, Boolean, Integer, Long, Double, String and Date");
             }
             addClaim(name, list);
-            return this;
-        }
-
-        /**
-         * Add specific Claims to set as the Payload. If provided map is null then
-         * nothing is changed If provided map contains a claim with null value then that
-         * claim will be removed from the payload
-         *
-         * @param payloadClaims the values to use as Claims in the token's payload.
-         * @return this same Builder instance.
-         */
-        public Builder withPayload(Map<String, Object> payloadClaims) {
-            if (payloadClaims == null) {
-                return this;
-            }
-
-            for (Map.Entry<String, Object> entry : payloadClaims.entrySet()) {
-                if (entry.getValue() == null) {
-                    this.payloadClaims.remove(entry.getKey());
-                } else {
-                    this.payloadClaims.put(entry.getKey(), entry.getValue());
-                }
-            }
-
             return this;
         }
 
@@ -427,8 +395,7 @@ public final class JWTCreator {
             if (c.isArray()) {
                 return c == Integer[].class || c == Long[].class || c == String[].class;
             }
-            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class
-                    || c == Boolean.class;
+            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Boolean.class;
         }
 
         /**
@@ -437,9 +404,7 @@ public final class JWTCreator {
          * @param algorithm used to sign the JWT
          * @return a new JWT token
          * @throws IllegalArgumentException if the provided algorithm is null.
-         * @throws JWTCreationException     if the claims could not be converted to a
-         *                                  valid JSON or there was a problem with the
-         *                                  signing key.
+         * @throws JWTCreationException     if the claims could not be converted to a valid JSON or there was a problem with the signing key.
          */
         public String sign(Algorithm algorithm) throws IllegalArgumentException, JWTCreationException {
             if (algorithm == null) {
@@ -475,8 +440,7 @@ public final class JWTCreator {
         String header = Base64.encodeBase64URLSafeString(headerJson.getBytes(StandardCharsets.UTF_8));
         String payload = Base64.encodeBase64URLSafeString(payloadJson.getBytes(StandardCharsets.UTF_8));
 
-        byte[] signatureBytes = algorithm.sign(header.getBytes(StandardCharsets.UTF_8),
-                payload.getBytes(StandardCharsets.UTF_8));
+        byte[] signatureBytes = algorithm.sign(header.getBytes(StandardCharsets.UTF_8), payload.getBytes(StandardCharsets.UTF_8));
         String signature = Base64.encodeBase64URLSafeString((signatureBytes));
 
         return String.format("%s.%s.%s", header, payload, signature);

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -36,7 +36,8 @@ public class JWTCreatorTest {
     public void shouldThrowWhenRequestingSignWithoutAlgorithm() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Algorithm cannot be null");
-        JWTCreator.init().sign(null);
+        JWTCreator.init()
+                .sign(null);
     }
 
     @SuppressWarnings("Convert2Diamond")
@@ -44,7 +45,9 @@ public class JWTCreatorTest {
     public void shouldAddHeaderClaim() throws Exception {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put("asd", 123);
-        String signed = JWTCreator.init().withHeader(header).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -53,8 +56,10 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldReturnBuilderIfNullMapIsProvidedForHeader() throws Exception {
-        String signed = JWTCreator.init().withHeader(null).sign(Algorithm.HMAC256("secret"));
+    public void shouldReturnBuilderIfNullMapIsProvided() throws Exception {
+        String signed = JWTCreator.init()
+                .withHeader(null)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
     }
@@ -64,7 +69,10 @@ public class JWTCreatorTest {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put(PublicClaims.KEY_ID, "xyz");
 
-        String signed = JWTCreator.init().withKeyId("abc").withHeader(header).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withKeyId("abc")
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -77,7 +85,10 @@ public class JWTCreatorTest {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put(PublicClaims.KEY_ID, "xyz");
 
-        String signed = JWTCreator.init().withHeader(header).withKeyId("abc").sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withHeader(header)
+                .withKeyId("abc")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -91,7 +102,10 @@ public class JWTCreatorTest {
         header.put(PublicClaims.KEY_ID, null);
         header.put("test2", "isSet");
 
-        String signed = JWTCreator.init().withKeyId("test").withHeader(header).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withKeyId("test")
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -102,7 +116,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddKeyId() throws Exception {
-        String signed = JWTCreator.init().withKeyId("56a8bd44da435300010000015f5ed").sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withKeyId("56a8bd44da435300010000015f5ed")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -117,7 +133,8 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init().sign(Algorithm.RSA256(provider));
+        String signed = JWTCreator.init()
+                .sign(Algorithm.RSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -132,7 +149,9 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init().withKeyId("real-key-id").sign(Algorithm.RSA256(provider));
+        String signed = JWTCreator.init()
+                .withKeyId("real-key-id")
+                .sign(Algorithm.RSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -147,7 +166,8 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init().sign(Algorithm.ECDSA256K(provider));
+        String signed = JWTCreator.init()
+                .sign(Algorithm.ECDSA256K(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -162,7 +182,9 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init().withKeyId("real-key-id").sign(Algorithm.ECDSA256(provider));
+        String signed = JWTCreator.init()
+                .withKeyId("real-key-id")
+                .sign(Algorithm.ECDSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -177,7 +199,8 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init().sign(Algorithm.ECDSA256(provider));
+        String signed = JWTCreator.init()
+                .sign(Algorithm.ECDSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -192,7 +215,9 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init().withKeyId("real-key-id").sign(Algorithm.ECDSA256(provider));
+        String signed = JWTCreator.init()
+                .withKeyId("real-key-id")
+                .sign(Algorithm.ECDSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -202,7 +227,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddIssuer() throws Exception {
-        String signed = JWTCreator.init().withIssuer("auth0").sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withIssuer("auth0")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJpc3MiOiJhdXRoMCJ9"));
@@ -210,7 +237,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddSubject() throws Exception {
-        String signed = JWTCreator.init().withSubject("1234567890").sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withSubject("1234567890")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJzdWIiOiIxMjM0NTY3ODkwIn0"));
@@ -218,12 +247,17 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddAudience() throws Exception {
-        String signed = JWTCreator.init().withAudience("Mark").sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withAudience("Mark")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJhdWQiOiJNYXJrIn0"));
 
-        String signedArr = JWTCreator.init().withAudience("Mark", "David").sign(Algorithm.HMAC256("secret"));
+
+        String signedArr = JWTCreator.init()
+                .withAudience("Mark", "David")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signedArr, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signedArr)[1], is("eyJhdWQiOlsiTWFyayIsIkRhdmlkIl19"));
@@ -231,7 +265,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddExpiresAt() throws Exception {
-        String signed = JWTCreator.init().withExpiresAt(new Date(1477592000)).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withExpiresAt(new Date(1477592000))
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJleHAiOjE0Nzc1OTJ9"));
@@ -239,7 +275,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddNotBefore() throws Exception {
-        String signed = JWTCreator.init().withNotBefore(new Date(1477592000)).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withNotBefore(new Date(1477592000))
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJuYmYiOjE0Nzc1OTJ9"));
@@ -247,7 +285,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddIssuedAt() throws Exception {
-        String signed = JWTCreator.init().withIssuedAt(new Date(1477592000)).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withIssuedAt(new Date(1477592000))
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJpYXQiOjE0Nzc1OTJ9"));
@@ -255,7 +295,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddJWTId() throws Exception {
-        String signed = JWTCreator.init().withJWTId("jwt_id_123").sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withJWTId("jwt_id_123")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJqdGkiOiJqd3RfaWRfMTIzIn0"));
@@ -263,7 +305,10 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldRemoveClaimWhenPassingNull() throws Exception {
-        String signed = JWTCreator.init().withIssuer("iss").withIssuer(null).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withIssuer("iss")
+                .withIssuer(null)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("e30"));
@@ -271,7 +316,8 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldSetCorrectAlgorithmInTheHeader() throws Exception {
-        String signed = JWTCreator.init().sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -281,7 +327,8 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldSetDefaultTypeInTheHeader() throws Exception {
-        String signed = JWTCreator.init().sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -292,7 +339,9 @@ public class JWTCreatorTest {
     @Test
     public void shouldSetCustomTypeInTheHeader() throws Exception {
         Map<String, Object> header = Collections.singletonMap("typ", "passport");
-        String signed = JWTCreator.init().withHeader(header).sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init()
+                .withHeader(header)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -302,7 +351,8 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldSetEmptySignatureIfAlgorithmIsNone() throws Exception {
-        String signed = JWTCreator.init().sign(Algorithm.none());
+        String signed = JWTCreator.init()
+                .sign(Algorithm.none());
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[2], is(""));
     }
@@ -311,12 +361,15 @@ public class JWTCreatorTest {
     public void shouldThrowOnNullCustomClaimName() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Custom Claim's name can't be null.");
-        JWTCreator.init().withClaim(null, "value");
+        JWTCreator.init()
+                .withClaim(null, "value");
     }
 
     @Test
     public void shouldAcceptCustomClaimOfTypeString() throws Exception {
-        String jwt = JWTCreator.init().withClaim("name", "value").sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("name", "value")
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -325,7 +378,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeInteger() throws Exception {
-        String jwt = JWTCreator.init().withClaim("name", 123).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("name", 123)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -334,7 +389,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeLong() throws Exception {
-        String jwt = JWTCreator.init().withClaim("name", Long.MAX_VALUE).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("name", Long.MAX_VALUE)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -343,7 +400,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeDouble() throws Exception {
-        String jwt = JWTCreator.init().withClaim("name", 23.45).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("name", 23.45)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -352,7 +411,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeBoolean() throws Exception {
-        String jwt = JWTCreator.init().withClaim("name", true).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("name", true)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -362,7 +423,9 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
         Date date = new Date(1478891521000L);
-        String jwt = JWTCreator.init().withClaim("name", date).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("name", date)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -371,7 +434,8 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
-        String jwt = JWTCreator.init().withArrayClaim("name", new String[] { "text", "123", "true" })
+        String jwt = JWTCreator.init()
+                .withArrayClaim("name", new String[]{"text", "123", "true"})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -381,7 +445,8 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeInteger() throws Exception {
-        String jwt = JWTCreator.init().withArrayClaim("name", new Integer[] { 1, 2, 3 })
+        String jwt = JWTCreator.init()
+                .withArrayClaim("name", new Integer[]{1, 2, 3})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -391,7 +456,8 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeLong() throws Exception {
-        String jwt = JWTCreator.init().withArrayClaim("name", new Long[] { 1L, 2L, 3L })
+        String jwt = JWTCreator.init()
+                .withArrayClaim("name", new Long[]{1L, 2L, 3L})
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -404,7 +470,9 @@ public class JWTCreatorTest {
         Map<String, Object> data = new HashMap<>();
         data.put("test1", "abc");
         data.put("test2", "def");
-        String jwt = JWTCreator.init().withClaim("data", data).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("data", data)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -418,7 +486,9 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @SuppressWarnings("unchecked")
@@ -435,9 +505,9 @@ public class JWTCreatorTest {
         data.put("boolean", true);
 
         // array types
-        data.put("intArray", new Integer[] { 3, 5 });
-        data.put("longArray", new Long[] { Long.MAX_VALUE, Long.MIN_VALUE });
-        data.put("stringArray", new String[] { "string" });
+        data.put("intArray", new Integer[]{3, 5});
+        data.put("longArray", new Long[]{Long.MAX_VALUE, Long.MIN_VALUE});
+        data.put("stringArray", new String[]{"string"});
 
         data.put("list", Arrays.asList("a", "b", "c"));
 
@@ -446,7 +516,9 @@ public class JWTCreatorTest {
 
         data.put("map", sub);
 
-        String jwt = JWTCreator.init().withClaim("data", data).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("data", data)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -463,9 +535,9 @@ public class JWTCreatorTest {
         assertThat(map.get("boolean"), is(true));
 
         // array types
-        assertThat(map.get("intArray"), is(Arrays.asList(new Integer[] { 3, 5 })));
-        assertThat(map.get("longArray"), is(Arrays.asList(new Long[] { Long.MAX_VALUE, Long.MIN_VALUE })));
-        assertThat(map.get("stringArray"), is(Arrays.asList(new String[] { "string" })));
+        assertThat(map.get("intArray"), is(Arrays.asList(new Integer[]{3, 5})));
+        assertThat(map.get("longArray"), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
+        assertThat(map.get("stringArray"), is(Arrays.asList(new String[]{"string"})));
 
         // list
         assertThat(map.get("list"), is(Arrays.asList("a", "b", "c")));
@@ -487,9 +559,9 @@ public class JWTCreatorTest {
         data.add(true);
 
         // array types
-        data.add(new Integer[] { 3, 5 });
-        data.add(new Long[] { Long.MAX_VALUE, Long.MIN_VALUE });
-        data.add(new String[] { "string" });
+        data.add(new Integer[]{3, 5});
+        data.add(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE});
+        data.add(new String[]{"string"});
 
         data.add(Arrays.asList("a", "b", "c"));
 
@@ -498,7 +570,9 @@ public class JWTCreatorTest {
 
         data.add(sub);
 
-        String jwt = JWTCreator.init().withClaim("data", data).sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init()
+                .withClaim("data", data)
+                .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -515,9 +589,9 @@ public class JWTCreatorTest {
         assertThat(list.get(5), is(true));
 
         // array types
-        assertThat(list.get(6), is(Arrays.asList(new Integer[] { 3, 5 })));
-        assertThat(list.get(7), is(Arrays.asList(new Long[] { Long.MAX_VALUE, Long.MIN_VALUE })));
-        assertThat(list.get(8), is(Arrays.asList(new String[] { "string" })));
+        assertThat(list.get(6), is(Arrays.asList(new Integer[]{3, 5})));
+        assertThat(list.get(7), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
+        assertThat(list.get(8), is(Arrays.asList(new String[]{"string"})));
 
         // list
         assertThat(list.get(9), is(Arrays.asList("a", "b", "c")));
@@ -530,13 +604,17 @@ public class JWTCreatorTest {
         Map<String, Object> data = new HashMap<>();
         data.put("test1", Arrays.asList("a", null, "c"));
 
-        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAcceptCustomClaimWithNullMapAndRemoveClaim() throws Exception {
-        String jwt = JWTCreator.init().withClaim("map", "stubValue").withClaim("map", (Map<String, ?>) null)
+        String jwt = JWTCreator.init()
+                .withClaim("map", "stubValue")
+                .withClaim("map", (Map<String, ?>) null)
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -551,7 +629,9 @@ public class JWTCreatorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAcceptCustomClaimWithNullListAndRemoveClaim() throws Exception {
-        String jwt = JWTCreator.init().withClaim("list", "stubValue").withClaim("list", (List<String>) null)
+        String jwt = JWTCreator.init()
+                .withClaim("list", "stubValue")
+                .withClaim("list", (List<String>) null)
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -570,7 +650,9 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
@@ -580,10 +662,12 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("pojo", data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void shouldRefuseCustomMapClaimForNonStringKey() throws Exception {
         Map data = new HashMap<>();
@@ -591,7 +675,9 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("pojo", (Map<String, Object>) data).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("pojo", (Map<String, Object>) data)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
@@ -600,7 +686,9 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("list", list).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("list", list)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
@@ -612,89 +700,21 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("list", list).sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init()
+                .withClaim("list", list)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
     public void shouldRefuseCustomListClaimForUnknownArrayType() throws Exception {
         List<Object> list = new ArrayList<>();
-        list.add(new Object[] { "test" });
+        list.add(new Object[]{"test"});
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init().withClaim("list", list).sign(Algorithm.HMAC256("secret"));
-    }
-
-    @SuppressWarnings("Convert2Diamond")
-    @Test
-    public void shouldAddPayloadClaim() throws Exception {
-        Map<String, Object> payload = new HashMap<String, Object>();
-        payload.put("asd", 123);
-        String signed = JWTCreator.init().withPayload(payload).sign(Algorithm.HMAC256("secret"));
-
-        assertThat(signed, is(notNullValue()));
-        String[] parts = signed.split("\\.");
-        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
-        assertThat(payloadJson, JsonMatcher.hasEntry("asd", 123));
-    }
-
-    @Test
-    public void shouldReturnBuilderIfNullMapIsProvidedForPayload() throws Exception {
-        String signed = JWTCreator.init().withPayload(null).sign(Algorithm.HMAC256("secret"));
-
-        assertThat(signed, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldOverwriteExistingPayloadIfPayloadMapContainsTheSameKey() throws Exception {
-        Map<String, Object> payload = new HashMap<String, Object>();
-        payload.put(PublicClaims.KEY_ID, "xyz");
-
-        String signed = JWTCreator.init().withKeyId("abc").withPayload(payload).sign(Algorithm.HMAC256("secret"));
-
-        assertThat(signed, is(notNullValue()));
-        String[] parts = signed.split("\\.");
-        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
-        assertThat(payloadJson, JsonMatcher.hasEntry(PublicClaims.KEY_ID, "xyz"));
-    }
-
-    @Test
-    public void shouldOverwriteExistingPayloadsWhenSettingSamePayloadKey() throws Exception {
-        Map<String, Object> payload = new HashMap<String, Object>();
-        payload.put(PublicClaims.ISSUER, "xyz");
-
-        String signed = JWTCreator.init().withPayload(payload).withIssuer("abc").sign(Algorithm.HMAC256("secret"));
-
-        assertThat(signed, is(notNullValue()));
-        String[] parts = signed.split("\\.");
-        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
-        assertThat(payloadJson, JsonMatcher.hasEntry(PublicClaims.ISSUER, "abc"));
-    }
-
-    @Test
-    public void shouldRemovePayloadIfTheValueIsNull() throws Exception {
-        Map<String, Object> payload = new HashMap<String, Object>();
-        payload.put(PublicClaims.KEY_ID, null);
-        payload.put("test2", "isSet");
-
-        String signed = JWTCreator.init().withKeyId("test").withPayload(payload).sign(Algorithm.HMAC256("secret"));
-
-        assertThat(signed, is(notNullValue()));
-        String[] parts = signed.split("\\.");
-        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
-        assertThat(payloadJson, JsonMatcher.isNotPresent(PublicClaims.KEY_ID));
-        assertThat(payloadJson, JsonMatcher.hasEntry("test2", "isSet"));
-    }
-
-    @Test
-    public void shouldSetCustomTypeInThePayload() throws Exception {
-        Map<String, Object> paylaod = Collections.singletonMap("typ", "passport");
-        String signed = JWTCreator.init().withPayload(paylaod).sign(Algorithm.HMAC256("secret"));
-
-        assertThat(signed, is(notNullValue()));
-        String[] parts = signed.split("\\.");
-        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
-        assertThat(payloadJson, JsonMatcher.hasEntry("typ", "passport"));
+        JWTCreator.init()
+                .withClaim("list", list)
+                .sign(Algorithm.HMAC256("secret"));
     }
 
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -36,8 +36,7 @@ public class JWTCreatorTest {
     public void shouldThrowWhenRequestingSignWithoutAlgorithm() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Algorithm cannot be null");
-        JWTCreator.init()
-                .sign(null);
+        JWTCreator.init().sign(null);
     }
 
     @SuppressWarnings("Convert2Diamond")
@@ -45,9 +44,7 @@ public class JWTCreatorTest {
     public void shouldAddHeaderClaim() throws Exception {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put("asd", 123);
-        String signed = JWTCreator.init()
-                .withHeader(header)
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withHeader(header).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -56,10 +53,8 @@ public class JWTCreatorTest {
     }
 
     @Test
-    public void shouldReturnBuilderIfNullMapIsProvided() throws Exception {
-        String signed = JWTCreator.init()
-                .withHeader(null)
-                .sign(Algorithm.HMAC256("secret"));
+    public void shouldReturnBuilderIfNullMapIsProvidedForHeader() throws Exception {
+        String signed = JWTCreator.init().withHeader(null).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
     }
@@ -69,10 +64,7 @@ public class JWTCreatorTest {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put(PublicClaims.KEY_ID, "xyz");
 
-        String signed = JWTCreator.init()
-                .withKeyId("abc")
-                .withHeader(header)
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withKeyId("abc").withHeader(header).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -85,10 +77,7 @@ public class JWTCreatorTest {
         Map<String, Object> header = new HashMap<String, Object>();
         header.put(PublicClaims.KEY_ID, "xyz");
 
-        String signed = JWTCreator.init()
-                .withHeader(header)
-                .withKeyId("abc")
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withHeader(header).withKeyId("abc").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -102,10 +91,7 @@ public class JWTCreatorTest {
         header.put(PublicClaims.KEY_ID, null);
         header.put("test2", "isSet");
 
-        String signed = JWTCreator.init()
-                .withKeyId("test")
-                .withHeader(header)
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withKeyId("test").withHeader(header).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -116,9 +102,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddKeyId() throws Exception {
-        String signed = JWTCreator.init()
-                .withKeyId("56a8bd44da435300010000015f5ed")
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withKeyId("56a8bd44da435300010000015f5ed").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -133,8 +117,7 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init()
-                .sign(Algorithm.RSA256(provider));
+        String signed = JWTCreator.init().sign(Algorithm.RSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -149,9 +132,7 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init()
-                .withKeyId("real-key-id")
-                .sign(Algorithm.RSA256(provider));
+        String signed = JWTCreator.init().withKeyId("real-key-id").sign(Algorithm.RSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -166,8 +147,7 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init()
-                .sign(Algorithm.ECDSA256K(provider));
+        String signed = JWTCreator.init().sign(Algorithm.ECDSA256K(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -182,9 +162,7 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init()
-                .withKeyId("real-key-id")
-                .sign(Algorithm.ECDSA256(provider));
+        String signed = JWTCreator.init().withKeyId("real-key-id").sign(Algorithm.ECDSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -199,8 +177,7 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init()
-                .sign(Algorithm.ECDSA256(provider));
+        String signed = JWTCreator.init().sign(Algorithm.ECDSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -215,9 +192,7 @@ public class JWTCreatorTest {
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);
 
-        String signed = JWTCreator.init()
-                .withKeyId("real-key-id")
-                .sign(Algorithm.ECDSA256(provider));
+        String signed = JWTCreator.init().withKeyId("real-key-id").sign(Algorithm.ECDSA256(provider));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -227,9 +202,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddIssuer() throws Exception {
-        String signed = JWTCreator.init()
-                .withIssuer("auth0")
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withIssuer("auth0").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJpc3MiOiJhdXRoMCJ9"));
@@ -237,9 +210,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddSubject() throws Exception {
-        String signed = JWTCreator.init()
-                .withSubject("1234567890")
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withSubject("1234567890").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJzdWIiOiIxMjM0NTY3ODkwIn0"));
@@ -247,17 +218,12 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddAudience() throws Exception {
-        String signed = JWTCreator.init()
-                .withAudience("Mark")
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withAudience("Mark").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJhdWQiOiJNYXJrIn0"));
 
-
-        String signedArr = JWTCreator.init()
-                .withAudience("Mark", "David")
-                .sign(Algorithm.HMAC256("secret"));
+        String signedArr = JWTCreator.init().withAudience("Mark", "David").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signedArr, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signedArr)[1], is("eyJhdWQiOlsiTWFyayIsIkRhdmlkIl19"));
@@ -265,9 +231,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddExpiresAt() throws Exception {
-        String signed = JWTCreator.init()
-                .withExpiresAt(new Date(1477592000))
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withExpiresAt(new Date(1477592000)).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJleHAiOjE0Nzc1OTJ9"));
@@ -275,9 +239,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddNotBefore() throws Exception {
-        String signed = JWTCreator.init()
-                .withNotBefore(new Date(1477592000))
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withNotBefore(new Date(1477592000)).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJuYmYiOjE0Nzc1OTJ9"));
@@ -285,9 +247,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddIssuedAt() throws Exception {
-        String signed = JWTCreator.init()
-                .withIssuedAt(new Date(1477592000))
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withIssuedAt(new Date(1477592000)).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJpYXQiOjE0Nzc1OTJ9"));
@@ -295,9 +255,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAddJWTId() throws Exception {
-        String signed = JWTCreator.init()
-                .withJWTId("jwt_id_123")
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withJWTId("jwt_id_123").sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("eyJqdGkiOiJqd3RfaWRfMTIzIn0"));
@@ -305,10 +263,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldRemoveClaimWhenPassingNull() throws Exception {
-        String signed = JWTCreator.init()
-                .withIssuer("iss")
-                .withIssuer(null)
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withIssuer("iss").withIssuer(null).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[1], is("e30"));
@@ -316,8 +271,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldSetCorrectAlgorithmInTheHeader() throws Exception {
-        String signed = JWTCreator.init()
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -327,8 +281,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldSetDefaultTypeInTheHeader() throws Exception {
-        String signed = JWTCreator.init()
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -339,9 +292,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldSetCustomTypeInTheHeader() throws Exception {
         Map<String, Object> header = Collections.singletonMap("typ", "passport");
-        String signed = JWTCreator.init()
-                .withHeader(header)
-                .sign(Algorithm.HMAC256("secret"));
+        String signed = JWTCreator.init().withHeader(header).sign(Algorithm.HMAC256("secret"));
 
         assertThat(signed, is(notNullValue()));
         String[] parts = signed.split("\\.");
@@ -351,8 +302,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldSetEmptySignatureIfAlgorithmIsNone() throws Exception {
-        String signed = JWTCreator.init()
-                .sign(Algorithm.none());
+        String signed = JWTCreator.init().sign(Algorithm.none());
         assertThat(signed, is(notNullValue()));
         assertThat(TokenUtils.splitToken(signed)[2], is(""));
     }
@@ -361,15 +311,12 @@ public class JWTCreatorTest {
     public void shouldThrowOnNullCustomClaimName() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The Custom Claim's name can't be null.");
-        JWTCreator.init()
-                .withClaim(null, "value");
+        JWTCreator.init().withClaim(null, "value");
     }
 
     @Test
     public void shouldAcceptCustomClaimOfTypeString() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", "value")
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("name", "value").sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -378,9 +325,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeInteger() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", 123)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("name", 123).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -389,9 +334,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeLong() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", Long.MAX_VALUE)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("name", Long.MAX_VALUE).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -400,9 +343,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeDouble() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", 23.45)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("name", 23.45).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -411,9 +352,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomClaimOfTypeBoolean() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("name", true)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("name", true).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -423,9 +362,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldAcceptCustomClaimOfTypeDate() throws Exception {
         Date date = new Date(1478891521000L);
-        String jwt = JWTCreator.init()
-                .withClaim("name", date)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("name", date).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -434,8 +371,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeString() throws Exception {
-        String jwt = JWTCreator.init()
-                .withArrayClaim("name", new String[]{"text", "123", "true"})
+        String jwt = JWTCreator.init().withArrayClaim("name", new String[] { "text", "123", "true" })
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -445,8 +381,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeInteger() throws Exception {
-        String jwt = JWTCreator.init()
-                .withArrayClaim("name", new Integer[]{1, 2, 3})
+        String jwt = JWTCreator.init().withArrayClaim("name", new Integer[] { 1, 2, 3 })
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -456,8 +391,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldAcceptCustomArrayClaimOfTypeLong() throws Exception {
-        String jwt = JWTCreator.init()
-                .withArrayClaim("name", new Long[]{1L, 2L, 3L})
+        String jwt = JWTCreator.init().withArrayClaim("name", new Long[] { 1L, 2L, 3L })
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -470,9 +404,7 @@ public class JWTCreatorTest {
         Map<String, Object> data = new HashMap<>();
         data.put("test1", "abc");
         data.put("test2", "def");
-        String jwt = JWTCreator.init()
-                .withClaim("data", data)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("data", data).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -486,9 +418,7 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("pojo", data)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
     }
 
     @SuppressWarnings("unchecked")
@@ -505,9 +435,9 @@ public class JWTCreatorTest {
         data.put("boolean", true);
 
         // array types
-        data.put("intArray", new Integer[]{3, 5});
-        data.put("longArray", new Long[]{Long.MAX_VALUE, Long.MIN_VALUE});
-        data.put("stringArray", new String[]{"string"});
+        data.put("intArray", new Integer[] { 3, 5 });
+        data.put("longArray", new Long[] { Long.MAX_VALUE, Long.MIN_VALUE });
+        data.put("stringArray", new String[] { "string" });
 
         data.put("list", Arrays.asList("a", "b", "c"));
 
@@ -516,9 +446,7 @@ public class JWTCreatorTest {
 
         data.put("map", sub);
 
-        String jwt = JWTCreator.init()
-                .withClaim("data", data)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("data", data).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -535,9 +463,9 @@ public class JWTCreatorTest {
         assertThat(map.get("boolean"), is(true));
 
         // array types
-        assertThat(map.get("intArray"), is(Arrays.asList(new Integer[]{3, 5})));
-        assertThat(map.get("longArray"), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
-        assertThat(map.get("stringArray"), is(Arrays.asList(new String[]{"string"})));
+        assertThat(map.get("intArray"), is(Arrays.asList(new Integer[] { 3, 5 })));
+        assertThat(map.get("longArray"), is(Arrays.asList(new Long[] { Long.MAX_VALUE, Long.MIN_VALUE })));
+        assertThat(map.get("stringArray"), is(Arrays.asList(new String[] { "string" })));
 
         // list
         assertThat(map.get("list"), is(Arrays.asList("a", "b", "c")));
@@ -559,9 +487,9 @@ public class JWTCreatorTest {
         data.add(true);
 
         // array types
-        data.add(new Integer[]{3, 5});
-        data.add(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE});
-        data.add(new String[]{"string"});
+        data.add(new Integer[] { 3, 5 });
+        data.add(new Long[] { Long.MAX_VALUE, Long.MIN_VALUE });
+        data.add(new String[] { "string" });
 
         data.add(Arrays.asList("a", "b", "c"));
 
@@ -570,9 +498,7 @@ public class JWTCreatorTest {
 
         data.add(sub);
 
-        String jwt = JWTCreator.init()
-                .withClaim("data", data)
-                .sign(Algorithm.HMAC256("secret"));
+        String jwt = JWTCreator.init().withClaim("data", data).sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
@@ -589,9 +515,9 @@ public class JWTCreatorTest {
         assertThat(list.get(5), is(true));
 
         // array types
-        assertThat(list.get(6), is(Arrays.asList(new Integer[]{3, 5})));
-        assertThat(list.get(7), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
-        assertThat(list.get(8), is(Arrays.asList(new String[]{"string"})));
+        assertThat(list.get(6), is(Arrays.asList(new Integer[] { 3, 5 })));
+        assertThat(list.get(7), is(Arrays.asList(new Long[] { Long.MAX_VALUE, Long.MIN_VALUE })));
+        assertThat(list.get(8), is(Arrays.asList(new String[] { "string" })));
 
         // list
         assertThat(list.get(9), is(Arrays.asList("a", "b", "c")));
@@ -604,17 +530,13 @@ public class JWTCreatorTest {
         Map<String, Object> data = new HashMap<>();
         data.put("test1", Arrays.asList("a", null, "c"));
 
-        JWTCreator.init()
-                .withClaim("pojo", data)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAcceptCustomClaimWithNullMapAndRemoveClaim() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("map", "stubValue")
-                .withClaim("map", (Map<String, ?>) null)
+        String jwt = JWTCreator.init().withClaim("map", "stubValue").withClaim("map", (Map<String, ?>) null)
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -629,9 +551,7 @@ public class JWTCreatorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAcceptCustomClaimWithNullListAndRemoveClaim() throws Exception {
-        String jwt = JWTCreator.init()
-                .withClaim("list", "stubValue")
-                .withClaim("list", (List<String>) null)
+        String jwt = JWTCreator.init().withClaim("list", "stubValue").withClaim("list", (List<String>) null)
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
@@ -650,9 +570,7 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("pojo", data)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
@@ -662,12 +580,10 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("pojo", data)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("pojo", data).sign(Algorithm.HMAC256("secret"));
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
     public void shouldRefuseCustomMapClaimForNonStringKey() throws Exception {
         Map data = new HashMap<>();
@@ -675,9 +591,7 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("pojo", (Map<String, Object>) data)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("pojo", (Map<String, Object>) data).sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
@@ -686,9 +600,7 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("list", list)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("list", list).sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
@@ -700,21 +612,89 @@ public class JWTCreatorTest {
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("list", list)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("list", list).sign(Algorithm.HMAC256("secret"));
     }
 
     @Test
     public void shouldRefuseCustomListClaimForUnknownArrayType() throws Exception {
         List<Object> list = new ArrayList<>();
-        list.add(new Object[]{"test"});
+        list.add(new Object[] { "test" });
 
         exception.expect(IllegalArgumentException.class);
 
-        JWTCreator.init()
-                .withClaim("list", list)
-                .sign(Algorithm.HMAC256("secret"));
+        JWTCreator.init().withClaim("list", list).sign(Algorithm.HMAC256("secret"));
+    }
+
+    @SuppressWarnings("Convert2Diamond")
+    @Test
+    public void shouldAddPayloadClaim() throws Exception {
+        Map<String, Object> payload = new HashMap<String, Object>();
+        payload.put("asd", 123);
+        String signed = JWTCreator.init().withPayload(payload).sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        assertThat(payloadJson, JsonMatcher.hasEntry("asd", 123));
+    }
+
+    @Test
+    public void shouldReturnBuilderIfNullMapIsProvidedForPayload() throws Exception {
+        String signed = JWTCreator.init().withPayload(null).sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldOverwriteExistingPayloadIfPayloadMapContainsTheSameKey() throws Exception {
+        Map<String, Object> payload = new HashMap<String, Object>();
+        payload.put(PublicClaims.KEY_ID, "xyz");
+
+        String signed = JWTCreator.init().withKeyId("abc").withPayload(payload).sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        assertThat(payloadJson, JsonMatcher.hasEntry(PublicClaims.KEY_ID, "xyz"));
+    }
+
+    @Test
+    public void shouldOverwriteExistingPayloadsWhenSettingSamePayloadKey() throws Exception {
+        Map<String, Object> payload = new HashMap<String, Object>();
+        payload.put(PublicClaims.ISSUER, "xyz");
+
+        String signed = JWTCreator.init().withPayload(payload).withIssuer("abc").sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        assertThat(payloadJson, JsonMatcher.hasEntry(PublicClaims.ISSUER, "abc"));
+    }
+
+    @Test
+    public void shouldRemovePayloadIfTheValueIsNull() throws Exception {
+        Map<String, Object> payload = new HashMap<String, Object>();
+        payload.put(PublicClaims.KEY_ID, null);
+        payload.put("test2", "isSet");
+
+        String signed = JWTCreator.init().withKeyId("test").withPayload(payload).sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        assertThat(payloadJson, JsonMatcher.isNotPresent(PublicClaims.KEY_ID));
+        assertThat(payloadJson, JsonMatcher.hasEntry("test2", "isSet"));
+    }
+
+    @Test
+    public void shouldSetCustomTypeInThePayload() throws Exception {
+        Map<String, Object> paylaod = Collections.singletonMap("typ", "passport");
+        String signed = JWTCreator.init().withPayload(paylaod).sign(Algorithm.HMAC256("secret"));
+
+        assertThat(signed, is(notNullValue()));
+        String[] parts = signed.split("\\.");
+        String payloadJson = new String(Base64.decodeBase64(parts[1]), StandardCharsets.UTF_8);
+        assertThat(payloadJson, JsonMatcher.hasEntry("typ", "passport"));
     }
 
 }


### PR DESCRIPTION
### Changes

Previously, you could initialize the `Header` of a `JWT` from a `Map` without any problem, but the story changed if you wanted to initialize a `Payload`, since you could not do it from a `Map`. The user had to add attributes one by one. With this new change, I added a new method `withPayload(Map<String, Object> payloadClaims)` in [`JWTCreator.java`](https://github.com/auth0/java-jwt/blob/master/lib/src/main/java/com/auth0/jwt/JWTCreator.java) that allows to initialize the `Payload` from a `Map`.

### References

Links supporting this change such as a:

- #445 discussed with @jimmyjames 

### Testing

Also, this new method has its own tests in the `JWTCreatorTest.java`.

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
