### PR TITLE
Update jackson-databind to 2.10.5.1 (fixes CVE-2020-25649)

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,7 +34,7 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
     implementation 'commons-codec:commons-codec:1.14'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Bump jackson-databind, as the new version contains a fix for a vulnerability.

While `java-jwt` itself is probably not affected due to the nature of JWT not being XML-based, we can not say for sure if this can't be exploited in downstream projects.

### Changes

Updated library version

### References

FasterXML/jackson-databind#2589

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java: Merely a smoke test, but I've updated the dependency in my downstream project using JDK 15 and I did not encounter any issues with JWTs

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
