### PR TITLE
Fix: updated jackson-databind to 2.11.0 to block CVE-2020-25649

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -41,7 +41,7 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
     implementation 'commons-codec:commons-codec:1.14'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
## Changes
 Version bump of jackson-databind to 2.11.0

## References: 
 [CVE-2020-25649](https://bugzilla.redhat.com/show_bug.cgi?id=1887664)