### PR TITLE
Add toString to Claim objects [SDK-2225]

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -128,6 +128,11 @@ class JsonNodeClaim implements Claim {
         return false;
     }
 
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+
     /**
      * Helper method to extract a Claim from the given JsonNode tree.
      *

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -65,4 +65,9 @@ public class NullClaim implements Claim {
     public <T> T as(Class<T> tClazz) throws JWTDecodeException {
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "Null Claim";
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -431,4 +431,11 @@ public class JsonNodeClaimTest {
         assertThat(claim, is(instanceOf(JsonNodeClaim.class)));
         assertThat(claim.isNull(), is(false));
     }
+
+    @Test
+    public void shouldDelegateToJsonNodeToString() {
+        JsonNode value = mapper.valueToTree(new UserPojo("john", 123));
+        Claim claim = claimFromNode(value);
+        assertThat(claim.toString(), is(value.toString()));
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -70,4 +70,8 @@ public class NullClaimTest {
         assertThat(claim.as(Object.class), is(nullValue()));
     }
 
+    @Test
+    public void shouldHaveToString() {
+        assertThat(claim.toString(), is("Null Claim"));
+    }
 }


### PR DESCRIPTION
### Changes

Fixes #466 to enable better debugging by implementing `toString()` on the claim types.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
