### PR TITLE
Update acceptedIssuedAt JavaDocs

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -64,6 +64,11 @@ public interface Verification {
 
     /**
      * Set a specific leeway window in seconds in which the Issued At ("iat") Claim will still be valid.
+     * This method overrides the value set with {@link #acceptLeeway(long)}.
+     * If Issued At verification has been disabled with {@link #ignoreIssuedAt()}, no verification of the Issued At
+     * claim will be performed, and this method has no effect.
+     *
+     * Issued At Date is verified by default when the value is present, unless disabled
      * Issued At Date is always verified when the value is present. This method overrides the value set with acceptLeeway
      *
      * @param leeway the window in seconds in which the Issued At Claim will still be valid.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -65,11 +65,8 @@ public interface Verification {
     /**
      * Set a specific leeway window in seconds in which the Issued At ("iat") Claim will still be valid.
      * This method overrides the value set with {@link #acceptLeeway(long)}.
-     * If Issued At verification has been disabled with {@link #ignoreIssuedAt()}, no verification of the Issued At
-     * claim will be performed, and this method has no effect.
-     *
-     * Issued At Date is verified by default when the value is present, unless disabled
-     * Issued At Date is always verified when the value is present. This method overrides the value set with acceptLeeway
+     * By default, the Issued At claim is always verified when the value is present, unless disabled with {@link #ignoreIssuedAt()}.
+     * If Issued At verification has been disabled, no verification of the Issued At claim will be performed, and this method has no effect.
      *
      * @param leeway the window in seconds in which the Issued At Claim will still be valid.
      * @return this same Verification instance.

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -672,12 +672,14 @@ public class JWTVerifierTest {
     @Test
     public void shouldOverrideAcceptIssuedAtWhenIgnoreIssuedAtFlagPassedAndSkipTheVerification() throws Exception {
         Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
+        when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 10000));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0Nzc1OTJ9.0WJky9eLN7kuxLyZlmbcXRL3Wy8hLoNCEk5CCl2M4lo";
-        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"));
-        DecodedJWT jwt = verification.acceptIssuedAt(20).ignoreIssuedAt()
-                .build()
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .acceptIssuedAt(1)
+                .ignoreIssuedAt();
+        DecodedJWT jwt = verification
+                .build(clock)
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));


### PR DESCRIPTION
### Changes

Fixes #470.

Updates the JavaDocs of `acceptIssuedAt` to clarify the behavior if used in combination with `ignoreIssuedAt`.

Also fixes the related test; it was not passing the mocked clock, and the mocked clock and issuedAt leeway was configured to always pass. This was masking any issues with `ignoreIssuedAt`, since the validation would pass if the issuedAt claim was not ignored.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
