### PR TITLE
Add ability to verify audience contains at least one of those expected

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -27,8 +27,9 @@ public interface Verification {
     /**
      * Require a specific Audience ("aud") claim. If multiple audiences are specified, they must all be present
      * in the "aud" claim.
-     * An {@linkplain IllegalStateException} will be thrown if this Verification instance has already been
-     * configured with {@link #withAnyOfAudience(String...)}
+     *
+     * If this is used in conjunction with {@link #withAnyOfAudience(String...)}, whichever one is configured last will
+     * determine the audience validation behavior.
      *
      * @param audience the required Audience value
      * @return this same Verification instance.
@@ -37,8 +38,9 @@ public interface Verification {
 
     /**
      * Require that the Audience ("aud") claim contain at least one of the specified audiences.
-     * An {@linkplain IllegalStateException} will be thrown if this Verification instance has already been
-     * configured with {@link #withAudience(String...)}
+     *
+     * If this is used in conjunction with {@link #withAudience(String...)}, whichever one is configured last will
+     * determine the audience validation behavior.
      *
      * @apiNote This method was added after the interface was released.
      *          It is defined as a default method for compatibility reasons.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -25,13 +25,35 @@ public interface Verification {
     Verification withSubject(String subject);
 
     /**
-     * Require a specific Audience ("aud") claim.
+     * Require a specific Audience ("aud") claim. If multiple audiences are specified, they must all be present
+     * in the "aud" claim.
+     * An {@linkplain IllegalStateException} will be thrown if this Verification instance has already been
+     * configured with {@link #withAnyOfAudience(String...)}
      *
      * @param audience the required Audience value
      * @return this same Verification instance.
      */
     Verification withAudience(String... audience);
 
+    /**
+     * Require that the Audience ("aud") claim contain at least one of the specified audiences.
+     * An {@linkplain IllegalStateException} will be thrown if this Verification instance has already been
+     * configured with {@link #withAudience(String...)}
+     *
+     * @apiNote This method was added after the interface was released.
+     *          It is defined as a default method for compatibility reasons.
+     *          From version 4.0 on, the method will be abstract and all implementations of this interface
+     *          will have to provide their own implementation.
+     *
+     * @implSpec The default implementation throws an {@linkplain UnsupportedOperationException}.
+     * 
+     * @param audience the required Audience value for which the "aud" claim must contain at least one value.
+     * @return this same Verification instance.
+     */
+    default Verification withAnyOfAudience(String... audience) {
+        throw new UnsupportedOperationException("withAnyOfAudience");
+    }
+    
     /**
      * Define the default window in seconds in which the Not Before, Issued At and Expires At Claims will still be valid.
      * Setting a specific leeway value on a given Claim will override this value for that Claim.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -42,12 +42,12 @@ public interface Verification {
      * If this is used in conjunction with {@link #withAudience(String...)}, whichever one is configured last will
      * determine the audience validation behavior.
      *
-     * @apiNote This method was added after the interface was released.
-     *          It is defined as a default method for compatibility reasons.
-     *          From version 4.0 on, the method will be abstract and all implementations of this interface
-     *          will have to provide their own implementation.
+     * Note: This method was added after the interface was released.
+     * It is defined as a default method for compatibility reasons.
+     * From version 4.0 on, the method will be abstract and all implementations of this interface
+     * will have to provide their own implementation.
      *
-     * @implSpec The default implementation throws an {@linkplain UnsupportedOperationException}.
+     * The default implementation throws an {@linkplain UnsupportedOperationException}.
      * 
      * @param audience the required Audience value for which the "aud" claim must contain at least one value.
      * @return this same Verification instance.


### PR DESCRIPTION
### Changes

This PR adds the ability to verify that a JWT's audience claim contains at least one of the expected audiences. Currently, `withAudience` requires that the audience claim match the specified audience exactly.

Resolves #449

**New public method:**

- `withAnyOfAudience(String... audience)` - verifies that the JWT's audience claim contains at least one of the specified audiences.

**Details:**

- If both `withAudience` and `withAnyOfAudience` are called on the same `Verification` instance, an `IllegalStateException` will be thrown.

**Alternatives considered:**

- Instead of managing the audience verification behavior with an enum, we could instead keep a boolean flag. This would mean that if both `withAudience` and `withAnyOfAudience` are used on the same `Verification` instance, the last one called wins. We could document that behavior, but discussion with @lbalmaceda thought it best for us to throw in that scenario.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
