### PR TITLE
Add withPayload to JWTCreator.Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,16 @@ String token = JWT.create()
         .sign(algorithm);
 ```
 
+You can also create a JWT by calling `withPayload()` and passing a map of claim names to values:
+
+```java
+Map<String, Object> payloadClaims = new HashMap<>();
+payloadClaims.put("@context", "https://auth0.com/");
+String token = JWT.create()
+        .withPayload(payloadClaims)
+        .sign(algorithm);
+```
+
 You can also verify custom Claims on the `JWT.require()` by calling `withClaim()` and passing both the name and the required value.
 
 ```java

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -375,7 +375,7 @@ public final class JWTCreator {
          * @throws IllegalArgumentException if any of the claim keys or null, or if the values are not of a supported type.
          * @return this same Builder instance.
          */
-        public Builder withPayload(Map<String, Object> payloadClaims) throws IllegalArgumentException {
+        public Builder withPayload(Map<String, ?> payloadClaims) throws IllegalArgumentException {
             if (payloadClaims == null) {
                 return this;
             }
@@ -385,15 +385,15 @@ public final class JWTCreator {
             }
 
             // add claims only after validating all claims so as not to corrupt the claims map of this builder
-            for (Map.Entry<String, Object> entry : payloadClaims.entrySet()) {
+            for (Map.Entry<String, ?> entry : payloadClaims.entrySet()) {
                 addClaim(entry.getKey(), entry.getValue());
             }
 
             return this;
         }
 
-        private boolean validatePayload(Map<String, Object> payload) {
-            for (Map.Entry<String, Object> entry : payload.entrySet()) {
+        private boolean validatePayload(Map<String, ?> payload) {
+            for (Map.Entry<String, ?> entry : payload.entrySet()) {
                 String key = entry.getKey();
                 assertNonNull(key);
 

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -13,10 +13,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 /**
@@ -358,6 +355,58 @@ public final class JWTCreator {
             }
             addClaim(name, list);
             return this;
+        }
+
+        /**
+         * Add specific Claims to set as the Payload. If the provided map is null then
+         * nothing is changed.
+         * <p>
+         * Accepted types are {@linkplain Map} and {@linkplain List} with basic types
+         * {@linkplain Boolean}, {@linkplain Integer}, {@linkplain Long}, {@linkplain Double},
+         * {@linkplain String} and {@linkplain Date}. {@linkplain Map}s cannot contain null keys or values.
+         * {@linkplain List}s can contain null elements.
+         * </p>
+         *
+         * <p>
+         * If any of the claims are invalid, none will be added.
+         * </p>
+         *
+         * @param payloadClaims the values to use as Claims in the token's payload.
+         * @throws IllegalArgumentException if any of the claim keys or null, or if the values are not of a supported type.
+         * @return this same Builder instance.
+         */
+        public Builder withPayload(Map<String, Object> payloadClaims) throws IllegalArgumentException {
+            if (payloadClaims == null) {
+                return this;
+            }
+
+            if (!validatePayload(payloadClaims)) {
+                throw new IllegalArgumentException("Claim values must only be of types Map, List, Boolean, Integer, Long, Double, String and Date");
+            }
+
+            // add claims only after validating all claims so as not to corrupt the claims map of this builder
+            for (Map.Entry<String, Object> entry : payloadClaims.entrySet()) {
+                addClaim(entry.getKey(), entry.getValue());
+            }
+
+            return this;
+        }
+
+        private boolean validatePayload(Map<String, Object> payload) {
+            for (Map.Entry<String, Object> entry : payload.entrySet()) {
+                String key = entry.getKey();
+                assertNonNull(key);
+
+                Object value = entry.getValue();
+                if (value instanceof List && !validateClaim((List<?>) value)) {
+                    return false;
+                } else if (value instanceof Map && !validateClaim((Map<?, ?>) value)) {
+                    return false;
+                } else if (value != null && !isSupportedType(value)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         private static boolean validateClaim(Map<?, ?> map) {


### PR DESCRIPTION
### Changes

This change adds a `withPayload(Map<String, ?> payloadClaims)` to the `JWTCreator.Builder`. It uses #454 as a starting point.

**Details**:
- It only supports claim values of supported types
- The behavior for map or list claims is consistent with the implementation of `withClaim(String name, Map<String, ?> map)` and `withClaim(String name, List<?> list`)
- If any of the claim values are invalid, none will be added to the payload claims

This will resolve #445 

### References

- #445 and #454 

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
