### PR TITLE
Remove jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,6 @@ allprojects {
     group = 'com.auth0'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
     }
     plugins {
         id 'com.jfrog.bintray' version '1.8.5'


### PR DESCRIPTION
### Changes

jcenter is being EOL'd: https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure/

This change removes jcenter from the build repositories, replacing with mavenCentral where required.

Fixes #481 

### References

https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure/

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
