### PR TITLE
Add module system support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: openjdk:8-jdk
+      - image: openjdk:11.0-jdk
     steps:
       - checkout-and-build
       - run-tests
@@ -45,7 +45,7 @@ jobs:
       TERM: dumb
   api-diff:
     docker:
-      - image: openjdk:8-jdk
+      - image: openjdk:11.0-jdk
     steps:
       - checkout-and-build
       - run-api-diff

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,13 +33,14 @@ oss {
 def javaVersion = 8
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(javaVersion)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 
 compileJava {
-    sourceCompatibility "$javaVersion"
-    targetCompatibility "$javaVersion"
+    exclude 'module-info.java'
+
+    options.compilerArgs = ['--release', "$javaVersion"]
 }
 
 // Use latest JDK for javadoc generation
@@ -51,7 +52,7 @@ tasks.withType(Javadoc).configureEach {
 
 javadoc {
     // Exclude internal implementation package from javadoc
-    excludes = ['com/auth0/jwt/impl']
+    excludes = ['com/auth0/jwt/impl', 'module-info.java']
     // Specify Java version this project uses
     // Otherwise would use version of javadoc toolchain by default which could
     // cause compilation error mismatch between compileJava and javadoc creation
@@ -80,3 +81,28 @@ test {
         exceptionFormat "short"
     }
 }
+
+task compileModuleInfoJava(type: JavaCompile) {
+    classpath = files()
+    source = 'src/main/java/module-info.java'
+    destinationDir = compileJava.destinationDir
+    doLast {
+        def descriptor = new File(compileJava.destinationDir, 'module-info.class')
+        def dest = new File(compileJava.destinationDir, 'META-INF/versions/9')
+        ant.move file: descriptor, todir: dest
+    }
+
+    doFirst {
+        options.compilerArgs = [
+                '--release', '9',
+                '--module-path', compileJava.classpath.asPath
+        ]
+    }
+}
+
+jar {
+    manifest.attributes('Multi-Release': 'true')
+}
+
+compileModuleInfoJava.dependsOn compileJava
+classes.dependsOn compileModuleInfoJava

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module com.auth0.jwt {
+    // remove transitive in next major release
+    requires com.fasterxml.jackson.databind;
+    // remove in next major release
+    exports com.auth0.jwt.impl;
+
+    exports com.auth0.jwt;
+    exports com.auth0.jwt.algorithms;
+    exports com.auth0.jwt.exceptions;
+    exports com.auth0.jwt.interfaces;
+}


### PR DESCRIPTION
### Changes
1. Added java module system support
2. Bumped compiler version to Java 11
3. Compiling code with java 8 target
4. Compiling module info class with java 9 target

Compiler warns about 0 in module component (auth0), module name components can't end with digits. Not sure how to deal with this.

### References
https://github.com/auth0/java-jwt/issues/483

### Testing
- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
