### PR TITLE
Update Java version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Java implementation of [JSON Web Token (JWT) - RFC 7519](https://tools.ietf.or
 
 If you're looking for an **Android** version of the JWT Decoder take a look at our [JWTDecode.Android](https://github.com/auth0/JWTDecode.Android) library.
 
-> This library currently supports Java 7. Beginning soon, it will require Java 8 as the minimum supported Java version. See [this issue](https://github.com/auth0/java-jwt/issues/457) for additional information and timelines.
+> This library requires Java 8 or higher. The last version that supported Java 7 was 3.11.0.
 
 ## Installation
 


### PR DESCRIPTION
Java 8 has been required since #457.

(Only a small documentation change, so I'm skipping most of the PR template.)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors