### PR TITLE
Update OSS plugin version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     }
     plugins {
         id 'com.jfrog.bintray' version '1.8.5'
-        id 'com.auth0.gradle.oss-library.java' version '0.14.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
     }
 }
 


### PR DESCRIPTION
Updates to use version 0.15.1 of the [OSS plugin](https://github.com/auth0/oss-library-gradle-plugin/), which enables publishing to Sonatype/maven without using Bintray.