### PR TITLE
Add package-info.java for internal `impl` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# Eclipse IDE
+.classpath
+.project
+.settings/
+
 ### Java template
 *.class
 

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The {@link NullClaim} class is a Claim implementation that returns null when any of it's methods it's called.
+ * The {@code NullClaim} class is a Claim implementation that returns null when any of it's methods is called.
  */
 public class NullClaim implements Claim {
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/package-info.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Contains parts of the <b>internal</b> implementation of this library.
+ *
+ * <p><b>Do not use any of the classes in this package.</b> They might be removed
+ * or changed at any point without prior warning.
+ */
+package com.auth0.jwt.impl;

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Header.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Header.java
@@ -34,7 +34,8 @@ public interface Header {
     String getKeyId();
 
     /**
-     * Get a Private Claim given it's name. If the Claim wasn't specified in the Header, a NullClaim will be returned.
+     * Get a Private Claim given it's name. If the Claim wasn't specified in the Header, a 'null claim' will be
+     * returned. All of the methods of that claim will return {@code null}.
      *
      * @param name the name of the Claim to retrieve.
      * @return a non-null Claim.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -59,7 +59,8 @@ public interface Payload {
     String getId();
 
     /**
-     * Get a Claim given it's name. If the Claim wasn't specified in the Payload, a NullClaim will be returned.
+     * Get a Claim given it's name. If the Claim wasn't specified in the Payload, a 'null claim'
+     * will be returned. All of the methods of that claim will return {@code null}.
      *
      * @param name the name of the Claim to retrieve.
      * @return a non-null Claim.


### PR DESCRIPTION
### Changes
Part of #487 which adds a `package-info.java` file for the internal `impl` package, warning users from using classes of the package.
(Additionally adds Eclipse IDE files to `.gitignore`.)

### References
Resolves partially #487

### Testing
The genereated Javadoc contains the package documentation:
![Javadoc screenshot](https://user-images.githubusercontent.com/11685886/116001355-6335b700-a5f4-11eb-9c6a-6a2018b35117.png)


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
