### PR TITLE
Improve Javadoc generation

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -30,15 +30,30 @@ oss {
     }
 }
 
+def javaVersion = 8
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(javaVersion)
     }
 }
 
 compileJava {
-    sourceCompatibility '1.8'
-    targetCompatibility '1.8'
+    sourceCompatibility "$javaVersion"
+    targetCompatibility "$javaVersion"
+}
+
+// Use latest JDK for javadoc generation
+tasks.withType(Javadoc).configureEach {
+    javadocTool = javaToolchains.javadocToolFor {
+        languageVersion = JavaLanguageVersion.of(16)
+    }
+}
+
+javadoc {
+    // Specify Java version this project uses
+    // Otherwise would use version of javadoc toolchain by default which could
+    // cause compilation error mismatch between compileJava and javadoc creation
+    options.addStringOption('-release', "$javaVersion")
 }
 
 dependencies {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -50,6 +50,8 @@ tasks.withType(Javadoc).configureEach {
 }
 
 javadoc {
+    // Exclude internal implementation package from javadoc
+    excludes = ['com/auth0/jwt/impl']
     // Specify Java version this project uses
     // Otherwise would use version of javadoc toolchain by default which could
     // cause compilation error mismatch between compileJava and javadoc creation


### PR DESCRIPTION
### Changes
- Use JDK 16 for creating the Javadoc to get the latest features, such as a search bar; the code will still be compiled with JDK 8
- Hide internal `impl` package from generated Javadoc (see #487)

### References
Fixes #489
Resolves partially #487

### Testing
Open the generated Javadoc in the browser:
- There should be a search bar in the top right corner
- The `impl` package (and its classes) should not be documentation

### Checklist
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
