### PR TITLE
Expose the claim name in InvalidClaimException

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/exceptions/InvalidClaimException.java
+++ b/lib/src/main/java/com/auth0/jwt/exceptions/InvalidClaimException.java
@@ -2,7 +2,19 @@ package com.auth0.jwt.exceptions;
 
 
 public class InvalidClaimException extends JWTVerificationException {
+    private final String claimName;
+
     public InvalidClaimException(String message) {
         super(message);
+        this.claimName = null;
+    }
+
+    public InvalidClaimException(String message, String claimName) {
+        super(message);
+        this.claimName = claimName;
+    }
+
+    public String getClaimName() {
+        return claimName;
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/exceptions/InvalidClaimException.java
+++ b/lib/src/main/java/com/auth0/jwt/exceptions/InvalidClaimException.java
@@ -2,19 +2,7 @@ package com.auth0.jwt.exceptions;
 
 
 public class InvalidClaimException extends JWTVerificationException {
-    private final String claimName;
-
     public InvalidClaimException(String message) {
         super(message);
-        this.claimName = null;
-    }
-
-    public InvalidClaimException(String message, String claimName) {
-        super(message);
-        this.claimName = claimName;
-    }
-
-    public String getClaimName() {
-        return claimName;
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/exceptions/MissingClaimException.java
+++ b/lib/src/main/java/com/auth0/jwt/exceptions/MissingClaimException.java
@@ -1,0 +1,14 @@
+package com.auth0.jwt.exceptions;
+
+public class MissingClaimException extends InvalidClaimException {
+    private final String claimName;
+
+    public MissingClaimException(String claimName) {
+        super(String.format("The Claim '%s' is not present in the JWT.", claimName));
+        this.claimName = claimName;
+    }
+
+    public String getClaimName() {
+        return claimName;
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/exceptions/WrongClaimValueException.java
+++ b/lib/src/main/java/com/auth0/jwt/exceptions/WrongClaimValueException.java
@@ -1,0 +1,29 @@
+package com.auth0.jwt.exceptions;
+
+import com.auth0.jwt.interfaces.Claim;
+
+public class WrongClaimValueException extends InvalidClaimException {
+    private final String claimName;
+
+    private final Object claimValue;
+
+    public WrongClaimValueException(String message, String claimName, Object claimValue) {
+        super(message);
+        this.claimName = claimName;
+        this.claimValue = claimValue;
+    }
+
+    public WrongClaimValueException(String message, String claimName, Claim claim) {
+        super(message);
+        this.claimName = claimName;
+        this.claimValue = claim.toString();
+    }
+
+    public String getClaimName() {
+        return claimName;
+    }
+
+    public Object getClaimValue() {
+        return claimValue;
+    }
+}

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -1,9 +1,7 @@
 package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.exceptions.AlgorithmMismatchException;
-import com.auth0.jwt.exceptions.InvalidClaimException;
-import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.exceptions.*;
 import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
@@ -67,9 +65,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidIssuer() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'iss' value doesn't match the required issuer.");
         exception.expect(hasProperty("claimName", equalTo("iss")));
+        exception.expect(hasProperty("claimValue", equalTo("auth0")));
         String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withIssuer("invalid")
@@ -79,9 +78,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnNullIssuer() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'iss' value doesn't match the required issuer.");
         exception.expect(hasProperty("claimName", equalTo("iss")));
+        exception.expect(hasProperty("claimValue", nullValue()));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
@@ -103,9 +103,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidSubject() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'sub' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("sub")));
+        exception.expect(hasProperty("claimValue", equalTo("1234567890")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withSubject("invalid")
@@ -149,9 +150,10 @@ public class JWTVerifierTest {
         }
 
         assertThat(exception, is(notNullValue()));
-        assertThat(exception, is(instanceOf(InvalidClaimException.class)));
+        assertThat(exception, is(instanceOf(WrongClaimValueException.class)));
         assertThat(exception.getMessage(), is("The Claim 'aud' value doesn't contain the required audience."));
         assertThat(exception, hasProperty("claimName", equalTo("aud")));
+        assertThat(exception, hasProperty("claimValue", hasItems("Mark", "David", "John")));
 
         DecodedJWT jwt = verification.withAnyOfAudience("Mark", "Jim").build().verify(token);
         assertThat(jwt, is(notNullValue()));
@@ -172,9 +174,10 @@ public class JWTVerifierTest {
         }
 
         assertThat(exception, is(notNullValue()));
-        assertThat(exception, is(instanceOf(InvalidClaimException.class)));
+        assertThat(exception, is(instanceOf(WrongClaimValueException.class)));
         assertThat(exception.getMessage(), is("The Claim 'aud' value doesn't contain the required audience."));
         assertThat(exception, hasProperty("claimName", equalTo("aud")));
+        assertThat(exception, hasProperty("claimValue", hasItems("Mark", "David", "John")));
 
         DecodedJWT jwt = verification.withAudience("Mark").build().verify(token);
         assertThat(jwt, is(notNullValue()));
@@ -206,9 +209,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenAudienceHasNoneOfExpectedAnyOfAudience() {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
         exception.expect(hasProperty("claimName", equalTo("aud")));
+        exception.expect(hasProperty("claimValue", hasItems("Mark", "David", "John")));
 
         // Token 'aud' = ["Mark", "David", "John"]
         String tokenArr = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIiwiSm9obiJdfQ.DX5xXiCaYvr54x_iL0LZsJhK7O6HhAdHeDYkgDeb0Rw";
@@ -220,9 +224,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenAudienceClaimDoesNotContainAllExpected() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
         exception.expect(hasProperty("claimName", equalTo("aud")));
+        exception.expect(hasProperty("claimValue", hasItems("Mark", "David", "John")));
 
         // Token 'aud' = ["Mark", "David", "John"]
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIiwiSm9obiJdfQ.DX5xXiCaYvr54x_iL0LZsJhK7O6HhAdHeDYkgDeb0Rw";
@@ -234,9 +239,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenAudienceClaimIsNull() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
         exception.expect(hasProperty("claimName", equalTo("aud")));
+        exception.expect(hasProperty("claimValue", nullValue()));
 
         // Token 'aud': null
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
@@ -248,9 +254,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenAudienceClaimIsNullWithAnAudience() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
         exception.expect(hasProperty("claimName", equalTo("aud")));
+        exception.expect(hasProperty("claimValue", nullValue()));
 
         // Token 'aud': null
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
@@ -376,9 +383,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenExpectedArrayClaimIsMissing() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'missing' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("missing")));
+        exception.expect(hasProperty("claimValue", equalTo("Null Claim")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcnJheSI6WzEsMiwzXX0.wKNFBcMdwIpdF9rXRxvexrzSM6umgSFqRO1WZj992YM";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withArrayClaim("missing", 1, 2, 3)
@@ -388,9 +396,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenExpectedClaimIsMissing() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'missing' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("missing")));
+        exception.expect(hasProperty("claimValue", equalTo("Null Claim")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGFpbSI6InRleHQifQ.aZ27Ze35VvTqxpaSIK5ZcnYHr4SrvANlUbDR8fw9qsQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("missing", "text")
@@ -400,9 +409,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeString() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("name")));
+        exception.expect(hasProperty("claimValue", equalTo("[\"something\"]")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", "value")
@@ -412,9 +422,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeInteger() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("name")));
+        exception.expect(hasProperty("claimValue", equalTo("[\"something\"]")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", 123)
@@ -424,9 +435,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeDouble() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("name")));
+        exception.expect(hasProperty("claimValue", equalTo("[\"something\"]")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", 23.45)
@@ -436,9 +448,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeBoolean() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("name")));
+        exception.expect(hasProperty("claimValue", equalTo("[\"something\"]")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", true)
@@ -449,9 +462,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("name")));
+        exception.expect(hasProperty("claimValue", equalTo("[\"something\"]")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", new Date())
@@ -461,9 +475,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidCustomClaimValue() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("name")));
+        exception.expect(hasProperty("claimValue", equalTo("[\"something\"]")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         Map<String, Object> map = new HashMap<>();
         map.put("name", new Object());
@@ -763,9 +778,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidNotBeforeIfPresent() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         exception.expect(hasProperty("claimName", equalTo("nbf")));
+        exception.expect(hasProperty("claimValue", equalTo(new Date(DATE_TOKEN_MS_VALUE))));
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -800,7 +816,7 @@ public class JWTVerifierTest {
     }
 
     // Issued At with future date
-    @Test(expected = InvalidClaimException.class)
+    @Test(expected = WrongClaimValueException.class)
     public void shouldThrowOnFutureIssuedAt() throws Exception {
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
@@ -828,9 +844,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidIssuedAtIfPresent() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
         exception.expect(hasProperty("claimName", equalTo("iat")));
+        exception.expect(hasProperty("claimValue", equalTo(new Date(DATE_TOKEN_MS_VALUE))));
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -893,9 +910,10 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowOnInvalidJWTId() throws Exception {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(WrongClaimValueException.class);
         exception.expectMessage("The Claim 'jti' value doesn't match the required one.");
         exception.expect(hasProperty("claimName", equalTo("jti")));
+        exception.expect(hasProperty("claimValue", equalTo("jwt_id_123")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJqd3RfaWRfMTIzIn0.0kegfXUvwOYioP8PDaLMY1IlV8HOAzSVz3EGL7-jWF4";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withJWTId("invalid")
@@ -968,7 +986,7 @@ public class JWTVerifierTest {
 
     @Test
     public void shouldThrowWhenVerifyingClaimPresenceButClaimNotPresent() {
-        exception.expect(InvalidClaimException.class);
+        exception.expect(MissingClaimException.class);
         exception.expectMessage("The Claim 'missing' is not present in the JWT.");
         exception.expect(hasProperty("claimName", equalTo("missing")));
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -69,6 +69,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidIssuer() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'iss' value doesn't match the required issuer.");
+        exception.expect(hasProperty("claimName", equalTo("iss")));
         String token = "eyJhbGciOiJIUzI1NiIsImN0eSI6IkpXVCJ9.eyJpc3MiOiJhdXRoMCJ9.mZ0m_N1J4PgeqWmi903JuUoDRZDBPB7HwkS4nVyWH1M";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withIssuer("invalid")
@@ -80,6 +81,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnNullIssuer() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'iss' value doesn't match the required issuer.");
+        exception.expect(hasProperty("claimName", equalTo("iss")));
 
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
@@ -103,6 +105,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidSubject() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'sub' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("sub")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withSubject("invalid")
@@ -148,6 +151,7 @@ public class JWTVerifierTest {
         assertThat(exception, is(notNullValue()));
         assertThat(exception, is(instanceOf(InvalidClaimException.class)));
         assertThat(exception.getMessage(), is("The Claim 'aud' value doesn't contain the required audience."));
+        assertThat(exception, hasProperty("claimName", equalTo("aud")));
 
         DecodedJWT jwt = verification.withAnyOfAudience("Mark", "Jim").build().verify(token);
         assertThat(jwt, is(notNullValue()));
@@ -170,6 +174,7 @@ public class JWTVerifierTest {
         assertThat(exception, is(notNullValue()));
         assertThat(exception, is(instanceOf(InvalidClaimException.class)));
         assertThat(exception.getMessage(), is("The Claim 'aud' value doesn't contain the required audience."));
+        assertThat(exception, hasProperty("claimName", equalTo("aud")));
 
         DecodedJWT jwt = verification.withAudience("Mark").build().verify(token);
         assertThat(jwt, is(notNullValue()));
@@ -203,6 +208,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenAudienceHasNoneOfExpectedAnyOfAudience() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
+        exception.expect(hasProperty("claimName", equalTo("aud")));
 
         // Token 'aud' = ["Mark", "David", "John"]
         String tokenArr = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIiwiSm9obiJdfQ.DX5xXiCaYvr54x_iL0LZsJhK7O6HhAdHeDYkgDeb0Rw";
@@ -216,6 +222,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenAudienceClaimDoesNotContainAllExpected() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
+        exception.expect(hasProperty("claimName", equalTo("aud")));
 
         // Token 'aud' = ["Mark", "David", "John"]
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiTWFyayIsIkRhdmlkIiwiSm9obiJdfQ.DX5xXiCaYvr54x_iL0LZsJhK7O6HhAdHeDYkgDeb0Rw";
@@ -229,6 +236,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenAudienceClaimIsNull() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
+        exception.expect(hasProperty("claimName", equalTo("aud")));
 
         // Token 'aud': null
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
@@ -242,6 +250,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenAudienceClaimIsNullWithAnAudience() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'aud' value doesn't contain the required audience.");
+        exception.expect(hasProperty("claimName", equalTo("aud")));
 
         // Token 'aud': null
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.Rq8IxqeX7eA6GgYxlcHdPFVRNFFZc5rEI3MQTZZbK3I";
@@ -369,6 +378,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenExpectedArrayClaimIsMissing() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'missing' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("missing")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcnJheSI6WzEsMiwzXX0.wKNFBcMdwIpdF9rXRxvexrzSM6umgSFqRO1WZj992YM";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withArrayClaim("missing", 1, 2, 3)
@@ -380,6 +390,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenExpectedClaimIsMissing() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'missing' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("missing")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGFpbSI6InRleHQifQ.aZ27Ze35VvTqxpaSIK5ZcnYHr4SrvANlUbDR8fw9qsQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("missing", "text")
@@ -391,6 +402,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidCustomClaimValueOfTypeString() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("name")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", "value")
@@ -402,6 +414,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidCustomClaimValueOfTypeInteger() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("name")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", 123)
@@ -413,6 +426,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidCustomClaimValueOfTypeDouble() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("name")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", 23.45)
@@ -424,6 +438,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidCustomClaimValueOfTypeBoolean() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("name")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", true)
@@ -436,6 +451,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidCustomClaimValueOfTypeDate() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("name")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", new Date())
@@ -447,6 +463,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidCustomClaimValue() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'name' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("name")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjpbInNvbWV0aGluZyJdfQ.3ENLez6tU_fG0SVFrGmISltZPiXLSHaz_dyn-XFTEGQ";
         Map<String, Object> map = new HashMap<>();
         map.put("name", new Object());
@@ -748,6 +765,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidNotBeforeIfPresent() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
+        exception.expect(hasProperty("claimName", equalTo("nbf")));
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -812,6 +830,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidIssuedAtIfPresent() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage(startsWith("The Token can't be used before"));
+        exception.expect(hasProperty("claimName", equalTo("iat")));
         Clock clock = mock(Clock.class);
         when(clock.getToday()).thenReturn(new Date(DATE_TOKEN_MS_VALUE - 1000));
 
@@ -876,6 +895,7 @@ public class JWTVerifierTest {
     public void shouldThrowOnInvalidJWTId() throws Exception {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'jti' value doesn't match the required one.");
+        exception.expect(hasProperty("claimName", equalTo("jti")));
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJqd3RfaWRfMTIzIn0.0kegfXUvwOYioP8PDaLMY1IlV8HOAzSVz3EGL7-jWF4";
         JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withJWTId("invalid")
@@ -950,6 +970,7 @@ public class JWTVerifierTest {
     public void shouldThrowWhenVerifyingClaimPresenceButClaimNotPresent() {
         exception.expect(InvalidClaimException.class);
         exception.expectMessage("The Claim 'missing' is not present in the JWT.");
+        exception.expect(hasProperty("claimName", equalTo("missing")));
 
         String jwt = JWTCreator.init()
                 .withClaim("custom", "")


### PR DESCRIPTION
### Changes

I need to know what claim is declared as invalid, so i propose to expose the claim name into the `InvalidClaimException`. Exposing the claim name to make checks is more reliable than compare the message exception.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [*] This change adds test coverage
- [*] This change has been tested on the latest version of Java or why not

### Checklist

- [*] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [*] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [*] All existing and new tests complete without errors
