### PR TITLE
Update OSS release plugin version

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -30,33 +30,13 @@ oss {
     }
 }
 
-def javaVersion = 8
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
-}
-
 compileJava {
     exclude 'module-info.java'
-
-    options.compilerArgs = ['--release', "$javaVersion"]
-}
-
-// Use latest JDK for javadoc generation
-tasks.withType(Javadoc).configureEach {
-    javadocTool = javaToolchains.javadocToolFor {
-        languageVersion = JavaLanguageVersion.of(16)
-    }
 }
 
 javadoc {
     // Exclude internal implementation package from javadoc
     excludes = ['com/auth0/jwt/impl', 'module-info.java']
-    // Specify Java version this project uses
-    // Otherwise would use version of javadoc toolchain by default which could
-    // cause compilation error mismatch between compileJava and javadoc creation
-    options.addStringOption('-release', "$javaVersion")
 }
 
 dependencies {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -29,6 +29,12 @@ oss {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
 compileJava {
     exclude 'module-info.java'
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'com.jfrog.bintray'
     id 'com.auth0.gradle.oss-library.java'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     }
     plugins {
         id 'com.jfrog.bintray' version '1.8.5'
-        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
+        id 'com.auth0.gradle.oss-library.java' version '0.16.0'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.jfrog.bintray' version '1.8.5'
         id 'com.auth0.gradle.oss-library.java' version '0.16.0'
     }
 }


### PR DESCRIPTION
### Changes

This PR updates the OSS release plugin version to 0.16.0, which makes use of a newer Javadoc HTML template.

I also removed the bintray plugin which is no longer used.