### PR TITLE
Fix min JDK version regression

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -37,6 +37,8 @@ java {
 
 compileJava {
     exclude 'module-info.java'
+    // Required to be compatible with JDK 8+
+    options.compilerArgs = ['--release', "8"]
 }
 
 javadoc {


### PR DESCRIPTION
### Changes

PR #501 removed by mistake a line that was making the library compatible with JDK 8. Since we don't intend to introduce breaking changes during minor releases, this PR re-adds that line.


### Testing

Tested from mvc-commons library. 

#### Before:
```bash
./gradlew clean build test

> Task :compileJava FAILED
/Users/lbalmaceda/Java/auth0-java-mvc-common/src/main/java/com/auth0/IdTokenVerifier.java:3: error: cannot access DecodedJWT
import com.auth0.jwt.interfaces.DecodedJWT;
                               ^
  bad class file: /Users/lbalmaceda/.gradle/caches/modules-2/files-2.1/com.auth0/java-jwt/3.18.0/72d9c4836cba9abf6c1b3471e262976e3d831b8a/java-jwt-3.18.0.jar(com/auth0/jwt/interfaces/DecodedJWT.class)
    class file has wrong version 55.0, should be 52.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'
```

#### After:

```bash
./gradlew clean build test

> Task :compileTestJava
Note: /Users/lbalmaceda/Java/auth0-java-mvc-common/src/test/java/com/auth0/AuthenticationControllerTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

BUILD SUCCESSFUL in 11s
```
