### PR TITLE
[SDK-2751] Serialize audience claim when a List

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
-import java.util.Date;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Jackson serializer implementation for converting into JWT Payload parts.
@@ -30,38 +29,49 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
 
         gen.writeStartObject();
         for (Map.Entry<String, Object> e : holder.getClaims().entrySet()) {
-            switch (e.getKey()) {
-                case PublicClaims.AUDIENCE:
-                    if (e.getValue() instanceof String) {
-                        gen.writeFieldName(e.getKey());
-                        gen.writeString((String) e.getValue());
-                        break;
-                    }
-                    String[] audArray = (String[]) e.getValue();
-                    if (audArray.length == 1) {
-                        gen.writeFieldName(e.getKey());
-                        gen.writeString(audArray[0]);
-                    } else if (audArray.length > 1) {
-                        gen.writeFieldName(e.getKey());
-                        gen.writeStartArray();
-                        for (String aud : audArray) {
-                            gen.writeString(aud);
-                        }
-                        gen.writeEndArray();
-                    }
-                    break;
-                default:
-                    gen.writeFieldName(e.getKey());
-                    if (e.getValue() instanceof Date) { // true for EXPIRES_AT, ISSUED_AT, NOT_BEFORE
-                        gen.writeNumber(dateToSeconds((Date) e.getValue()));
-                    } else {
-                        gen.writeObject(e.getValue());
-                    }
-                    break;
+            if (PublicClaims.AUDIENCE.equals(e.getKey())) {
+                writeAudience(gen, e);
+            } else {
+                gen.writeFieldName(e.getKey());
+                if (e.getValue() instanceof Date) { // true for EXPIRES_AT, ISSUED_AT, NOT_BEFORE
+                    gen.writeNumber(dateToSeconds((Date) e.getValue()));
+                } else {
+                    gen.writeObject(e.getValue());
+                }
             }
         }
 
         gen.writeEndObject();
+    }
+
+    private void writeAudience(JsonGenerator gen, Map.Entry<String, Object> e) throws IOException {
+        if (e.getValue() instanceof String) {
+            gen.writeFieldName(e.getKey());
+            gen.writeString((String) e.getValue());
+        } else {
+            List<String> audArray = new ArrayList<>();
+            if (e.getValue() instanceof String[]) {
+                audArray = Arrays.asList((String[]) e.getValue());
+            } else if (e.getValue() instanceof List) {
+                List<?> audList = (List<?>) e.getValue();
+                for (Object aud : audList) {
+                    if (aud instanceof String) {
+                        audArray.add((String)aud);
+                    }
+                }
+            }
+            if (audArray.size() == 1) {
+                gen.writeFieldName(e.getKey());
+                gen.writeString(audArray.get(0));
+            } else if (audArray.size() > 1) {
+                gen.writeFieldName(e.getKey());
+                gen.writeStartArray();
+                for (String aud : audArray) {
+                    gen.writeString(aud);
+                }
+                gen.writeEndArray();
+            }
+        }
     }
 
     private long dateToSeconds(Date date) {

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -9,10 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -74,6 +71,60 @@ public class PayloadSerializerTest {
     @Test
     public void shouldSkipSerializationOnEmptyAudience() throws Exception {
         ClaimsHolder holder = holderFor("aud", new String[0]);
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{}")));
+    }
+
+    @Test
+    public void shouldSerializeSingleItemAudienceAsArrayWhenAList() throws Exception {
+        ClaimsHolder holder = holderFor("aud", Collections.singletonList("auth0"));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"aud\":\"auth0\"}")));
+    }
+
+    @Test
+    public void shouldSerializeMultipleItemsAudienceAsArrayWhenAList() throws Exception {
+        ClaimsHolder holder = holderFor("aud", Arrays.asList("auth0", "auth10"));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"aud\":[\"auth0\",\"auth10\"]}")));
+    }
+
+    @Test
+    public void shouldSkipSerializationOnEmptyAudienceWhenList() throws Exception {
+        ClaimsHolder holder = holderFor("aud", new ArrayList());
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{}")));
+    }
+
+    @Test
+    public void shouldSkipNonStringsOnAudienceWhenSingleItemList() throws Exception {
+        ClaimsHolder holder = holderFor("aud", Collections.singletonList(2));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{}")));
+    }
+
+    @Test
+    public void shouldSkipNonStringsOnAudienceWhenList() throws Exception {
+        ClaimsHolder holder = holderFor("aud", Arrays.asList("auth0", 2, "auth10"));
+        serializer.serialize(holder, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+
+        assertThat(writer.toString(), is(equalTo("{\"aud\":[\"auth0\",\"auth10\"]}")));
+    }
+
+    @Test
+    public void shouldSkipNonStringsOnAudience() throws Exception {
+        ClaimsHolder holder = holderFor("aud", 4);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 


### PR DESCRIPTION
### Changes

As discussed in #508, when constructing a JWT using the `withPayload` method, the `aud` claim cannot be properly serialized, as we only expected it to be a String array (as it is when using the `withAudience` method). This change updates the `PayloadSerializer` to handle both String arrays and Lists to be serialized for the audience claim.

Fixes #508