### PR TITLE
[SDK-2758] Restore withIssuer

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -8,6 +8,17 @@ import java.util.Date;
  * Holds the Claims and claim-based configurations required for a JWT to be considered valid.
  */
 public interface Verification {
+
+    /**
+     * Require a specific Issuer ("iss") claim.
+     *
+     * @param issuer the required Issuer value.
+     * @return this same Verification instance.
+     */
+    default Verification withIssuer(String issuer) {
+        return withIssuer(new String[]{issuer});
+    }
+
     /**
      * Require a specific Issuer ("iss") claim.
      *


### PR DESCRIPTION
### Changes

#288 changed the signature of `withIssuer(String issuer)` to `withIssuer(String... issuer)`. As discussed in #507, this is a binary incompatible change. 

This change restores that binary compatibility, by introducing a new default method on the `Verification` interface, that simply delegates to the existing implementation. 

Notes:
* This change will cause the `apiDiff` check to fail, as the japicmp gradle plugin does not currently support configuring this check (see https://github.com/melix/japicmp-gradle-plugin/issues/43)
* Rather then configure the plugin to ignore the `Verification` interface, which would then never catch any issues, we'll need to bump the baseline compare version when this change is released.
* Regarding if adding a default method to an existing interface is binary compatible, [this documentation from Oracle](https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.5.6) provides a good explanation on why it should be considered binary compatible.
* No tests were added as part of this change,  as the `JWTVerifierTests` already contain a test that verify the behavior when calling `withIssuer` with a single string.
* When this change is released, we will need to update the `CHANGELOG` for 3.8.0 to indicate the binary incompatible change,  and note its fixed version.