### PR TITLE
Release 3.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [3.18.2](https://github.com/auth0/java-jwt/tree/3.18.2) (2021-09-16)
+[Full Changelog](https://github.com/auth0/java-jwt/compare/3.18.1...3.18.2)
+
+**Fixed**
+- [SDK-2758] Restore withIssuer [\#513](https://github.com/auth0/java-jwt/pull/513) ([jimmyjames](https://github.com/jimmyjames))
+- [SDK-2751] Serialize audience claim when a List [\#512](https://github.com/auth0/java-jwt/pull/512) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [3.18.1](https://github.com/auth0/java-jwt/tree/3.18.1) (2021-07-06)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/3.18.0...3.18.1)
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ The library is available on both Maven Central and Bintray, and the Javadoc is p
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>java-jwt</artifactId>
-    <version>3.18.1</version>
+    <version>3.18.2</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation 'com.auth0:java-jwt:3.18.1'
+implementation 'com.auth0:java-jwt:3.18.2'
 ```
 
 ## Available Algorithms


### PR DESCRIPTION
### Changes

[Full Changelog](https://github.com/auth0/java-jwt/compare/3.18.1...3.18.2)

**Fixed**
- [SDK-2758] Restore withIssuer [\#513](https://github.com/auth0/java-jwt/pull/513) ([jimmyjames](https://github.com/jimmyjames))
- [SDK-2751] Serialize audience claim when a List [\#512](https://github.com/auth0/java-jwt/pull/512) ([jimmyjames](https://github.com/jimmyjames))

**Note:**
As discussed in #513, the apiDiff task will fail until we bump the baseline compare version, which will be done following this release.

[SDK-2758]: https://auth0team.atlassian.net/browse/SDK-2758
[SDK-2751]: https://auth0team.atlassian.net/browse/SDK-2751