### PR TITLE
Replace deprecated assertThat method in tests

### DIFF
--- a/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/ClockImplTest.java
@@ -7,7 +7,7 @@ import java.util.Date;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ClockImplTest {
 

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -16,7 +16,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -6,7 +6,6 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -244,24 +243,24 @@ public class JWTDecoderTest {
     public void shouldGetCustomClaimOfTypeInteger() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxMjN9.XZAudnA7h3_Al5kJydzLjw6RzZC3Q6OvnLEYlhNW7HA";
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asInt(), is(123));
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asInt(), is(123));
     }
 
     @Test
     public void shouldGetCustomClaimOfTypeDouble() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoyMy40NX0.7pyX2OmEGaU9q15T8bGFqRm-d3RVTYnqmZNZtxMKSlA";
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asDouble(), is(23.45));
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asDouble(), is(23.45));
     }
 
     @Test
     public void shouldGetCustomClaimOfTypeBoolean() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjp0cnVlfQ.FwQ8VfsZNRqBa9PXMinSIQplfLU4-rkCLfIlTLg_MV0";
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asBoolean(), is(true));
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asBoolean(), is(true));
     }
 
     @Test
@@ -269,35 +268,35 @@ public class JWTDecoderTest {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
         Date date = new Date(1478891521000L);
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asDate().getTime(), is(date.getTime()));
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asDate().getTime(), is(date.getTime()));
     }
 
     @Test
     public void shouldGetCustomArrayClaimOfTypeString() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asArray(String.class), arrayContaining("text", "123", "true"));
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asArray(String.class), arrayContaining("text", "123", "true"));
     }
 
     @Test
     public void shouldGetCustomArrayClaimOfTypeInteger() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbMSwyLDNdfQ.UEuMKRQYrzKAiPpPLhIVawWkKWA1zj0_GderrWUIyFE";
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
-        Assert.assertThat(jwt.getClaim("name").asArray(Integer.class), arrayContaining(1, 2, 3));
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asArray(Integer.class), arrayContaining(1, 2, 3));
     }
 
     @Test
     public void shouldGetCustomMapClaim() throws Exception {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjp7InN0cmluZyI6InZhbHVlIiwibnVtYmVyIjoxLCJib29sZWFuIjp0cnVlfX0.-8aIaXd2-rp1lLuDEQmCeisCBX9X_zbqdPn2llGxNoc";
         DecodedJWT jwt = JWT.decode(token);
-        Assert.assertThat(jwt, is(notNullValue()));
+        assertThat(jwt, is(notNullValue()));
         Map<String, Object> map = jwt.getClaim("name").asMap();
-        Assert.assertThat(map, hasEntry("string", (Object) "value"));
-        Assert.assertThat(map, hasEntry("number", (Object) 1));
-        Assert.assertThat(map, hasEntry("boolean", (Object) true));
+        assertThat(map, hasEntry("string", (Object) "value"));
+        assertThat(map, hasEntry("number", (Object) 1));
+        assertThat(map, hasEntry("boolean", (Object) true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -18,7 +18,7 @@ import java.util.Base64;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class JWTVerifierTest {

--- a/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
+++ b/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TokenUtilsTest {
 

--- a/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.interfaces.*;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.ArgumentMatchers.any;

--- a/lib/src/test/java/com/auth0/jwt/algorithms/CryptoTestHelper.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/CryptoTestHelper.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public abstract class CryptoTestHelper {

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -6,7 +6,6 @@ import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIn;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -27,14 +26,13 @@ import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignaturePresent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("deprecation")
 public class ECDSAAlgorithmTest {
 
     private static final String PRIVATE_KEY_FILE_256 = "src/test/resources/ec256-key-private.pem";
@@ -1136,10 +1134,10 @@ public class ECDSAAlgorithmTest {
 
     //Test Helpers
     static void assertValidJOSESignature(byte[] joseSignature, int numberSize, boolean withRPadding, boolean withSPadding) {
-        Assert.assertThat(joseSignature, is(Matchers.notNullValue()));
-        Assert.assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
+        assertThat(joseSignature, is(Matchers.notNullValue()));
+        assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
 
-        Assert.assertThat(joseSignature.length, is(numberSize * 2));
+        assertThat(joseSignature.length, is(numberSize * 2));
 
         byte[] rCopy = Arrays.copyOfRange(joseSignature, 0, numberSize);
         byte[] sCopy = Arrays.copyOfRange(joseSignature, numberSize, numberSize * 2);
@@ -1154,12 +1152,12 @@ public class ECDSAAlgorithmTest {
         if (withSPadding) {
             sNumber[0] = (byte) 0;
         }
-        Assert.assertThat(Arrays.equals(rNumber, rCopy), is(true));
-        Assert.assertThat(Arrays.equals(sNumber, sCopy), is(true));
+        assertThat(Arrays.equals(rNumber, rCopy), is(true));
+        assertThat(Arrays.equals(sNumber, sCopy), is(true));
     }
 
     static byte[] createDERSignature(int numberSize, boolean withRPadding, boolean withSPadding) {
-        Assert.assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
+        assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
 
         int rLength = withRPadding ? numberSize - 1 : numberSize;
         int sLength = withSPadding ? numberSize - 1 : numberSize;
@@ -1202,7 +1200,7 @@ public class ECDSAAlgorithmTest {
     }
 
     static byte[] createJOSESignature(int numberSize, boolean withRPadding, boolean withSPadding) {
-        Assert.assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
+        assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
 
         byte[] rNumber = new byte[numberSize];
         byte[] sNumber = new byte[numberSize];
@@ -1221,8 +1219,8 @@ public class ECDSAAlgorithmTest {
     }
 
     static void assertValidDERSignature(byte[] derSignature, int numberSize, boolean withRPadding, boolean withSPadding) {
-        Assert.assertThat(derSignature, is(Matchers.notNullValue()));
-        Assert.assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
+        assertThat(derSignature, is(Matchers.notNullValue()));
+        assertThat(numberSize, is(IsIn.oneOf(32, 48, 66)));
 
         int rLength = withRPadding ? numberSize - 1 : numberSize;
         int sLength = withSPadding ? numberSize - 1 : numberSize;
@@ -1230,24 +1228,24 @@ public class ECDSAAlgorithmTest {
         int offset = 0;
 
         //Start sequence
-        Assert.assertThat(derSignature[offset++], is((byte) 0x30));
+        assertThat(derSignature[offset++], is((byte) 0x30));
         if (totalLength > 0x7f) {
             //Add sign before sequence length
             totalLength++;
-            Assert.assertThat(derSignature[offset++], is((byte) 0x81));
+            assertThat(derSignature[offset++], is((byte) 0x81));
         }
         //Sequence length
-        Assert.assertThat(derSignature[offset++], is((byte) (totalLength - offset)));
+        assertThat(derSignature[offset++], is((byte) (totalLength - offset)));
 
         //R number
-        Assert.assertThat(derSignature[offset++], is((byte) 0x02));
-        Assert.assertThat(derSignature[offset++], is((byte) rLength));
+        assertThat(derSignature[offset++], is((byte) 0x02));
+        assertThat(derSignature[offset++], is((byte) rLength));
         byte[] rCopy = Arrays.copyOfRange(derSignature, offset, offset + rLength);
         offset += rLength;
 
         //S number
-        Assert.assertThat(derSignature[offset++], is((byte) 0x02));
-        Assert.assertThat(derSignature[offset++], is((byte) sLength));
+        assertThat(derSignature[offset++], is((byte) 0x02));
+        assertThat(derSignature[offset++], is((byte) sLength));
         byte[] sCopy = Arrays.copyOfRange(derSignature, offset, offset + sLength);
 
 
@@ -1255,9 +1253,9 @@ public class ECDSAAlgorithmTest {
         byte[] sNumber = new byte[sLength];
         Arrays.fill(rNumber, (byte) 0x11);
         Arrays.fill(sNumber, (byte) 0x22);
-        Assert.assertThat(Arrays.equals(rNumber, rCopy), is(true));
-        Assert.assertThat(Arrays.equals(sNumber, sCopy), is(true));
-        Assert.assertThat(derSignature.length, is(totalLength));
+        assertThat(Arrays.equals(rNumber, rCopy), is(true));
+        assertThat(Arrays.equals(sNumber, sCopy), is(true));
+        assertThat(derSignature.length, is(totalLength));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
@@ -25,7 +25,7 @@ import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignaturePresent;
 import static com.auth0.jwt.algorithms.ECDSAAlgorithmTest.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/lib/src/test/java/com/auth0/jwt/algorithms/HMACAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/HMACAlgorithmTest.java
@@ -19,8 +19,8 @@ import static com.auth0.jwt.algorithms.CryptoTestHelper.asJWT;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignaturePresent;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.assertSignatureValue;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -36,8 +36,8 @@ public class HMACAlgorithmTest {
     @Test
     public void shouldGetStringBytes() throws Exception {
         String text = "abcdef123456!@#$%^";
-        byte[] expectedBytes = text.getBytes("UTF-8");
-        assertTrue(Arrays.equals(expectedBytes, HMACAlgorithm.getSecretBytes(text)));
+        byte[] expectedBytes = text.getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(expectedBytes, HMACAlgorithm.getSecretBytes(text));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/NoneAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/NoneAlgorithmTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class NoneAlgorithmTest {
 

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -17,7 +17,7 @@ import java.security.interfaces.RSAPublicKey;
 import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
 import static com.auth0.jwt.PemUtils.readPublicKeyFromFile;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static com.auth0.jwt.algorithms.CryptoTestHelper.*;
 
-@SuppressWarnings("deprecation")
 public class RSAAlgorithmTest {
 
     private static final String PRIVATE_KEY_FILE = "src/test/resources/rsa-private.pem";

--- a/lib/src/test/java/com/auth0/jwt/impl/ClaimsHolderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/ClaimsHolderTest.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ClaimsHolderTest {
 

--- a/lib/src/test/java/com/auth0/jwt/impl/HeaderDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/HeaderDeserializerTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -27,7 +27,7 @@ import static com.auth0.jwt.impl.JsonNodeClaim.claimFromNode;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class JsonNodeClaimTest {

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class NullClaimTest {
     private NullClaim claim;

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -22,7 +22,7 @@ import java.io.StringReader;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -12,7 +12,7 @@ import java.io.StringWriter;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PayloadSerializerTest {
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:
The changes are for tests that used `org.junit.Assert.assertThat` method. This has been deprecated hence replaced with `org.hamcrest.MatcherAssert.assertThat`

### References
Java Doc of Deprecated Method - https://junit.org/junit4/javadoc/latest/org/junit/Assert.html#assertThat(java.lang.String,%20T,%20org.hamcrest.Matcher)

<img width="664" alt="Screenshot 2022-02-28 at 16 03 52" src="https://user-images.githubusercontent.com/15910425/155968208-422f87e1-2409-47ae-a24a-166c1adc38e6.png">

### Testing
Since the changes are around test methods themselves, it is tested by running all the unit tests
