### PR TITLE
[SDK-3160] Replace com.auth0.jwt.interfaces.Clock with java.time.Clock

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -6,12 +6,11 @@ import com.auth0.jwt.impl.JWTParser;
 import com.auth0.jwt.impl.NullClaim;
 import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.Claim;
-import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.time.Clock;
 
 /**
  * The JWTVerifier class holds the verify method to assert that a given Token has not only a proper JWT format, but also its signature matches.
@@ -200,7 +199,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public JWTVerifier build() {
-            return this.build(new ClockImpl());
+            return this.build(Clock.systemUTC());
         }
 
         /**
@@ -208,7 +207,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
          * ONLY FOR TEST PURPOSES.
          *
          * @param clock the instance that will handle the current time.
-         * @return a new JWTVerifier instance with a custom Clock.
+         * @return a new JWTVerifier instance with a custom {@link java.time.Clock}
          */
         public JWTVerifier build(Clock clock) {
             addLeewayToDateClaims();
@@ -405,7 +404,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
     }
 
     private void assertValidDateClaim(Date date, long leeway, boolean shouldBeFuture) {
-        Date today = new Date(clock.getToday().getTime());
+        Date today = new Date(clock.millis());
         today.setTime(today.getTime() / 1000 * 1000); // truncate millis
         if (shouldBeFuture) {
             assertDateIsFuture(date, leeway, today);

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -1,7 +1,6 @@
 package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsCollectionContaining;
@@ -14,6 +13,9 @@ import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAKey;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Date;
 
@@ -35,7 +37,6 @@ public class JWTTest {
     private static final String PRIVATE_KEY_FILE_EC_256K = "src/test/resources/ec256k-key-private.pem";
     private static final String PRIVATE_KEY_FILE_EC_384 = "src/test/resources/ec384-key-private.pem";
     private static final String PRIVATE_KEY_FILE_EC_512 = "src/test/resources/ec512-key-private.pem";
-
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -274,9 +275,8 @@ public class JWTTest {
 
     @Test
     public void shouldGetExpirationTime() throws Exception {
-        Date expectedDate = new Date(1477592 * 1000);
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(expectedDate);
+        long seconds = 1477592L;
+        Clock clock = Clock.fixed(Instant.ofEpochSecond(seconds), ZoneId.of("UTC"));
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTJ9.x_ZjkPkKYUV5tdvc0l8go6D_z2kez1MQcOxokXrDc3k";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -287,14 +287,13 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
         assertThat(jwt.getExpiresAt(), is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getExpiresAt(), is(equalTo(new Date(seconds * 1000))));
     }
 
     @Test
-    public void shouldGetNotBefore() throws Exception {
-        Date expectedDate = new Date(1477592 * 1000);
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(expectedDate);
+    public void shouldGetNotBefore() {
+        long seconds = 1477592;
+        Clock clock = Clock.fixed(Instant.ofEpochSecond(seconds), ZoneId.of("UTC"));
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0Nzc1OTJ9.mWYSOPoNXstjKbZkKrqgkwPOQWEx3F3gMm6PMcfuJd8";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -305,14 +304,13 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
         assertThat(jwt.getNotBefore(), is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
+        assertThat(jwt.getNotBefore(), is(equalTo(new Date(seconds * 1000))));
     }
 
     @Test
     public void shouldGetIssuedAt() throws Exception {
-        Date expectedDate = new Date(1477592 * 1000);
-        Clock clock = mock(Clock.class);
-        when(clock.getToday()).thenReturn(expectedDate);
+        long seconds = 1477592;
+        Clock clock = Clock.fixed(Instant.ofEpochSecond(seconds), ZoneId.of("UTC"));
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0Nzc1OTJ9.5o1CKlLFjKKcddZzoarQ37pq7qZqNPav3sdZ_bsZaD4";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
@@ -323,7 +321,7 @@ public class JWTTest {
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
         assertThat(jwt.getIssuedAt(), is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getIssuedAt(), is(equalTo(new Date(seconds * 1000))));
     }
 
     @Test


### PR DESCRIPTION
Replaces usages of `com.auth0.jwt.interfaces.Clock` with [java.time.Clock](https://docs.oracle.com/javase/8/docs/api/java/time/Clock.html), which simplifies testing through the ability to inject a clock instance for testing.

Note that this is a breaking change, as the `JWTVerifier#build(com.auth0.jwt.interfaces.Clock clock)` method is public for testing purposes (the `Verification` interface does not expose this method, only `JWTVerifier#build()`). 

A separate PR will follow that removes the `Clock` interface and `ClockImpl` class, as they will no longer have any usages following this change. 