### PR TITLE
[SDK-3150] Serialize dates in collections as seconds since epoch

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -140,7 +140,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Expires At ("exp") claim to the Payload.
+         * Add a specific Expires At ("exp") claim to the payload. The claim will be written as seconds since the epoch;
+         * milliseconds will be truncated.
          *
          * @param expiresAt the Expires At value.
          * @return this same Builder instance.
@@ -151,7 +152,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Not Before ("nbf") claim to the Payload.
+         * Add a specific Not Before ("nbf") claim to the Payload. The claim will be written as seconds since the epoch;
+         * milliseconds will be truncated.
          *
          * @param notBefore the Not Before value.
          * @return this same Builder instance.
@@ -162,7 +164,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Issued At ("iat") claim to the Payload.
+         * Add a specific Issued At ("iat") claim to the Payload. The claim will be written as seconds since the epoch;
+         * milliseconds will be truncated.
          *
          * @param issuedAt the Issued At value.
          * @return this same Builder instance.
@@ -254,7 +257,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a custom Claim value.
+         * Add a custom Claim value. The claim will be written as seconds since the epoch;
+         * milliseconds will be truncated.
          *
          * @param name  the Claim's name.
          * @param value the Claim's value.

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -140,8 +140,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Expires At ("exp") claim to the payload. The claim will be written as seconds since the epoch;
-         * milliseconds will be truncated.
+         * Add a specific Expires At ("exp") claim to the payload. The claim will be written as seconds since the epoch.
+         * Milliseconds will be truncated by rounding down to the nearest second.
          *
          * @param expiresAt the Expires At value.
          * @return this same Builder instance.
@@ -152,8 +152,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Not Before ("nbf") claim to the Payload. The claim will be written as seconds since the epoch;
-         * milliseconds will be truncated.
+         * Add a specific Not Before ("nbf") claim to the Payload. The claim will be written as seconds since the epoch.
+         * Milliseconds will be truncated by rounding down to the nearest second.
          *
          * @param notBefore the Not Before value.
          * @return this same Builder instance.
@@ -164,8 +164,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Issued At ("iat") claim to the Payload. The claim will be written as seconds since the epoch;
-         * milliseconds will be truncated.
+         * Add a specific Issued At ("iat") claim to the Payload. The claim will be written as seconds since the epoch.
+         * Milliseconds will be truncated by rounding down to the nearest second.
          *
          * @param issuedAt the Issued At value.
          * @return this same Builder instance.
@@ -257,8 +257,8 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a custom Claim value. The claim will be written as seconds since the epoch;
-         * milliseconds will be truncated.
+         * Add a custom Claim value. The claim will be written as seconds since the epoch.
+         * Milliseconds will be truncated by rounding down to the nearest second.
          *
          * @param name  the Claim's name.
          * @param value the Claim's value.

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -2,7 +2,6 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.impl.PublicClaims;
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,8 +13,6 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
@@ -502,7 +499,7 @@ public class JWTCreatorTest {
         data.put("integer", 1);
         data.put("long", Long.MAX_VALUE);
         data.put("double", 123.456d);
-        data.put("date", new Date(123456789));
+        data.put("date", new Date(123000));
         data.put("boolean", true);
 
         // array types
@@ -533,13 +530,13 @@ public class JWTCreatorTest {
         assertThat(map.get("long"), is(Long.MAX_VALUE));
         assertThat(map.get("double"), is(123.456d));
 
-        assertThat(map.get("date"), is(123456));
+        assertThat(map.get("date"), is(123));
         assertThat(map.get("boolean"), is(true));
 
         // array types
-        assertThat(map.get("intArray"), is(Arrays.asList(new Integer[]{3, 5})));
-        assertThat(map.get("longArray"), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
-        assertThat(map.get("stringArray"), is(Arrays.asList(new String[]{"string"})));
+        assertThat(map.get("intArray"), is(Arrays.asList(3, 5)));
+        assertThat(map.get("longArray"), is(Arrays.asList(Long.MAX_VALUE, Long.MIN_VALUE)));
+        assertThat(map.get("stringArray"), is(Arrays.asList("string")));
 
         // list
         assertThat(map.get("list"), is(Arrays.asList("a", "b", "c")));
@@ -557,7 +554,7 @@ public class JWTCreatorTest {
         data.add(1);
         data.add(Long.MAX_VALUE);
         data.add(123.456d);
-        data.add(new Date(123456789));
+        data.add(new Date(123000));
         data.add(true);
 
         // array types
@@ -587,13 +584,13 @@ public class JWTCreatorTest {
         assertThat(list.get(1), is(1));
         assertThat(list.get(2), is(Long.MAX_VALUE));
         assertThat(list.get(3), is(123.456d));
-        assertThat(list.get(4), is(123456));
+        assertThat(list.get(4), is(123));
         assertThat(list.get(5), is(true));
 
         // array types
-        assertThat(list.get(6), is(Arrays.asList(new Integer[]{3, 5})));
-        assertThat(list.get(7), is(Arrays.asList(new Long[]{Long.MAX_VALUE, Long.MIN_VALUE})));
-        assertThat(list.get(8), is(Arrays.asList(new String[]{"string"})));
+        assertThat(list.get(6), is(Arrays.asList(3, 5)));
+        assertThat(list.get(7), is(Arrays.asList(Long.MAX_VALUE, Long.MIN_VALUE)));
+        assertThat(list.get(8), is(Arrays.asList("string")));
 
         // list
         assertThat(list.get(9), is(Arrays.asList("a", "b", "c")));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -2,6 +2,7 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.impl.PublicClaims;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +14,8 @@ import org.junit.rules.ExpectedException;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
@@ -499,7 +502,7 @@ public class JWTCreatorTest {
         data.put("integer", 1);
         data.put("long", Long.MAX_VALUE);
         data.put("double", 123.456d);
-        data.put("date", new Date(123L));
+        data.put("date", new Date(123456789));
         data.put("boolean", true);
 
         // array types
@@ -529,7 +532,8 @@ public class JWTCreatorTest {
         assertThat(map.get("integer"), is(1));
         assertThat(map.get("long"), is(Long.MAX_VALUE));
         assertThat(map.get("double"), is(123.456d));
-        assertThat(map.get("date"), is(123));
+
+        assertThat(map.get("date"), is(123456));
         assertThat(map.get("boolean"), is(true));
 
         // array types
@@ -553,7 +557,7 @@ public class JWTCreatorTest {
         data.add(1);
         data.add(Long.MAX_VALUE);
         data.add(123.456d);
-        data.add(new Date(123L));
+        data.add(new Date(123456789));
         data.add(true);
 
         // array types
@@ -583,7 +587,7 @@ public class JWTCreatorTest {
         assertThat(list.get(1), is(1));
         assertThat(list.get(2), is(Long.MAX_VALUE));
         assertThat(list.get(3), is(123.456d));
-        assertThat(list.get(4), is(123));
+        assertThat(list.get(4), is(123456));
         assertThat(list.get(5), is(true));
 
         // array types

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -176,15 +176,32 @@ public class PayloadSerializerTest {
         claims.put("nbf", date);
         claims.put("exp", date);
         claims.put("ctm", date);
+        claims.put("map", Collections.singletonMap("date", date));
+        claims.put("list", Collections.singletonList(date));
+
+        Map<String, Object> nestedInMap = new HashMap<>();
+        nestedInMap.put("list", Collections.singletonList(date));
+        claims.put("nestedInMap", nestedInMap);
+
+        List<Object> nestedInList = new ArrayList<>();
+        nestedInList.add(Collections.singletonMap("nested", date));
+        claims.put("nestedInList", nestedInList);
+
         ClaimsHolder holder = new ClaimsHolder(claims);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
         String json = writer.toString();
+        System.out.println(json);
+
         assertThat(json, containsString("\"iat\":2147493647"));
         assertThat(json, containsString("\"nbf\":2147493647"));
         assertThat(json, containsString("\"exp\":2147493647"));
         assertThat(json, containsString("\"ctm\":2147493647"));
+        assertThat(json, containsString("\"map\":{\"date\":2147493647"));
+        assertThat(json, containsString("\"list\":[2147493647]"));
+        assertThat(json, containsString("\"nestedInMap\":{\"list\":[2147493647]}"));
+        assertThat(json, containsString("\"nestedInList\":[{\"nested\":2147493647}]"));
     }
 
     @Test


### PR DESCRIPTION
This change ensures that `Date` claim values are serialized as seconds since the epoch, as specified by [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519). It also updates the JavaDocs for Date-based claim creation in `JWTCreator`, to more accurately define how Date-based claims are written to the resulting JSON.

The change is marked as breaking change due to the behavioral nature of this fix; clients relying upon the existing behavior will need to be updated to account for this change.