### PR TITLE
[SDK-3149] Add Instant support

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -308,6 +308,15 @@ public final class JWTCreator {
             return this;
         }
 
+        /**
+         * Add a custom Claim value. The claim will be written as seconds since the epoch.
+         * Milliseconds will be truncated by rounding down to the nearest second.
+         *
+         * @param name  the Claim's name.
+         * @param value the Claim's value.
+         * @return this same Builder instance.
+         * @throws IllegalArgumentException if the name is null.
+         */
         public Builder withClaim(String name, Instant value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -152,7 +153,19 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Not Before ("nbf") claim to the Payload. The claim will be written as seconds since the epoch.
+         * Add a specific Expires At ("exp") claim to the payload. The claim will be written as seconds since the epoch;
+         * Milliseconds will be truncated by rounding down to the nearest second.
+         *
+         * @param expiresAt the Expires At value.
+         * @return this same Builder instance.
+         */
+        public Builder withExpiresAt(Instant expiresAt) {
+            addClaim(PublicClaims.EXPIRES_AT, expiresAt);
+            return this;
+        }
+
+        /**
+         * Add a specific Not Before ("nbf") claim to the Payload. The claim will be written as seconds since the epoch;
          * Milliseconds will be truncated by rounding down to the nearest second.
          *
          * @param notBefore the Not Before value.
@@ -164,13 +177,37 @@ public final class JWTCreator {
         }
 
         /**
-         * Add a specific Issued At ("iat") claim to the Payload. The claim will be written as seconds since the epoch.
+         * Add a specific Not Before ("nbf") claim to the Payload. The claim will be written as seconds since the epoch;
+         * Milliseconds will be truncated by rounding down to the nearest second.
+         *
+         * @param notBefore the Not Before value.
+         * @return this same Builder instance.
+         */
+        public Builder withNotBefore(Instant notBefore) {
+            addClaim(PublicClaims.NOT_BEFORE, notBefore);
+            return this;
+        }
+
+        /**
+         * Add a specific Issued At ("iat") claim to the Payload. The claim will be written as seconds since the epoch;
          * Milliseconds will be truncated by rounding down to the nearest second.
          *
          * @param issuedAt the Issued At value.
          * @return this same Builder instance.
          */
         public Builder withIssuedAt(Date issuedAt) {
+            addClaim(PublicClaims.ISSUED_AT, issuedAt);
+            return this;
+        }
+
+        /**
+         * Add a specific Issued At ("iat") claim to the Payload. The claim will be written as seconds since the epoch;
+         * Milliseconds will be truncated by rounding down to the nearest second.
+         *
+         * @param issuedAt the Issued At value.
+         * @return this same Builder instance.
+         */
+        public Builder withIssuedAt(Instant issuedAt) {
             addClaim(PublicClaims.ISSUED_AT, issuedAt);
             return this;
         }
@@ -266,6 +303,12 @@ public final class JWTCreator {
          * @throws IllegalArgumentException if the name is null.
          */
         public Builder withClaim(String name, Date value) throws IllegalArgumentException {
+            assertNonNull(name);
+            addClaim(name, value);
+            return this;
+        }
+
+        public Builder withClaim(String name, Instant value) throws IllegalArgumentException {
             assertNonNull(name);
             addClaim(name, value);
             return this;
@@ -453,7 +496,7 @@ public final class JWTCreator {
             if (c.isArray()) {
                 return c == Integer[].class || c == Long[].class || c == String[].class;
             }
-            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Boolean.class;
+            return c == String.class || c == Integer.class || c == Long.class || c == Double.class || c == Date.class || c == Instant.class || c == Boolean.class;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTDecoder.java
@@ -9,6 +9,7 @@ import com.auth0.jwt.interfaces.Payload;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -94,13 +95,28 @@ final class JWTDecoder implements DecodedJWT, Serializable {
     }
 
     @Override
+    public Instant getExpiresAtAsInstant() {
+        return payload.getExpiresAtAsInstant();
+    }
+
+    @Override
     public Date getNotBefore() {
         return payload.getNotBefore();
     }
 
     @Override
+    public Instant getNotBeforeAsInstant() {
+        return  payload.getNotBeforeAsInstant();
+    }
+
+    @Override
     public Date getIssuedAt() {
         return payload.getIssuedAt();
+    }
+
+    @Override
+    public Instant getIssuedAtAsInstant() {
+        return payload.getIssuedAtAsInstant();
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -373,8 +373,6 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             isValid = value.equals(claim.asDouble());
         } else if (value instanceof Date) {
             isValid = value.equals(claim.asDate());
-        } else if (value instanceof Instant) {
-            isValid = value.equals(claim.asInstant());
         } else if (value instanceof Object[]) {
             List<Object> claimArr;
             Object[] claimAsObject = claim.as(Object[].class);

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -6,11 +6,11 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -61,6 +61,15 @@ class JsonNodeClaim implements Claim {
         }
         long seconds = data.asLong();
         return new Date(seconds * 1000);
+    }
+
+    @Override
+    public Instant asInstant() {
+        if (!data.canConvertToLong()) {
+            return null;
+        }
+        long seconds = data.asLong();
+        return Instant.ofEpochSecond(seconds);
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/NullClaim.java
@@ -3,6 +3,7 @@ package com.auth0.jwt.impl;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,11 @@ public class NullClaim implements Claim {
 
     @Override
     public Date asDate() {
+        return null;
+    }
+
+    @Override
+    public Instant asInstant() {
         return null;
     }
 

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -45,9 +46,9 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         String issuer = getString(tree, PublicClaims.ISSUER);
         String subject = getString(tree, PublicClaims.SUBJECT);
         List<String> audience = getStringOrArray(tree, PublicClaims.AUDIENCE);
-        Date expiresAt = getDateFromSeconds(tree, PublicClaims.EXPIRES_AT);
-        Date notBefore = getDateFromSeconds(tree, PublicClaims.NOT_BEFORE);
-        Date issuedAt = getDateFromSeconds(tree, PublicClaims.ISSUED_AT);
+        Instant expiresAt = getInstantFromSeconds(tree, PublicClaims.EXPIRES_AT);
+        Instant notBefore = getInstantFromSeconds(tree, PublicClaims.NOT_BEFORE);
+        Instant issuedAt = getInstantFromSeconds(tree, PublicClaims.ISSUED_AT);
         String jwtId = getString(tree, PublicClaims.JWT_ID);
 
         return new PayloadImpl(issuer, subject, audience, expiresAt, notBefore, issuedAt, jwtId, tree, objectReader);
@@ -73,7 +74,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         return list;
     }
 
-    Date getDateFromSeconds(Map<String, JsonNode> tree, String claimName) {
+    Instant getInstantFromSeconds(Map<String, JsonNode> tree, String claimName) {
         JsonNode node = tree.get(claimName);
         if (node == null || node.isNull()) {
             return null;
@@ -81,8 +82,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         if (!node.canConvertToLong()) {
             throw new JWTDecodeException(String.format("The claim '%s' contained a non-numeric date value.", claimName));
         }
-        final long ms = node.asLong() * 1000;
-        return new Date(ms);
+        return Instant.ofEpochSecond(node.asLong());
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.*;
 
 import static com.auth0.jwt.impl.JsonNodeClaim.extractClaim;
@@ -24,14 +25,14 @@ class PayloadImpl implements Payload, Serializable {
     private final String issuer;
     private final String subject;
     private final List<String> audience;
-    private final Date expiresAt;
-    private final Date notBefore;
-    private final Date issuedAt;
+    private final Instant expiresAt;
+    private final Instant notBefore;
+    private final Instant issuedAt;
     private final String jwtId;
     private final Map<String, JsonNode> tree;
     private final ObjectReader objectReader;
 
-    PayloadImpl(String issuer, String subject, List<String> audience, Date expiresAt, Date notBefore, Date issuedAt, String jwtId, Map<String, JsonNode> tree, ObjectReader objectReader) {
+    PayloadImpl(String issuer, String subject, List<String> audience, Instant expiresAt, Instant notBefore, Instant issuedAt, String jwtId, Map<String, JsonNode> tree, ObjectReader objectReader) {
         this.issuer = issuer;
         this.subject = subject;
         this.audience = audience != null ? Collections.unmodifiableList(audience) : null;
@@ -64,17 +65,33 @@ class PayloadImpl implements Payload, Serializable {
 
     @Override
     public Date getExpiresAt() {
+        return (expiresAt != null) ? Date.from(expiresAt) : null;
+    }
+
+
+    @Override
+    public Instant getExpiresAtAsInstant() {
         return expiresAt;
     }
 
     @Override
-    public Date getNotBefore() {
-        return notBefore;
+    public Date getIssuedAt() {
+        return (issuedAt != null) ? Date.from(issuedAt) : null;
     }
 
     @Override
-    public Date getIssuedAt() {
+    public Instant getIssuedAtAsInstant() {
         return issuedAt;
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return (notBefore != null) ? Date.from(notBefore) : null;
+    }
+
+    @Override
+    public Instant getNotBeforeAsInstant() {
+        return notBefore;
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -71,13 +72,15 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
     }
 
     /**
-     * Serializes {@linkplain Date} to epoch second values, traversing maps and lists as needed.
+     * Serializes {@linkplain Instant} to epoch second values, traversing maps and lists as needed.
      * @param value the object to serialize
      * @param gen the JsonGenerator to use for JSON serialization
      */
     private void handleSerialization(Object value, JsonGenerator gen) throws IOException {
-        if (value instanceof Date) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom date claims
+        if (value instanceof Date) {
             gen.writeNumber(dateToSeconds((Date) value));
+        } else if (value instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
+            gen.writeNumber(instantToSeconds((Instant) value));
         } else if (value instanceof Map) {
             serializeMap((Map<?, ?>) value, gen);
         } else if (value instanceof List) {
@@ -103,6 +106,10 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
             handleSerialization(entry, gen);
         }
         gen.writeEndArray();
+    }
+
+    private long instantToSeconds(Instant instant) {
+        return instant.getEpochSecond();
     }
 
     private long dateToSeconds(Date date) {

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -2,6 +2,7 @@ package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,17 @@ public interface Claim {
      * @return the value as a Date or null.
      */
     Date asDate();
+
+    /**
+     * Get this Claim as an Instant.
+     * If the value can't be converted to an Instant, null will be returned.
+     *
+     * @return the value as a Date or null.
+     */
+    default Instant asInstant() {
+        Date date = asDate();
+        return date != null? date.toInstant() : null;
+    }
 
     /**
      * Get this Claim as an Array of type T.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -75,7 +75,7 @@ public interface Claim {
      */
     default Instant asInstant() {
         Date date = asDate();
-        return date != null? date.toInstant() : null;
+        return date != null ? date.toInstant() : null;
     }
 
     /**

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -1,5 +1,6 @@
 package com.auth0.jwt.interfaces;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,15 @@ public interface Payload {
     Date getExpiresAt();
 
     /**
+     * Get the value of the "exp" claim as an {@linkplain Instant}, or null if it's not available.
+     *
+     * @return the Expiration Time value or null.
+     */
+    default Instant getExpiresAtAsInstant() {
+        return getExpiresAt() != null ? getExpiresAt().toInstant() : null ;
+    }
+
+    /**
      * Get the value of the "nbf" claim, or null if it's not available.
      *
      * @return the Not Before value or null.
@@ -45,11 +55,29 @@ public interface Payload {
     Date getNotBefore();
 
     /**
+     * Get the value of the "nbf" claim as an {@linkplain Instant}, or null if it's not available.
+     *
+     * @return the Not Before value or null.
+     */
+    default Instant getNotBeforeAsInstant() {
+        return getNotBefore() != null ? getNotBefore().toInstant() : null;
+    }
+
+    /**
      * Get the value of the "iat" claim, or null if it's not available.
      *
      * @return the Issued At value or null.
      */
     Date getIssuedAt();
+
+    /**
+     * Get the value of the "iat" claim as an {@linkplain Instant}, or null if it's not available.
+     *
+     * @return the Issued At value or null.
+     */
+    default Instant getIssuedAtAsInstant() {
+        return getIssuedAt() != null? getIssuedAt().toInstant() : null;
+    }
 
     /**
      * Get the value of the "jti" claim, or null if it's not available.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Payload.java
@@ -44,7 +44,7 @@ public interface Payload {
      * @return the Expiration Time value or null.
      */
     default Instant getExpiresAtAsInstant() {
-        return getExpiresAt() != null ? getExpiresAt().toInstant() : null ;
+        return getExpiresAt() != null ? getExpiresAt().toInstant() : null;
     }
 
     /**
@@ -76,7 +76,7 @@ public interface Payload {
      * @return the Issued At value or null.
      */
     default Instant getIssuedAtAsInstant() {
-        return getIssuedAt() != null? getIssuedAt().toInstant() : null;
+        return getIssuedAt() != null ? getIssuedAt().toInstant() : null;
     }
 
     /**

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
@@ -156,33 +157,27 @@ public class JWTDecoderTest {
     public void shouldGetExpirationTime() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0NzY3MjcwODZ9.L9dcPHEDQew2u9MkDCORFkfDGcSOsgoPqNY-LUMLEHg");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
         long ms = 1476727086L * 1000;
-        Date expectedDate = new Date(ms);
-        assertThat(jwt.getExpiresAt(), is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getExpiresAt(), is(equalTo(new Date(ms))));
+        assertThat(jwt.getExpiresAtAsInstant(), is(equalTo(Instant.ofEpochMilli(ms))));
     }
 
     @Test
     public void shouldGetNotBefore() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0NzY3MjcwODZ9.tkpD3iCPQPVqjnjpDVp2bJMBAgpVCG9ZjlBuMitass0");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
         long ms = 1476727086L * 1000;
-        Date expectedDate = new Date(ms);
-        assertThat(jwt.getNotBefore(), is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(equalTo(expectedDate)));
+        assertThat(jwt.getNotBefore(), is(equalTo(new Date(ms))));
+        assertThat(jwt.getNotBeforeAsInstant(), is(equalTo(Instant.ofEpochMilli(ms))));
     }
 
     @Test
     public void shouldGetIssuedAt() {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0NzY3MjcwODZ9.KPjGoW665E8V5_27Jugab8qSTxLk2cgquhPCBfAP0_w");
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
         long ms = 1476727086L * 1000;
-        Date expectedDate = new Date(ms);
-        assertThat(jwt.getIssuedAt(), is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(equalTo(expectedDate)));
+        assertThat(jwt.getIssuedAt(), is(equalTo(new Date(ms))));
+        assertThat(jwt.getIssuedAtAsInstant(), is(equalTo(Instant.ofEpochMilli(ms))));
     }
 
     @Test
@@ -273,6 +268,15 @@ public class JWTDecoderTest {
     }
 
     @Test
+    public void shouldGetCustomClaimOfTypeInstant() {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
+        Instant instant = Instant.ofEpochSecond(1478891521L);
+        DecodedJWT jwt = JWT.decode(token);
+        assertThat(jwt, is(notNullValue()));
+        assertThat(jwt.getClaim("name").asInstant(), is(equalTo(instant)));
+    }
+
+    @Test
     public void shouldGetCustomArrayClaimOfTypeString() {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
         DecodedJWT jwt = JWT.decode(token);
@@ -294,9 +298,9 @@ public class JWTDecoderTest {
         DecodedJWT jwt = JWT.decode(token);
         assertThat(jwt, is(notNullValue()));
         Map<String, Object> map = jwt.getClaim("name").asMap();
-        assertThat(map, hasEntry("string", (Object) "value"));
-        assertThat(map, hasEntry("number", (Object) 1));
-        assertThat(map, hasEntry("boolean", (Object) true));
+        assertThat(map, hasEntry("string", "value"));
+        assertThat(map, hasEntry("number", 1));
+        assertThat(map, hasEntry("boolean", true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -21,8 +21,6 @@ import java.util.Date;
 
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class JWTTest {
 
@@ -285,9 +283,9 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getExpiresAt(), is(instanceOf(Date.class)));
-        assertThat(jwt.getExpiresAt(), is(notNullValue()));
         assertThat(jwt.getExpiresAt(), is(equalTo(new Date(seconds * 1000))));
+        assertThat(jwt.getExpiresAtAsInstant(), is(equalTo(Instant.ofEpochSecond(seconds))));
+
     }
 
     @Test
@@ -302,9 +300,8 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getNotBefore(), is(instanceOf(Date.class)));
-        assertThat(jwt.getNotBefore(), is(notNullValue()));
         assertThat(jwt.getNotBefore(), is(equalTo(new Date(seconds * 1000))));
+        assertThat(jwt.getNotBeforeAsInstant(), is(equalTo(Instant.ofEpochSecond(seconds))));
     }
 
     @Test
@@ -319,9 +316,8 @@ public class JWTTest {
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));
-        assertThat(jwt.getIssuedAt(), is(instanceOf(Date.class)));
-        assertThat(jwt.getIssuedAt(), is(notNullValue()));
         assertThat(jwt.getIssuedAt(), is(equalTo(new Date(seconds * 1000))));
+        assertThat(jwt.getIssuedAtAsInstant(), is(equalTo(Instant.ofEpochSecond(seconds))));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -19,17 +19,15 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.assertThrows;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 public class JWTVerifierTest {
 
-    private Clock mockNow = Clock.fixed(Instant.ofEpochSecond(1477592), ZoneId.of("UTC"));
-    private Clock mockOneSecondEarlier = Clock.offset(mockNow, Duration.ofSeconds(-1));
-    private Clock mockOneSecondLater = Clock.offset(mockNow, Duration.ofSeconds(1));
+    private final Clock mockNow = Clock.fixed(Instant.ofEpochSecond(1477592), ZoneId.of("UTC"));
+    private final Clock mockOneSecondEarlier = Clock.offset(mockNow, Duration.ofSeconds(-1));
+    private final Clock mockOneSecondLater = Clock.offset(mockNow, Duration.ofSeconds(1));
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JsonNodeClaimTest.java
@@ -20,14 +20,14 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatchers;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
-import static com.auth0.jwt.impl.JsonNodeClaim.claimFromNode;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class JsonNodeClaimTest {
@@ -117,20 +117,23 @@ public class JsonNodeClaimTest {
     }
 
     @Test
-    public void shouldGetDateValue() {
-        JsonNode value = mapper.valueToTree(1476824844L);
+    public void shouldGetNumericDateValue() {
+        long seconds = 1476824844L;
+        JsonNode value = mapper.valueToTree(seconds);
         Claim claim = claimFromNode(value);
 
-        assertThat(claim.asDate(), is(notNullValue()));
-        assertThat(claim.asDate(), is(new Date(1476824844L * 1000)));
+        assertThat(claim.asDate(), is(new Date(seconds * 1000)));
+        assertThat(claim.asInstant(), is(Instant.ofEpochSecond(seconds)));
     }
 
     @Test
-    public void shouldGetNullDateIfNotDateValue() {
+    public void shouldGetNullIfNotNumericDateValue() {
         JsonNode objectValue = mapper.valueToTree(new Object());
         assertThat(claimFromNode(objectValue).asDate(), is(nullValue()));
+        assertThat(claimFromNode(objectValue).asInstant(), is(nullValue()));
         JsonNode stringValue = mapper.valueToTree("1476824844");
         assertThat(claimFromNode(stringValue).asDate(), is(nullValue()));
+        assertThat(claimFromNode(stringValue).asInstant(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -51,6 +51,11 @@ public class NullClaimTest {
     }
 
     @Test
+    public void shouldGetAsInstant() {
+        assertThat(claim.asDate(), is(nullValue()));
+    }
+
+    @Test
     public void shouldGetAsArray() {
         assertThat(claim.asArray(Object.class), is(nullValue()));
     }

--- a/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/NullClaimTest.java
@@ -52,7 +52,7 @@ public class NullClaimTest {
 
     @Test
     public void shouldGetAsInstant() {
-        assertThat(claim.asDate(), is(nullValue()));
+        assertThat(claim.asInstant(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
@@ -96,6 +97,9 @@ public class PayloadDeserializerTest {
         assertThat(payload.getIssuedAt().getTime(), is(10101010L * 1000));
         assertThat(payload.getExpiresAt().getTime(), is(11111111L * 1000));
         assertThat(payload.getNotBefore().getTime(), is(10101011L * 1000));
+        assertThat(payload.getIssuedAtAsInstant().getEpochSecond(), is(10101010L));
+        assertThat(payload.getExpiresAtAsInstant().getEpochSecond(), is(11111111L));
+        assertThat(payload.getNotBeforeAsInstant().getEpochSecond(), is(10101011L));
         assertThat(payload.getId(), is("idid"));
 
         assertThat(payload.getClaim("roles").asString(), is("admin"));
@@ -177,24 +181,23 @@ public class PayloadDeserializerTest {
         assertThat(values, is(nullValue()));
     }
 
-
     @Test
-    public void shouldGetNullDateWhenParsingNullNode() {
+    public void shouldGetNullInstantWhenParsingNullNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         NullNode node = NullNode.getInstance();
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(nullValue()));
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(nullValue()));
     }
 
     @Test
-    public void shouldGetNullDateWhenParsingNull() {
+    public void shouldGetNullInstantWhenParsingNull() {
         Map<String, JsonNode> tree = new HashMap<>();
         tree.put("key", null);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(nullValue()));
+        Instant instant  = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(nullValue()));
     }
 
     @Test
@@ -206,32 +209,33 @@ public class PayloadDeserializerTest {
         TextNode node = new TextNode("123456789");
         tree.put("key", node);
 
-        deserializer.getDateFromSeconds(tree, "key");
+        deserializer.getInstantFromSeconds(tree, "key");
     }
 
     @Test
-    public void shouldGetDateWhenParsingNumericNode() {
+    public void shouldGetInstantWhenParsingNumericNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         long seconds = 1478627949 / 1000;
         LongNode node = new LongNode(seconds);
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(notNullValue()));
-        assertThat(date.getTime(), is(seconds * 1000));
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(notNullValue()));
+        assertThat(instant.toEpochMilli(), is(seconds * 1000));
     }
 
+
     @Test
-    public void shouldGetLargeDateWhenParsingNumericNode() {
+    public void shouldGetLargeInstantWhenParsingNumericNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         long seconds = Integer.MAX_VALUE + 10000L;
         LongNode node = new LongNode(seconds);
         tree.put("key", node);
 
-        Date date = deserializer.getDateFromSeconds(tree, "key");
-        assertThat(date, is(notNullValue()));
-        assertThat(date.getTime(), is(seconds * 1000));
-        assertThat(date.getTime(), is(2147493647L * 1000));
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(notNullValue()));
+        assertThat(instant.toEpochMilli(), is(seconds * 1000));
+        assertThat(instant.toEpochMilli(), is(2147493647L * 1000));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -11,8 +11,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 
+import java.time.Instant;
 import java.util.*;
 
 import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
@@ -25,38 +25,33 @@ public class PayloadImplTest {
     public ExpectedException exception = ExpectedException.none();
 
     private PayloadImpl payload;
-    private Date expiresAt;
-    private Date notBefore;
-    private Date issuedAt;
+    private final Instant expiresAt = Instant.now().plusSeconds(10);
+    private final Instant notBefore = Instant.now();
+    private final Instant issuedAt = Instant.now();
 
-    private ObjectMapper mapper;
     private ObjectReader objectReader;
 
     @Before
     public void setUp() {
-        mapper = getDefaultObjectMapper();
+        ObjectMapper mapper = getDefaultObjectMapper();
         objectReader = mapper.reader();
 
-        expiresAt = Mockito.mock(Date.class);
-        notBefore = Mockito.mock(Date.class);
-        issuedAt = Mockito.mock(Date.class);
         Map<String, JsonNode> tree = new HashMap<>();
         tree.put("extraClaim", new TextNode("extraValue"));
         payload = new PayloadImpl("issuer", "subject", Collections.singletonList("audience"), expiresAt, notBefore, issuedAt, "jwtId", tree, objectReader);
     }
 
-    @SuppressWarnings("Convert2Diamond")
     @Test
     public void shouldHaveUnmodifiableTree() {
         exception.expect(UnsupportedOperationException.class);
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, new HashMap<String, JsonNode>(), objectReader);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, new HashMap<>(), objectReader);
         payload.getTree().put("something", null);
     }
 
     @Test
     public void shouldHaveUnmodifiableAudience() {
         exception.expect(UnsupportedOperationException.class);
-        PayloadImpl payload = new PayloadImpl(null, null, new ArrayList<String>(), null, null, null, null, null, objectReader);
+        PayloadImpl payload = new PayloadImpl(null, null, new ArrayList<>(), null, null, null, null, null, objectReader);
         payload.getAudience().add("something");
     }
 
@@ -104,7 +99,8 @@ public class PayloadImplTest {
     @Test
     public void shouldGetExpiresAt() {
         assertThat(payload, is(notNullValue()));
-        assertThat(payload.getExpiresAt(), is(expiresAt));
+        assertThat(payload.getExpiresAt(), is(Date.from(expiresAt)));
+        assertThat(payload.getExpiresAtAsInstant(), is(expiresAt));
     }
 
     @Test
@@ -112,12 +108,14 @@ public class PayloadImplTest {
         PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectReader);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getExpiresAt(), is(nullValue()));
+        assertThat(payload.getExpiresAtAsInstant(), is(nullValue()));
     }
 
     @Test
     public void shouldGetNotBefore() {
         assertThat(payload, is(notNullValue()));
-        assertThat(payload.getNotBefore(), is(notBefore));
+        assertThat(payload.getNotBefore(), is(Date.from(notBefore)));
+        assertThat(payload.getNotBeforeAsInstant(), is(notBefore));
     }
 
     @Test
@@ -125,12 +123,14 @@ public class PayloadImplTest {
         PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectReader);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getNotBefore(), is(nullValue()));
+        assertThat(payload.getNotBeforeAsInstant(), is(nullValue()));
     }
 
     @Test
     public void shouldGetIssuedAt() {
         assertThat(payload, is(notNullValue()));
-        assertThat(payload.getIssuedAt(), is(issuedAt));
+        assertThat(payload.getIssuedAt(), is(Date.from(issuedAt)));
+        assertThat(payload.getIssuedAtAsInstant(), is(issuedAt));
     }
 
     @Test
@@ -138,6 +138,7 @@ public class PayloadImplTest {
         PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectReader);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getIssuedAt(), is(nullValue()));
+        assertThat(payload.getIssuedAtAsInstant(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/interfaces/ClaimTest.java
+++ b/lib/src/test/java/com/auth0/jwt/interfaces/ClaimTest.java
@@ -1,0 +1,93 @@
+package com.auth0.jwt.interfaces;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ClaimTest {
+
+    @Test
+    public void shouldGetInstantUsingDefault() {
+        Date date = new Date(1646667492000L);
+        Claim claim = new ClaimImplForTest(date);
+        assertThat(claim.asInstant(), is(date.toInstant()));
+    }
+
+    @Test
+    public void shouldGetNullInstantUsingDefault() {
+        Claim claim = new ClaimImplForTest(null);
+        assertThat(claim.asInstant(), is(nullValue()));
+    }
+
+    /**
+     * Implementation that does not override {@code asInstant()}
+     */
+    static class ClaimImplForTest implements Claim {
+        private final Date date;
+
+        ClaimImplForTest(Date date) {
+            this.date = date;
+        }
+
+        @Override
+        public boolean isNull() {
+            return false;
+        }
+
+        @Override
+        public Boolean asBoolean() {
+            return null;
+        }
+
+        @Override
+        public Integer asInt() {
+            return null;
+        }
+
+        @Override
+        public Long asLong() {
+            return null;
+        }
+
+        @Override
+        public Double asDouble() {
+            return null;
+        }
+
+        @Override
+        public String asString() {
+            return null;
+        }
+
+        @Override
+        public Date asDate() {
+            return date;
+        }
+
+        @Override
+        public <T> T[] asArray(Class<T> tClazz) throws JWTDecodeException {
+            return null;
+        }
+
+        @Override
+        public <T> List<T> asList(Class<T> tClazz) throws JWTDecodeException {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> asMap() throws JWTDecodeException {
+            return null;
+        }
+
+        @Override
+        public <T> T as(Class<T> tClazz) throws JWTDecodeException {
+            return null;
+        }
+    }
+}

--- a/lib/src/test/java/com/auth0/jwt/interfaces/PayloadTest.java
+++ b/lib/src/test/java/com/auth0/jwt/interfaces/PayloadTest.java
@@ -1,0 +1,83 @@
+package com.auth0.jwt.interfaces;
+
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PayloadTest {
+
+    @Test
+    public void shouldGetInstantFromDefault() {
+        Date date = new Date(1646667492000L);
+        Payload payload = new PayloadImplForTest(date);
+        assertThat(payload.getExpiresAtAsInstant(), is(date.toInstant()));
+        assertThat(payload.getIssuedAtAsInstant(), is(date.toInstant()));
+        assertThat(payload.getNotBeforeAsInstant(), is(date.toInstant()));
+    }
+
+    @Test
+    public void shouldGetInstantFromDefaultAsNu() {
+        Payload payload = new PayloadImplForTest(null);
+        assertThat(payload.getExpiresAtAsInstant(), is(nullValue()));
+        assertThat(payload.getIssuedAtAsInstant(), is(nullValue()));
+        assertThat(payload.getNotBeforeAsInstant(), is(nullValue()));
+    }
+
+    static class PayloadImplForTest implements Payload {
+        private final Date date;
+
+        PayloadImplForTest(Date date) {
+            this.date = date;
+        }
+
+        @Override
+        public String getIssuer() {
+            return null;
+        }
+
+        @Override
+        public String getSubject() {
+            return null;
+        }
+
+        @Override
+        public List<String> getAudience() {
+            return null;
+        }
+
+        @Override
+        public Date getExpiresAt() {
+            return date;
+        }
+
+        @Override
+        public Date getNotBefore() {
+            return date;
+        }
+
+        @Override
+        public Date getIssuedAt() {
+            return date;
+        }
+
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public Claim getClaim(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Claim> getClaims() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Changes

**🕐 Adds support for `java.time.Instant` 🕐** 

This PR adds support for `java.time.Instant` for creating and verifying JWTs. Key points to note:
* `Instant` support is added to `Date` functionality; customers using `Date` can continue to do so.
* Additional methods added to interfaces have a default implementation using the underlying `Date` methods
* Internal implementation updated to use `Instant` for its improved functionality

**Note:** This PR does not include support for custom claim validation of type `Instant`. A separate PR will add support for this as well as address the current issue of `Date`-based claim validation not accounting for date/time claims being serialized as seconds since the epoch.

### References

https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html
### Testing

Existing unit tests provide good coverage, and tests added for new methods
