### PR TITLE
[SDK-3186] Support date/time custom claim validation

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -174,8 +174,14 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
 
         @Override
         public Verification withClaim(String name, Date value) throws IllegalArgumentException {
+            return withClaim(name, value != null ? value.toInstant() : null);
+        }
+
+        @Override
+        public Verification withClaim(String name, Instant value) throws IllegalArgumentException {
             assertNonNull(name);
-            requireClaim(name, value);
+            // Since date-time claims are serialized as epoch seconds, we need to compare them with only seconds-granularity
+            requireClaim(name, value != null ? value.truncatedTo(ChronoUnit.SECONDS) : null);
             return this;
         }
 
@@ -371,8 +377,8 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
             isValid = value.equals(claim.asBoolean());
         } else if (value instanceof Double) {
             isValid = value.equals(claim.asDouble());
-        } else if (value instanceof Date) {
-            isValid = value.equals(claim.asDate());
+        } else if (value instanceof Instant) {
+            isValid = value.equals(claim.asInstant());
         } else if (value instanceof Object[]) {
             List<Object> claimArr;
             Object[] claimAsObject = claim.as(Object[].class);

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -178,7 +178,7 @@ public interface Verification {
 
     /**
      * Require a specific Claim value. Note that date-time claims are serialized as seconds since the epoch; when verifying
-     * date-time claim value, any time units more granular than seconds will be discarded.
+     * date-time claim value, any time units more granular than seconds will not be considered.
      *
      * @param name  the Claim's name.
      * @param value the Claim's value.
@@ -189,7 +189,7 @@ public interface Verification {
 
     /**
      * Require a specific Claim value. Note that date-time claims are serialized as seconds since the epoch; when verifying
-     * a date-time claim value, any time units more granular than seconds will be discarded.
+     * a date-time claim value, any time units more granular than seconds will not be considered.
      *
      * @param name  the Claim's name.
      * @param value the Claim's value.

--- a/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Verification.java
@@ -2,6 +2,7 @@ package com.auth0.jwt.interfaces;
 
 import com.auth0.jwt.JWTVerifier;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -176,7 +177,8 @@ public interface Verification {
     Verification withClaim(String name, String value) throws IllegalArgumentException;
 
     /**
-     * Require a specific Claim value.
+     * Require a specific Claim value. Note that date-time claims are serialized as seconds since the epoch; when verifying
+     * date-time claim value, any time units more granular than seconds will be discarded.
      *
      * @param name  the Claim's name.
      * @param value the Claim's value.
@@ -184,6 +186,19 @@ public interface Verification {
      * @throws IllegalArgumentException if the name is null.
      */
     Verification withClaim(String name, Date value) throws IllegalArgumentException;
+
+    /**
+     * Require a specific Claim value. Note that date-time claims are serialized as seconds since the epoch; when verifying
+     * a date-time claim value, any time units more granular than seconds will be discarded.
+     *
+     * @param name  the Claim's name.
+     * @param value the Claim's value.
+     * @return this same Verification instance.
+     * @throws IllegalArgumentException if the name is null.
+     */
+    default Verification withClaim(String name, Instant value) throws IllegalArgumentException {
+        return withClaim(name, value != null ? Date.from(value) : null);
+    }
 
     /**
      * Require a specific Array Claim to contain at least the given items.

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -517,7 +517,7 @@ public class JWTVerifierTest {
     @Test
     public void shouldValidateCustomClaimOfTypeDate() {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoxNDc4ODkxNTIxfQ.mhioumeok8fghQEhTKF3QtQAksSvZ_9wIhJmgZLhJ6c";
-        Date date = new Date(1478891521000L);
+        Date date = new Date(1478891521123L);
         DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withClaim("name", date)
                 .build()

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -527,6 +527,17 @@ public class JWTVerifierTest {
     }
 
     @Test
+    public void shouldRemoveCustomClaimOfTypeDateWhenNull() {
+        JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
+                .withClaim("name", new Date())
+                .withClaim("name", (Date) null)
+                .build();
+
+        assertThat(verifier.claims, is(notNullValue()));
+        assertThat(verifier.claims, not(hasKey("iss")));
+    }
+
+    @Test
     public void shouldValidateCustomArrayClaimOfTypeString() {
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjpbInRleHQiLCIxMjMiLCJ0cnVlIl19.lxM8EcmK1uSZRAPd0HUhXGZJdauRmZmLjoeqz4J9yAA";
         DecodedJWT jwt = JWTVerifier.init(Algorithm.HMAC256("secret"))

--- a/lib/src/test/java/com/auth0/jwt/interfaces/VerificationTest.java
+++ b/lib/src/test/java/com/auth0/jwt/interfaces/VerificationTest.java
@@ -1,0 +1,162 @@
+package com.auth0.jwt.interfaces;
+
+import com.auth0.jwt.JWTVerifier;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Tests for any default method implementations in the {@link Verification} interface.
+ */
+public class VerificationTest {
+
+    @Test
+    public void withInstantClaimShouldUseDefaultImpl() {
+        Instant instant = Instant.ofEpochSecond(1478891521);
+        Verification verification = new VerificationImplForTest()
+                .withClaim("name", instant);
+
+        assertThat(verification, instanceOf(VerificationImplForTest.class));
+        assertThat(((VerificationImplForTest)verification).expectedClaims, hasEntry("name", Date.from(instant)));
+    }
+
+    @Test
+    public void withInstantClaimShouldUseDefaultImplAndHandleNull() {
+        Verification verification = new VerificationImplForTest()
+                .withClaim("name", (Instant) null);
+
+        assertThat(verification, instanceOf(VerificationImplForTest.class));
+        assertThat(((VerificationImplForTest)verification).expectedClaims, hasEntry("name", null));
+    }
+
+    @Test
+    public void withAnyOfAudienceDeafultImplShouldThrow() {
+        assertThrows("withAnyOfAudience", UnsupportedOperationException.class, () -> {
+            new VerificationImplForTest().withAnyOfAudience("");
+        });
+    }
+
+    @Test
+    public void withIssuerStringDefaultImplShouldDelegate() {
+        Verification verification = new VerificationImplForTest()
+                .withIssuer("string");
+
+        assertThat(verification, instanceOf(VerificationImplForTest.class));
+        assertThat(((VerificationImplForTest)verification).expectedClaims, hasEntry("iss", new String[]{"string"}));
+    }
+
+    static class VerificationImplForTest implements Verification {
+
+        private final Map<String, Object> expectedClaims = new HashMap<>();
+
+        @Override
+        public Verification withIssuer(String... issuer) {
+            expectedClaims.put("iss", issuer);
+            return this;
+        }
+
+        @Override
+        public Verification withSubject(String subject) {
+            return null;
+        }
+
+        @Override
+        public Verification withAudience(String... audience) {
+            return null;
+        }
+
+        @Override
+        public Verification acceptLeeway(long leeway) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification acceptExpiresAt(long leeway) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification acceptNotBefore(long leeway) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification acceptIssuedAt(long leeway) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withJWTId(String jwtId) {
+            return null;
+        }
+
+        @Override
+        public Verification withClaimPresence(String name) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withClaim(String name, Boolean value) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withClaim(String name, Integer value) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withClaim(String name, Long value) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withClaim(String name, Double value) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withClaim(String name, String value) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withClaim(String name, Date value) throws IllegalArgumentException {
+            this.expectedClaims.put(name, value);
+            return this;
+        }
+
+        @Override
+        public Verification withArrayClaim(String name, String... items) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withArrayClaim(String name, Integer... items) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification withArrayClaim(String name, Long... items) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Verification ignoreIssuedAt() {
+            return null;
+        }
+
+        @Override
+        public JWTVerifier build() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Changes

Adds a new verification method to verify a custom date/time claim: `Verification#withClaim(String name, Instant value)`

Notes:
* Default implementation delegates to existing `withClaim(String name, Date value)` method to avoid breaking changes
* The current `Date`-based claim validation delegates to the new `Instant`-based validation, allowing us to remove `Date`-based validation code
* The current custom `Date`-based claim verification was arguably broken, or at least not intuitive. Because date claims are serialized as seconds since the epoch, any expected `Date` claim would need to have its milliseconds set to zero to be considered equal. This change fixes that by truncating the expected claim's value to seconds.

### References

Builds on #537 