### PR TITLE
[SDK-3197] Update test deps

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -48,11 +48,12 @@ javadoc {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6'
-    testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'net.jodah:concurrentunit:0.4.3'
-    testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testImplementation 'org.mockito:mockito-core:2.18.3'
+
+    testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'net.jodah:concurrentunit:0.4.6'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.mockito:mockito-core:4.4.0'
 }
 
 jacoco {
@@ -92,7 +93,7 @@ task compileModuleInfoJava(type: JavaCompile) {
 }
 
 compileTestJava {
-    options.compilerArgs = ['--release', "8"]
+    options.compilerArgs = ['--release', "8", "-Xlint:deprecation"]
 }
 
 def testJava8 = tasks.register('testJava8', Test) {

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -5,7 +5,7 @@ import com.auth0.jwt.impl.NullClaim;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.hamcrest.collection.IsCollectionWithSize;
-import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -142,7 +142,7 @@ public class JWTDecoderTest {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsiSG9wZSIsIlRyYXZpcyIsIlNvbG9tb24iXX0.Tm4W8WnfPjlmHSmKFakdij0on2rWPETpoM7Sh0u6-S4");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getAudience(), is(IsCollectionWithSize.hasSize(3)));
-        assertThat(jwt.getAudience(), is(IsCollectionContaining.hasItems("Hope", "Travis", "Solomon")));
+        assertThat(jwt.getAudience(), is(IsIterableContaining.hasItems("Hope", "Travis", "Solomon")));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class JWTDecoderTest {
         DecodedJWT jwt = JWT.decode("eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJKYWNrIFJleWVzIn0.a4I9BBhPt1OB1GW67g2P1bEHgi6zgOjGUL4LvhE9Dgc");
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getAudience(), is(IsCollectionWithSize.hasSize(1)));
-        assertThat(jwt.getAudience(), is(IsCollectionContaining.hasItems("Jack Reyes")));
+        assertThat(jwt.getAudience(), is(IsIterableContaining.hasItems("Jack Reyes")));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -3,7 +3,7 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.hamcrest.collection.IsCollectionWithSize;
-import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -256,7 +256,7 @@ public class JWTTest {
 
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getAudience(), is(IsCollectionWithSize.hasSize(3)));
-        assertThat(jwt.getAudience(), is(IsCollectionContaining.hasItems("Hope", "Travis", "Solomon")));
+        assertThat(jwt.getAudience(), is(IsIterableContaining.hasItems("Hope", "Travis", "Solomon")));
     }
 
     @Test
@@ -268,7 +268,7 @@ public class JWTTest {
 
         assertThat(jwt, is(notNullValue()));
         assertThat(jwt.getAudience(), is(IsCollectionWithSize.hasSize(1)));
-        assertThat(jwt.getAudience(), is(IsCollectionContaining.hasItems("Jack Reyes")));
+        assertThat(jwt.getAudience(), is(IsIterableContaining.hasItems("Jack Reyes")));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.*;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsEmptyCollection;
-import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -93,7 +93,7 @@ public class PayloadDeserializerTest {
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getIssuer(), is("auth0"));
         assertThat(payload.getSubject(), is("emails"));
-        assertThat(payload.getAudience(), is(IsCollectionContaining.hasItem("users")));
+        assertThat(payload.getAudience(), is(IsIterableContaining.hasItem("users")));
         assertThat(payload.getIssuedAt().getTime(), is(10101010L * 1000));
         assertThat(payload.getExpiresAt().getTime(), is(11111111L * 1000));
         assertThat(payload.getNotBefore().getTime(), is(10101011L * 1000));
@@ -126,7 +126,7 @@ public class PayloadDeserializerTest {
         List<String> values = deserializer.getStringOrArray(tree, "key");
         assertThat(values, is(notNullValue()));
         assertThat(values, is(IsCollectionWithSize.hasSize(2)));
-        assertThat(values, is(IsCollectionContaining.hasItems("one", "two")));
+        assertThat(values, is(IsIterableContaining.hasItems("one", "two")));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class PayloadDeserializerTest {
         List<String> values = deserializer.getStringOrArray(tree, "key");
         assertThat(values, is(notNullValue()));
         assertThat(values, is(IsCollectionWithSize.hasSize(1)));
-        assertThat(values, is(IsCollectionContaining.hasItems("something")));
+        assertThat(values, is(IsIterableContaining.hasItems("something")));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.hamcrest.collection.IsCollectionWithSize;
-import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,7 +86,7 @@ public class PayloadImplTest {
         assertThat(payload, is(notNullValue()));
 
         assertThat(payload.getAudience(), is(IsCollectionWithSize.hasSize(1)));
-        assertThat(payload.getAudience(), is(IsCollectionContaining.hasItems("audience")));
+        assertThat(payload.getAudience(), is(IsIterableContaining.hasItems("audience")));
     }
 
     @Test


### PR DESCRIPTION
Updates test dependencies to latest versions. 

Notes:
* Due to in issue with jackson `2.12`, it was exporting junit `4.13.2` as a transitive dependency, overriding our declared `4.12` dependency. This change explicitly updates to `4.13.2` which will also be required when updating our jackson dependency, as we'll be making use of some of the features in `4.13.2`.
* Replaces the now-deprecated `IsCollectionContaining` with `IsIterableContaining`. Other deprecated methods that involve less trivial code changes (e.g, deprecation of `ExpectedException` in favor of `assertThrows`) are not included in this PR, but can be made opportunistically going forward.