### PR TITLE
[SDK-3192] Deprecate secp256k1 curve for EC Algorithms

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -118,7 +118,6 @@ def testJava17 = tasks.register('testJava17', Test) {
     filter {
         excludeTestsMatching "*.jwt.ConcurrentVerifyTest.shouldPassECDSA256KVerificationWithJOSESignature"
         excludeTestsMatching "*.jwt.JWTCreatorTest.shouldAddKeyIdIfAvailableFromECDSAKAlgorithms"
-        excludeTestsMatching "*.jwt.JWTCreatorTest.shouldNotOverwriteKeyIdIfAddedFromECDSAKAlgorithms"
         excludeTestsMatching "*.jwt.JWTTest.shouldCreateAnEmptyECDSA256KSignedToken"
         excludeTestsMatching "*.jwt.algorithms.ECDSAAlgorithmTest.shouldPassECDSA256KVerificationWithJOSESignature"
         excludeTestsMatching "*.jwt.algorithms.ECDSAAlgorithmTest.shouldPassECDSA256KVerificationWithJOSESignatureWithBothKeys"

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -182,8 +182,10 @@ public abstract class Algorithm {
      *
      * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
      * @return a valid ECDSA256 Algorithm.
+     * @deprecated This method is deprecated since Java 15+ disables SECP-256K1 Curve. Using this in Java 15+ will throw a SignatureException
      * @throws IllegalArgumentException if the Key Provider is null.
      */
+    @Deprecated
     public static Algorithm ECDSA256K(ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
         return new ECDSAAlgorithm("ES256K", "SHA256withECDSA", 32, keyProvider);
     }
@@ -194,8 +196,10 @@ public abstract class Algorithm {
      * @param publicKey  the key to use in the verify instance.
      * @param privateKey the key to use in the signing instance.
      * @return a valid ECDSA256 Algorithm.
+     * @deprecated This method is deprecated since Java 15+ disables SECP-256K1 Curve. Using this in Java 15+ will throw a SignatureException
      * @throws IllegalArgumentException if the provided Key is null.
      */
+    @Deprecated
     public static Algorithm ECDSA256K(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
         return ECDSA256K(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
     }

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -176,7 +176,7 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldNotOverwriteKeyIdIfAddedFromECDSAKAlgorithms() throws Exception {
-        ECPrivateKey privateKey = (ECPrivateKey) PemUtils.readPrivateKeyFromFile(PRIVATE_KEY_FILE_EC_256K, "EC");
+        ECPrivateKey privateKey = (ECPrivateKey) PemUtils.readPrivateKeyFromFile(PRIVATE_KEY_FILE_EC_256, "EC");
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         when(provider.getPrivateKeyId()).thenReturn("my-key-id");
         when(provider.getPrivateKey()).thenReturn(privateKey);


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

We are deprecating the secp256k1 curve since Java 15+ has disabled this. This algorithm "ES256K" is not mentioned in RFC and removal of this algorithm in future is planned.

### Testing

We have removed the use of the ES256K algorithm for one of the tests since it fails for Java 17.  Since this is part of a test util we will not need to handle this separately

