### PR TITLE
[SDK-3192] Deprecate secp256k1 curve for EC Algorithms and undeprecate single key constructors & signing methods

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -182,8 +182,10 @@ public abstract class Algorithm {
      *
      * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
      * @return a valid ECDSA256 Algorithm.
-     * @deprecated This method is deprecated since Java 15+ disables SECP-256K1 Curve. Using this in Java 15+ will throw a SignatureException
      * @throws IllegalArgumentException if the Key Provider is null.
+     * @deprecated The SECP-256K1 Curve algorithm has been disabled beginning in Java 15.
+     * Use of this method in those unsupported Java versions will throw a {@link java.security.SignatureException}.
+     * This method will be removed in the next major version. See for additional information
      */
     @Deprecated
     public static Algorithm ECDSA256K(ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
@@ -196,8 +198,10 @@ public abstract class Algorithm {
      * @param publicKey  the key to use in the verify instance.
      * @param privateKey the key to use in the signing instance.
      * @return a valid ECDSA256 Algorithm.
-     * @deprecated This method is deprecated since Java 15+ disables SECP-256K1 Curve. Using this in Java 15+ will throw a SignatureException
      * @throws IllegalArgumentException if the provided Key is null.
+     * @deprecated The SECP-256K1 Curve algorithm has been disabled beginning in Java 15.
+     * Use of this method in those unsupported Java versions will throw a {@link java.security.SignatureException}.
+     * This method will be removed in the next major version. See for additional information
      */
     @Deprecated
     public static Algorithm ECDSA256K(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -405,14 +405,13 @@ public abstract class Algorithm {
 
     /**
      * Sign the given content using this Algorithm instance.
+     * To get the correct JWT Signature, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param contentBytes an array of bytes representing the base64 encoded content to be verified against the signature.
      * @return the signature in a base64 encoded array of bytes
      * @throws SignatureGenerationException if the Key is invalid.
-     * @deprecated Please use the {@linkplain #sign(byte[], byte[])} method instead.
      */
 
-    @Deprecated
     public abstract byte[] sign(byte[] contentBytes) throws SignatureGenerationException;
 
 }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -182,8 +182,10 @@ public abstract class Algorithm {
      *
      * @param keyProvider the provider of the Public Key and Private Key for the verify and signing instance.
      * @return a valid ECDSA256 Algorithm.
+     * @deprecated This method is deprecated since Java 15+ disables SECP-256K1 Curve. Using this in Java 15+ will throw a SignatureException
      * @throws IllegalArgumentException if the Key Provider is null.
      */
+    @Deprecated
     public static Algorithm ECDSA256K(ECDSAKeyProvider keyProvider) throws IllegalArgumentException {
         return new ECDSAAlgorithm("ES256K", "SHA256withECDSA", 32, keyProvider);
     }
@@ -194,8 +196,10 @@ public abstract class Algorithm {
      * @param publicKey  the key to use in the verify instance.
      * @param privateKey the key to use in the signing instance.
      * @return a valid ECDSA256 Algorithm.
+     * @deprecated This method is deprecated since Java 15+ disables SECP-256K1 Curve. Using this in Java 15+ will throw a SignatureException
      * @throws IllegalArgumentException if the provided Key is null.
      */
+    @Deprecated
     public static Algorithm ECDSA256K(ECPublicKey publicKey, ECPrivateKey privateKey) throws IllegalArgumentException {
         return ECDSA256K(ECDSAAlgorithm.providerForKeys(publicKey, privateKey));
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -48,9 +48,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA256 Algorithm.
      * @throws IllegalArgumentException if the Key Provider is null.
-     * @deprecated use {@link #RSA256(RSAPublicKey, RSAPrivateKey)} or {@link #RSA256(RSAKeyProvider)}
      */
-    @Deprecated
     public static Algorithm RSA256(RSAKey key) throws IllegalArgumentException {
         RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
         RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
@@ -86,9 +84,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA384 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #RSA384(RSAPublicKey, RSAPrivateKey)} or {@link #RSA384(RSAKeyProvider)}
      */
-    @Deprecated
     public static Algorithm RSA384(RSAKey key) throws IllegalArgumentException {
         RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
         RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
@@ -124,9 +120,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid RSA512 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #RSA512(RSAPublicKey, RSAPrivateKey)} or {@link #RSA512(RSAKeyProvider)}
      */
-    @Deprecated
     public static Algorithm RSA512(RSAKey key) throws IllegalArgumentException {
         RSAPublicKey publicKey = key instanceof RSAPublicKey ? (RSAPublicKey) key : null;
         RSAPrivateKey privateKey = key instanceof RSAPrivateKey ? (RSAPrivateKey) key : null;
@@ -261,9 +255,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA256 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA256(ECPublicKey, ECPrivateKey)} or {@link #ECDSA256(ECDSAKeyProvider)}
      */
-    @Deprecated
     public static Algorithm ECDSA256(ECKey key) throws IllegalArgumentException {
         ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
         ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
@@ -299,9 +291,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA384 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA384(ECPublicKey, ECPrivateKey)} or {@link #ECDSA384(ECDSAKeyProvider)}
      */
-    @Deprecated
     public static Algorithm ECDSA384(ECKey key) throws IllegalArgumentException {
         ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
         ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;
@@ -337,9 +327,7 @@ public abstract class Algorithm {
      * @param key the key to use in the verify or signing instance.
      * @return a valid ECDSA512 Algorithm.
      * @throws IllegalArgumentException if the provided Key is null.
-     * @deprecated use {@link #ECDSA512(ECPublicKey, ECPrivateKey)} or {@link #ECDSA512(ECDSAKeyProvider)}
      */
-    @Deprecated
     public static Algorithm ECDSA512(ECKey key) throws IllegalArgumentException {
         ECPublicKey publicKey = key instanceof ECPublicKey ? (ECPublicKey) key : null;
         ECPrivateKey privateKey = key instanceof ECPrivateKey ? (ECPrivateKey) key : null;

--- a/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
@@ -131,6 +131,7 @@ class CryptoHelper {
 
     /**
      * Verify signature.
+     * For valid verification, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param secretBytes algorithm secret.
@@ -139,16 +140,15 @@ class CryptoHelper {
      * @return true if signature is valid.
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     boolean verifySignatureFor(String algorithm, byte[] secretBytes, byte[] contentBytes, byte[] signatureBytes) throws NoSuchAlgorithmException, InvalidKeyException {
         return MessageDigest.isEqual(createSignatureFor(algorithm, secretBytes, contentBytes), signatureBytes);
     }
 
     /**
      * Create signature.
+     * To get the correct JWT Signature, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param secretBytes algorithm secret.
@@ -156,10 +156,8 @@ class CryptoHelper {
      * @return the signature bytes.
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     byte[] createSignatureFor(String algorithm, byte[] secretBytes, byte[] contentBytes) throws NoSuchAlgorithmException, InvalidKeyException {
         final Mac mac = Mac.getInstance(algorithm);
         mac.init(new SecretKeySpec(secretBytes, algorithm));
@@ -168,6 +166,7 @@ class CryptoHelper {
 
     /**
      * Verify signature using a public key.
+     * For valid verification, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param publicKey algorithm public key.
@@ -177,10 +176,8 @@ class CryptoHelper {
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
      * @throws SignatureException if this signature object is not initialized properly or if this signature algorithm is unable to process the input data provided.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     boolean verifySignatureFor(String algorithm, PublicKey publicKey, byte[] contentBytes, byte[] signatureBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         final Signature s = Signature.getInstance(algorithm);
         s.initVerify(publicKey);
@@ -190,6 +187,7 @@ class CryptoHelper {
 
     /**
      * Create signature using a private key.
+     * To get the correct JWT Signature, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param privateKey the private key to use for signing.
@@ -198,10 +196,8 @@ class CryptoHelper {
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
      * @throws SignatureException if this signature object is not initialized properly or if this signature algorithm is unable to process the input data provided.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     byte[] createSignatureFor(String algorithm, PrivateKey privateKey, byte[] contentBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         final Signature s = Signature.getInstance(algorithm);
         s.initSign(privateKey);

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -71,7 +71,6 @@ class ECDSAAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
             ECPrivateKey privateKey = keyProvider.getPrivateKey();

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -69,7 +69,6 @@ class HMACAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
             return crypto.createSignatureFor(getDescription(), secret, contentBytes);

--- a/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
@@ -31,7 +31,6 @@ class NoneAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         return new byte[0];
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -55,7 +55,6 @@ class RSAAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
         try {
             RSAPrivateKey privateKey = keyProvider.getPrivateKey();


### PR DESCRIPTION
Changes
We are deprecating the secp256k1 curve since Java 15+ has disabled this. This algorithm "ES256K" is not mentioned in RFC and removal of this algorithm in future is planned.

We are also removing deprecation notice for constructing Algorithm using a single key and signing contents using single parameter instead since we have found these to be useful methods

Testing
No tests since just a documentation change