### PR TITLE
fix problem with claim Date object handling not respecting millisecon…

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -481,6 +481,14 @@ public final class JWTCreator {
             }
         }
 
+        private void addClaim(String name, Date value) {
+            if (value == null) {
+                payloadClaims.remove(name);
+                return;
+            }
+            payloadClaims.put(name, value.getTime());
+        }
+
         private void addClaim(String name, Object value) {
             if (value == null) {
                 payloadClaims.remove(name);

--- a/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JsonNodeClaim.java
@@ -60,7 +60,7 @@ class JsonNodeClaim implements Claim {
             return null;
         }
         long seconds = data.asLong();
-        return new Date(seconds * 1000);
+        return new Date(seconds);
     }
 
     @Override

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -34,9 +34,7 @@ public class JWTCreatorTest {
     @Test
     public void shouldReturnSameDateWithMilliAccuracy() {
         long date = 1647277221778L;
-        System.out.println(date);
         Date in = new Date(date);
-        System.out.println(in);
         String token = JWTCreator.init()
                                .withClaim("aDate", in)
                                .sign(Algorithm.HMAC256("secret"));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -2,6 +2,7 @@ package com.auth0.jwt;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.impl.PublicClaims;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,21 @@ public class JWTCreatorTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldReturnSameDateWithMilliAccuracy() {
+        long date = 1647277221778L;
+        System.out.println(date);
+        Date in = new Date(date);
+        System.out.println(in);
+        String token = JWTCreator.init()
+                               .withClaim("aDate", in)
+                               .sign(Algorithm.HMAC256("secret"));
+        JWTVerifier verifier = JWT.require(Algorithm.HMAC256("secret")).build();
+        DecodedJWT jwt = verifier.verify(token);
+        Date out = jwt.getClaim("aDate").asDate();
+        assertThat(out.getTime(), is(in.getTime()));
+    }
 
     @Test
     public void shouldThrowWhenRequestingSignWithoutAlgorithm() throws Exception {
@@ -574,7 +590,7 @@ public class JWTCreatorTest {
 
         assertThat(jwt, is(notNullValue()));
         String[] parts = jwt.split("\\.");
-        
+
         String body = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
         ObjectMapper mapper = new ObjectMapper();
         List<Object> list = (List<Object>) mapper.readValue(body, Map.class).get("data");


### PR DESCRIPTION
Please see test, in short Date claims were chopping off millis

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
