### PR TITLE
[SDK-3171] Fix header claims serialization

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -3,9 +3,7 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
-import com.auth0.jwt.impl.ClaimsHolder;
-import com.auth0.jwt.impl.PayloadSerializer;
-import com.auth0.jwt.impl.PublicClaims;
+import com.auth0.jwt.impl.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,7 +32,8 @@ public final class JWTCreator {
     static {
         mapper = new ObjectMapper();
         module = new SimpleModule();
-        module.addSerializer(ClaimsHolder.class, new PayloadSerializer());
+        module.addSerializer(PayloadClaimsHolder.class, new PayloadSerializer());
+        module.addSerializer(HeaderClaimsHolder.class, new HeaderSerializer());
         mapper.registerModule(module);
         mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
     }
@@ -42,8 +41,8 @@ public final class JWTCreator {
     private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims) throws JWTCreationException {
         this.algorithm = algorithm;
         try {
-            headerJson = mapper.writeValueAsString(headerClaims);
-            payloadJson = mapper.writeValueAsString(new ClaimsHolder(payloadClaims));
+            headerJson = mapper.writeValueAsString(new HeaderClaimsHolder(headerClaims));
+            payloadJson = mapper.writeValueAsString(new PayloadClaimsHolder(payloadClaims));
         } catch (JsonProcessingException e) {
             throw new JWTCreationException("Some of the Claims couldn't be converted to a valid JSON format.", e);
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/ClaimsHolder.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/ClaimsHolder.java
@@ -6,11 +6,11 @@ import java.util.Map;
 /**
  * The ClaimsHolder class is just a wrapper for the Map of Claims used for building a JWT.
  */
-public final class ClaimsHolder {
+public abstract class ClaimsHolder {
     private Map<String, Object> claims;
 
-    public ClaimsHolder(Map<String, Object> claims) {
-        this.claims = claims == null ? new HashMap<String, Object>() : claims;
+    protected ClaimsHolder(Map<String, Object> claims) {
+        this.claims = claims == null ? new HashMap<>() : claims;
     }
 
     Map<String, Object> getClaims() {

--- a/lib/src/main/java/com/auth0/jwt/impl/ClaimsSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/ClaimsSerializer.java
@@ -24,7 +24,6 @@ public class ClaimsSerializer<T extends ClaimsHolder> extends StdSerializer<T> {
     @Override
     public void serialize(T holder, JsonGenerator gen, SerializerProvider provider) throws IOException {
         gen.writeStartObject();
-        holder.getClaims().forEach((key, val) -> System.out.println(key + ": " + val));
         for (Map.Entry<String, Object> entry : holder.getClaims().entrySet()) {
             writeClaim(entry, gen);
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/ClaimsSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/ClaimsSerializer.java
@@ -1,0 +1,87 @@
+package com.auth0.jwt.impl;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom serializer used to write the resulting JWT.
+ *
+ * @param <T> the type this serializer operates on.
+ */
+public class ClaimsSerializer<T extends ClaimsHolder> extends StdSerializer<T> {
+
+    public ClaimsSerializer(Class<T> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(T holder, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        holder.getClaims().forEach((key, val) -> System.out.println(key + ": " + val));
+        for (Map.Entry<String, Object> entry : holder.getClaims().entrySet()) {
+            writeClaim(entry, gen);
+        }
+        gen.writeEndObject();
+    }
+
+    /**
+     * Writes the given entry to the JSON representation. Custom claim serialization handling can override this method
+     * to provide use-case specific serialization. Implementors who override this method must write the field name and the
+     * field value.
+     *
+     * @param entry The entry that corresponds to the JSON field to write
+     * @param gen The {@code JsonGenerator} to use
+     * @throws IOException
+     */
+    protected void writeClaim(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
+        gen.writeFieldName(entry.getKey());
+        handleSerialization(entry.getValue(), gen);
+    }
+
+    private static void handleSerialization(Object value, JsonGenerator gen) throws IOException {
+        if (value instanceof Date) {
+            gen.writeNumber(dateToSeconds((Date) value));
+        } else if (value instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
+            gen.writeNumber(instantToSeconds((Instant) value));
+        } else if (value instanceof Map) {
+            serializeMap((Map<?, ?>) value, gen);
+        } else if (value instanceof List) {
+            serializeList((List<?>) value, gen);
+        } else {
+            gen.writeObject(value);
+        }
+    }
+
+    private static void serializeMap(Map<?, ?> map, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            gen.writeFieldName((String) entry.getKey());
+            Object value = entry.getValue();
+            handleSerialization(value, gen);
+        }
+        gen.writeEndObject();
+    }
+
+    private static void serializeList(List<?> list, JsonGenerator gen) throws IOException {
+        gen.writeStartArray();
+        for (Object entry : list) {
+            handleSerialization(entry, gen);
+        }
+        gen.writeEndArray();
+    }
+
+    private static long instantToSeconds(Instant instant) {
+        return instant.getEpochSecond();
+    }
+
+    private static long dateToSeconds(Date date) {
+        return date.getTime() / 1000;
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/impl/HeaderClaimsHolder.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/HeaderClaimsHolder.java
@@ -1,0 +1,12 @@
+package com.auth0.jwt.impl;
+
+import java.util.Map;
+
+/**
+ * Holds the header claims when serializing a JWT.
+ */
+public final class HeaderClaimsHolder extends ClaimsHolder {
+    public HeaderClaimsHolder(Map<String, Object> claims) {
+        super(claims);
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/impl/HeaderSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/HeaderSerializer.java
@@ -1,0 +1,10 @@
+package com.auth0.jwt.impl;
+
+/**
+ * Responsible for serializing a JWT's header representation to JSON.
+ */
+public class HeaderSerializer extends ClaimsSerializer<HeaderClaimsHolder> {
+    public HeaderSerializer() {
+        super(HeaderClaimsHolder.class);
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadClaimsHolder.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadClaimsHolder.java
@@ -1,0 +1,12 @@
+package com.auth0.jwt.impl;
+
+import java.util.Map;
+
+/**
+ * Holds the payload claims when serializing a JWT.
+ */
+public final class PayloadClaimsHolder extends ClaimsHolder {
+    public PayloadClaimsHolder(Map<String, Object> claims) {
+        super(claims);
+    }
+}

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -1,12 +1,12 @@
 package com.auth0.jwt.impl;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Jackson serializer implementation for converting into JWT Payload parts.
@@ -15,32 +15,26 @@ import java.util.*;
  * <p>
  * This class is thread-safe.
  */
-public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
-
+public class PayloadSerializer extends ClaimsSerializer<PayloadClaimsHolder> {
     public PayloadSerializer() {
-        this(null);
-    }
-
-    private PayloadSerializer(Class<ClaimsHolder> t) {
-        super(t);
+        super(PayloadClaimsHolder.class);
     }
 
     @Override
-    public void serialize(ClaimsHolder holder, JsonGenerator gen, SerializerProvider provider) throws IOException {
-
-        gen.writeStartObject();
-        for (Map.Entry<String, Object> e : holder.getClaims().entrySet()) {
-            if (PublicClaims.AUDIENCE.equals(e.getKey())) {
-                writeAudience(gen, e);
-            } else {
-                gen.writeFieldName(e.getKey());
-                handleSerialization(e.getValue(), gen);
-            }
+    protected void writeClaim(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
+        if (PublicClaims.AUDIENCE.equals(entry.getKey())) {
+            writeAudience(gen, entry);
+        } else {
+            super.writeClaim(entry, gen);
         }
-
-        gen.writeEndObject();
     }
 
+    /**
+     * Audience may be a list of strings or a single string. This is needed to properly handle the aud claim when
+     * added with the {@linkplain com.auth0.jwt.JWTCreator.Builder#withPayload(Map)} method.
+     */
+
+    //
     private void writeAudience(JsonGenerator gen, Map.Entry<String, Object> e) throws IOException {
         if (e.getValue() instanceof String) {
             gen.writeFieldName(e.getKey());
@@ -69,50 +63,5 @@ public class PayloadSerializer extends StdSerializer<ClaimsHolder> {
                 gen.writeEndArray();
             }
         }
-    }
-
-    /**
-     * Serializes {@linkplain Instant} to epoch second values, traversing maps and lists as needed.
-     * @param value the object to serialize
-     * @param gen the JsonGenerator to use for JSON serialization
-     */
-    private void handleSerialization(Object value, JsonGenerator gen) throws IOException {
-        if (value instanceof Date) {
-            gen.writeNumber(dateToSeconds((Date) value));
-        } else if (value instanceof Instant) { // EXPIRES_AT, ISSUED_AT, NOT_BEFORE, custom Instant claims
-            gen.writeNumber(instantToSeconds((Instant) value));
-        } else if (value instanceof Map) {
-            serializeMap((Map<?, ?>) value, gen);
-        } else if (value instanceof List) {
-            serializeList((List<?>) value, gen);
-        } else {
-            gen.writeObject(value);
-        }
-    }
-
-    private void serializeMap(Map<?, ?> map, JsonGenerator gen) throws IOException {
-        gen.writeStartObject();
-        for (Map.Entry<?, ?> entry : map.entrySet()) {
-            gen.writeFieldName((String) entry.getKey());
-            Object value = entry.getValue();
-            handleSerialization(value, gen);
-        }
-        gen.writeEndObject();
-    }
-
-    private void serializeList(List<?> list, JsonGenerator gen) throws IOException {
-        gen.writeStartArray();
-        for (Object entry : list) {
-            handleSerialization(entry, gen);
-        }
-        gen.writeEndArray();
-    }
-
-    private long instantToSeconds(Instant instant) {
-        return instant.getEpochSecond();
-    }
-
-    private long dateToSeconds(Date date) {
-        return date.getTime() / 1000;
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -345,6 +346,35 @@ public class JWTDecoderTest {
         assertThat(originalJwt.getType(), is(equalTo(deserializedJwt.getType())));
         assertThat(originalJwt.getClaims().get("extraClaim").asString(),
                 is(equalTo(deserializedJwt.getClaims().get("extraClaim").asString())));
+    }
+
+    @Test
+    public void shouldDecodeHeaderClaims() {
+        String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImRhdGUiOjE2NDczNTgzMjUsInN0cmluZyI6InN0cmluZyIsImJvb2wiOnRydWUsImRvdWJsZSI6MTIzLjEyMywibGlzdCI6WzE2NDczNTgzMjVdLCJtYXAiOnsiZGF0ZSI6MTY0NzM1ODMyNSwiaW5zdGFudCI6MTY0NzM1ODMyNX0sImludCI6NDIsImxvbmciOjQyMDAwMDAwMDAsImluc3RhbnQiOjE2NDczNTgzMjV9.eyJpYXQiOjE2NDczNjA4ODF9.S2nZDM03ZDvLMeJLWOIqWZ9kmYHZUueyQiIZCCjYNL8";
+
+        Instant expectedInstant = Instant.ofEpochSecond(1647358325);
+        Date expectedDate = Date.from(expectedInstant);
+
+        DecodedJWT decoded = JWT.decode(jwt);
+        assertThat(decoded, is(notNullValue()));
+        assertThat(decoded.getHeaderClaim("date").asDate(), is(expectedDate));
+        assertThat(decoded.getHeaderClaim("instant").asInstant(), is(expectedInstant));
+        assertThat(decoded.getHeaderClaim("string").asString(), is("string"));
+        assertThat(decoded.getHeaderClaim("bool").asBoolean(), is(true));
+        assertThat(decoded.getHeaderClaim("double").asDouble(), is(123.123));
+        assertThat(decoded.getHeaderClaim("int").asInt(), is(42));
+        assertThat(decoded.getHeaderClaim("long").asLong(), is(4200000000L));
+
+        Map<String, Object> headerMap = decoded.getHeaderClaim("map").asMap();
+        assertThat(headerMap, is(notNullValue()));
+        assertThat(headerMap.size(), is(2));
+        assertThat(headerMap, hasEntry("date", 1647358325));
+        assertThat(headerMap, hasEntry("instant", 1647358325));
+
+        List<Object> headerList = decoded.getHeaderClaim("list").asList(Object.class);
+        assertThat(headerList, is(notNullValue()));
+        assertThat(headerList.size(), is(1));
+        assertThat(headerList, contains(1647358325));
     }
 
     //Helper Methods

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadClaimsHolderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadClaimsHolderTest.java
@@ -9,23 +9,22 @@ import java.util.Map;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ClaimsHolderTest {
+public class PayloadClaimsHolderTest {
 
-    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldGetClaims() {
         HashMap<String, Object> claims = new HashMap<>();
         claims.put("iss", "auth0");
-        ClaimsHolder holder = new ClaimsHolder(claims);
+        ClaimsHolder holder = new PayloadClaimsHolder(claims);
         assertThat(holder, is(notNullValue()));
         assertThat(holder.getClaims(), is(notNullValue()));
         assertThat(holder.getClaims(), is(instanceOf(Map.class)));
-        assertThat(holder.getClaims(), is(IsMapContaining.hasEntry("iss", (Object) "auth0")));
+        assertThat(holder.getClaims(), is(IsMapContaining.hasEntry("iss", "auth0")));
     }
 
     @Test
     public void shouldGetNotNullClaims() {
-        ClaimsHolder holder = new ClaimsHolder(null);
+        ClaimsHolder holder = new PayloadClaimsHolder(null);
         assertThat(holder, is(notNullValue()));
         assertThat(holder.getClaims(), is(notNullValue()));
         assertThat(holder.getClaims(), is(instanceOf(Map.class)));

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadSerializerTest.java
@@ -11,8 +11,8 @@ import org.junit.Test;
 import java.io.StringWriter;
 import java.util.*;
 
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class PayloadSerializerTest {
 
@@ -31,10 +31,9 @@ public class PayloadSerializerTest {
         serializerProvider = mapper.getSerializerProvider();
     }
 
-    @SuppressWarnings("Convert2Diamond")
     @Test
     public void shouldSerializeEmptyMap() throws Exception {
-        ClaimsHolder holder = new ClaimsHolder(new HashMap<String, Object>());
+        PayloadClaimsHolder holder = new PayloadClaimsHolder(new HashMap<>());
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -43,7 +42,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeStringAudienceAsString() throws Exception {
-        ClaimsHolder holder = holderFor("aud", "auth0");
+        PayloadClaimsHolder holder = holderFor("aud", "auth0");
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -52,7 +51,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeSingleItemAudienceAsArray() throws Exception {
-        ClaimsHolder holder = holderFor("aud", new String[]{"auth0"});
+        PayloadClaimsHolder holder = holderFor("aud", new String[]{"auth0"});
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -61,7 +60,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeMultipleItemsAudienceAsArray() throws Exception {
-        ClaimsHolder holder = holderFor("aud", new String[]{"auth0", "auth10"});
+        PayloadClaimsHolder holder = holderFor("aud", new String[]{"auth0", "auth10"});
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -70,7 +69,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSkipSerializationOnEmptyAudience() throws Exception {
-        ClaimsHolder holder = holderFor("aud", new String[0]);
+        PayloadClaimsHolder holder = holderFor("aud", new String[0]);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -79,7 +78,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeSingleItemAudienceAsArrayWhenAList() throws Exception {
-        ClaimsHolder holder = holderFor("aud", Collections.singletonList("auth0"));
+        PayloadClaimsHolder holder = holderFor("aud", Collections.singletonList("auth0"));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -88,7 +87,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeMultipleItemsAudienceAsArrayWhenAList() throws Exception {
-        ClaimsHolder holder = holderFor("aud", Arrays.asList("auth0", "auth10"));
+        PayloadClaimsHolder holder = holderFor("aud", Arrays.asList("auth0", "auth10"));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -97,7 +96,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSkipSerializationOnEmptyAudienceWhenList() throws Exception {
-        ClaimsHolder holder = holderFor("aud", new ArrayList());
+        PayloadClaimsHolder holder = holderFor("aud", new ArrayList<>());
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -106,7 +105,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSkipNonStringsOnAudienceWhenSingleItemList() throws Exception {
-        ClaimsHolder holder = holderFor("aud", Collections.singletonList(2));
+        PayloadClaimsHolder holder = holderFor("aud", Collections.singletonList(2));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -115,7 +114,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSkipNonStringsOnAudienceWhenList() throws Exception {
-        ClaimsHolder holder = holderFor("aud", Arrays.asList("auth0", 2, "auth10"));
+        PayloadClaimsHolder holder = holderFor("aud", Arrays.asList("auth0", 2, "auth10"));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -124,7 +123,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSkipNonStringsOnAudience() throws Exception {
-        ClaimsHolder holder = holderFor("aud", 4);
+        PayloadClaimsHolder holder = holderFor("aud", 4);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -133,7 +132,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeNotBeforeDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("nbf", new Date(1478874000));
+        PayloadClaimsHolder holder = holderFor("nbf", new Date(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -142,7 +141,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeIssuedAtDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("iat", new Date(1478874000));
+        PayloadClaimsHolder holder = holderFor("iat", new Date(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -151,7 +150,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeExpiresAtDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("exp", new Date(1478874000));
+        PayloadClaimsHolder holder = holderFor("exp", new Date(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -160,7 +159,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeCustomDateInSeconds() throws Exception {
-        ClaimsHolder holder = holderFor("birthdate", new Date(1478874000));
+        PayloadClaimsHolder holder = holderFor("birthdate", new Date(1478874000));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -171,7 +170,7 @@ public class PayloadSerializerTest {
     public void shouldSerializeDatesUsingLong() throws Exception {
         long secs = Integer.MAX_VALUE + 10000L;
         Date date = new Date(secs * 1000L);
-        Map<String, Object> claims = new HashMap<String, Object>();
+        Map<String, Object> claims = new HashMap<>();
         claims.put("iat", date);
         claims.put("nbf", date);
         claims.put("exp", date);
@@ -187,7 +186,7 @@ public class PayloadSerializerTest {
         nestedInList.add(Collections.singletonMap("nested", date));
         claims.put("nestedInList", nestedInList);
 
-        ClaimsHolder holder = new ClaimsHolder(claims);
+        PayloadClaimsHolder holder = new PayloadClaimsHolder(claims);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -206,7 +205,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeStrings() throws Exception {
-        ClaimsHolder holder = holderFor("name", "Auth0 Inc");
+        PayloadClaimsHolder holder = holderFor("name", "Auth0 Inc");
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -215,7 +214,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeIntegers() throws Exception {
-        ClaimsHolder holder = holderFor("number", 12345);
+        PayloadClaimsHolder holder = holderFor("number", 12345);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -224,7 +223,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeDoubles() throws Exception {
-        ClaimsHolder holder = holderFor("fraction", 23.45);
+        PayloadClaimsHolder holder = holderFor("fraction", 23.45);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -233,7 +232,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeBooleans() throws Exception {
-        ClaimsHolder holder = holderFor("pro", true);
+        PayloadClaimsHolder holder = holderFor("pro", true);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -242,7 +241,7 @@ public class PayloadSerializerTest {
 
     @Test
     public void shouldSerializeNulls() throws Exception {
-        ClaimsHolder holder = holderFor("id", null);
+        PayloadClaimsHolder holder = holderFor("id", null);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -253,7 +252,7 @@ public class PayloadSerializerTest {
     public void shouldSerializeCustomArrayOfObject() throws Exception {
         UserPojo user1 = new UserPojo("Michael", 1);
         UserPojo user2 = new UserPojo("Lucas", 2);
-        ClaimsHolder holder = holderFor("users", new UserPojo[]{user1, user2});
+        PayloadClaimsHolder holder = holderFor("users", new UserPojo[]{user1, user2});
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -264,7 +263,7 @@ public class PayloadSerializerTest {
     public void shouldSerializeCustomListOfObject() throws Exception {
         UserPojo user1 = new UserPojo("Michael", 1);
         UserPojo user2 = new UserPojo("Lucas", 2);
-        ClaimsHolder holder = holderFor("users", Arrays.asList(user1, user2));
+        PayloadClaimsHolder holder = holderFor("users", Arrays.asList(user1, user2));
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
@@ -274,18 +273,17 @@ public class PayloadSerializerTest {
     @Test
     public void shouldSerializeCustomObject() throws Exception {
         UserPojo user = new UserPojo("Michael", 1);
-        ClaimsHolder holder = holderFor("users", user);
+        PayloadClaimsHolder holder = holderFor("users", user);
         serializer.serialize(holder, jsonGenerator, serializerProvider);
         jsonGenerator.flush();
 
         assertThat(writer.toString(), is(equalTo("{\"users\":{\"name\":\"Michael\",\"id\":1}}")));
     }
 
-    @SuppressWarnings("Convert2Diamond")
-    private ClaimsHolder holderFor(String key, Object value) {
-        Map<String, Object> map = new HashMap<String, Object>();
+    private PayloadClaimsHolder holderFor(String key, Object value) {
+        Map<String, Object> map = new HashMap<>();
         map.put(key, value);
-        return new ClaimsHolder(map);
+        return new PayloadClaimsHolder(map);
     }
 
 }


### PR DESCRIPTION
### Changes

Currently, we serialize the header claims using Jackson's default `writeString`. This causes date-time based claims to be serialized as milliseconds since the epoch, instead of the required seconds since the epoch.

This PR refactors much of the logic of the `PayloadSerializer` out to a new class `ClaimsSerializer`, which allows a subclass to override how the claim is written (needed to handle the `aud` claim serialization for the payload).