### PR TITLE
Update documentation and undeprecate single content sign methods

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java
@@ -409,14 +409,13 @@ public abstract class Algorithm {
 
     /**
      * Sign the given content using this Algorithm instance.
+     * To get the correct JWT Signature, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param contentBytes an array of bytes representing the base64 encoded content to be verified against the signature.
      * @return the signature in a base64 encoded array of bytes
      * @throws SignatureGenerationException if the Key is invalid.
-     * @deprecated Please use the {@linkplain #sign(byte[], byte[])} method instead.
      */
 
-    @Deprecated
     public abstract byte[] sign(byte[] contentBytes) throws SignatureGenerationException;
 
 }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
@@ -131,6 +131,7 @@ class CryptoHelper {
 
     /**
      * Verify signature.
+     * For valid verification, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param secretBytes algorithm secret.
@@ -139,16 +140,15 @@ class CryptoHelper {
      * @return true if signature is valid.
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     boolean verifySignatureFor(String algorithm, byte[] secretBytes, byte[] contentBytes, byte[] signatureBytes) throws NoSuchAlgorithmException, InvalidKeyException {
         return MessageDigest.isEqual(createSignatureFor(algorithm, secretBytes, contentBytes), signatureBytes);
     }
 
     /**
      * Create signature.
+     * To get the correct JWT Signature, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param secretBytes algorithm secret.
@@ -156,10 +156,8 @@ class CryptoHelper {
      * @return the signature bytes.
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     byte[] createSignatureFor(String algorithm, byte[] secretBytes, byte[] contentBytes) throws NoSuchAlgorithmException, InvalidKeyException {
         final Mac mac = Mac.getInstance(algorithm);
         mac.init(new SecretKeySpec(secretBytes, algorithm));
@@ -168,6 +166,7 @@ class CryptoHelper {
 
     /**
      * Verify signature using a public key.
+     * For valid verification, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param publicKey algorithm public key.
@@ -177,10 +176,8 @@ class CryptoHelper {
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
      * @throws SignatureException if this signature object is not initialized properly or if this signature algorithm is unable to process the input data provided.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     boolean verifySignatureFor(String algorithm, PublicKey publicKey, byte[] contentBytes, byte[] signatureBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         final Signature s = Signature.getInstance(algorithm);
         s.initVerify(publicKey);
@@ -190,6 +187,7 @@ class CryptoHelper {
 
     /**
      * Create signature using a private key.
+     * To get the correct JWT Signature, ensure the content is in the format {HEADER}.{PAYLOAD}
      *
      * @param algorithm algorithm name.
      * @param privateKey the private key to use for signing.
@@ -198,10 +196,8 @@ class CryptoHelper {
      * @throws NoSuchAlgorithmException if the algorithm is not supported.
      * @throws InvalidKeyException if the given key is inappropriate for initializing the specified algorithm.
      * @throws SignatureException if this signature object is not initialized properly or if this signature algorithm is unable to process the input data provided.
-     * @deprecated rather use corresponding method which takes header and payload as separate inputs
      */
 
-    @Deprecated
     byte[] createSignatureFor(String algorithm, PrivateKey privateKey, byte[] contentBytes) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         final Signature s = Signature.getInstance(algorithm);
         s.initSign(privateKey);

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -71,7 +71,6 @@ class ECDSAAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
             ECPrivateKey privateKey = keyProvider.getPrivateKey();

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -69,7 +69,6 @@ class HMACAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         try {
             return crypto.createSignatureFor(getDescription(), secret, contentBytes);

--- a/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
@@ -31,7 +31,6 @@ class NoneAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
         return new byte[0];
     }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -55,7 +55,6 @@ class RSAAlgorithm extends Algorithm {
     }
 
     @Override
-    @Deprecated
     public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
         try {
             RSAPrivateKey privateKey = keyProvider.getPrivateKey();


### PR DESCRIPTION
Changes
We are removing deprecation notice for methods that get the payload and header as a single content. We have just added new documentation so that the developer can understand the correct format to use.

Testing
No tests since just a documentation change