### PR TITLE
[SDK-3212] Remove impl package export in module-info

### DIFF
--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -1,8 +1,5 @@
 module com.auth0.jwt {
-    // remove transitive in next major release
     requires com.fasterxml.jackson.databind;
-    // remove in next major release
-    exports com.auth0.jwt.impl;
 
     exports com.auth0.jwt;
     exports com.auth0.jwt.algorithms;


### PR DESCRIPTION
### Changes
We are removing the option where library users can use our implementations. This will ensure we will be able to change the internal working much easier and avoid unwanted dependencies on customer end. Though we have to remember that projects that doesn't use module system will still be able to access our `impl` package

We have also removed the comment which says to remove transitive for Jackson. We should not use 'remove transitive' since that will expose the Jackson library through ours. The current use of Jackson library is correct. This StackOverflow answer explains it better - https://stackoverflow.com/a/46504020

### Testing
We created a new project and tested the library as a dependency with module-info removed. This was tested in Java 8 (which doesn't have module support), Java 11 with modules and Java 11 without modules
