### PR TITLE
Security: Bump `jackson-databind` to 2.13.2.1

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -47,7 +47,7 @@ javadoc {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     testImplementation 'junit:junit:4.12'
     testImplementation 'net.jodah:concurrentunit:0.4.3'


### PR DESCRIPTION
This PR bumps the `jackson-databind` dependency to 2.13.2.1 to address [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) in that library

---

Re: https://togithub.com/FasterXML/jackson-databind/issues/3428
Build is currently failing due to an upstream issue; holding until resolved.