### PR TITLE
Release 3.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.19.1](https://github.com/auth0/java-jwt/tree/3.19.1) (2022-03-30)
+[Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.0...3.19.1)
+
+**Security**
+- Security: Bump `jackson-databind` to 2.13.2.2 [\#566](https://github.com/auth0/java-jwt/pull/566) ([evansims](https://github.com/evansims))
+
 ## [3.19.0](https://github.com/auth0/java-jwt/tree/3.19.0) (2022-03-14)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/3.18.3...3.19.0)
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ The library is available on both Maven Central and Bintray, and the Javadoc is p
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>java-jwt</artifactId>
-    <version>3.19.0</version>
+    <version>3.19.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation 'com.auth0:java-jwt:3.19.0'
+implementation 'com.auth0:java-jwt:3.19.1'
 ```
 
 ## Available Algorithms


### PR DESCRIPTION
## [3.19.1](https://github.com/auth0/java-jwt/tree/3.19.1) (2022-03-30)
[Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.0...3.19.1)

**Security**
- Security: Bump `jackson-databind` to 2.13.2.2 [\#566](https://github.com/auth0/java-jwt/pull/566) ([evansims](https://github.com/evansims))