### PR TITLE
Improve keyprovider reliability

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/CryptoHelper.java
@@ -113,33 +113,6 @@ class CryptoHelper {
     }
 
     /**
-     * Create signature for JWT header and payload using a private key.
-     *
-     * @param algorithm    algorithm name.
-     * @param privateKey   the private key to use for signing.
-     * @param headerBytes  JWT header.
-     * @param payloadBytes JWT payload.
-     * @return the signature bytes.
-     * @throws NoSuchAlgorithmException if the algorithm is not supported.
-     * @throws InvalidKeyException      if the given key is inappropriate for initializing the specified algorithm.
-     * @throws SignatureException       if this signature object is not initialized properly
-     *                                  or if this signature algorithm is unable to process the input data provided.
-     */
-    byte[] createSignatureFor(
-            String algorithm,
-            PrivateKey privateKey,
-            byte[] headerBytes,
-            byte[] payloadBytes
-    ) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        final Signature s = Signature.getInstance(algorithm);
-        s.initSign(privateKey);
-        s.update(headerBytes);
-        s.update(JWT_PART_SEPARATOR);
-        s.update(payloadBytes);
-        return s.sign();
-    }
-
-    /**
      * Create signature for JWT header and payload.
      *
      * @param algorithm    algorithm name.

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -4,9 +4,11 @@ import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
+import com.auth0.jwt.interfaces.PrivateKeyDetail;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.SignatureException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -61,23 +63,8 @@ class ECDSAAlgorithm extends Algorithm {
     }
 
     @Override
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    public byte[] sign(byte[] contentBytes, PrivateKey privateKey) throws SignatureGenerationException {
         try {
-            ECPrivateKey privateKey = keyProvider.getPrivateKey();
-            if (privateKey == null) {
-                throw new IllegalStateException("The given Private Key is null.");
-            }
-            byte[] signature = crypto.createSignatureFor(getDescription(), privateKey, headerBytes, payloadBytes);
-            return DERToJOSE(signature);
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
-            throw new SignatureGenerationException(this, e);
-        }
-    }
-
-    @Override
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
-        try {
-            ECPrivateKey privateKey = keyProvider.getPrivateKey();
             if (privateKey == null) {
                 throw new IllegalStateException("The given Private Key is null.");
             }
@@ -89,8 +76,8 @@ class ECDSAAlgorithm extends Algorithm {
     }
 
     @Override
-    public String getSigningKeyId() {
-        return keyProvider.getPrivateKeyId();
+    public PrivateKeyDetail<ECPrivateKey> getPrivateKeyDetails() {
+        return keyProvider.getPrivateKeyDetails();
     }
 
     //Visible for testing

--- a/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/HMACAlgorithm.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -62,16 +63,7 @@ class HMACAlgorithm extends Algorithm {
     }
 
     @Override
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
-        try {
-            return crypto.createSignatureFor(getDescription(), secret, headerBytes, payloadBytes);
-        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-            throw new SignatureGenerationException(this, e);
-        }
-    }
-
-    @Override
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+    public byte[] sign(byte[] contentBytes, PrivateKey privateKey) throws SignatureGenerationException {
         try {
             return crypto.createSignatureFor(getDescription(), secret, contentBytes);
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {

--- a/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/NoneAlgorithm.java
@@ -3,6 +3,8 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+
+import java.security.PrivateKey;
 import java.util.Base64;
 
 class NoneAlgorithm extends Algorithm {
@@ -31,6 +33,11 @@ class NoneAlgorithm extends Algorithm {
 
     @Override
     public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+        return new byte[0];
+    }
+
+    @Override
+    public byte[] sign(byte[] contentBytes, PrivateKey privateKey) throws SignatureGenerationException {
         return new byte[0];
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/RSAAlgorithm.java
@@ -3,11 +3,13 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.PrivateKeyDetail;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.SignatureException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -58,22 +60,8 @@ class RSAAlgorithm extends Algorithm {
     }
 
     @Override
-    public byte[] sign(byte[] headerBytes, byte[] payloadBytes) throws SignatureGenerationException {
+    public byte[] sign(byte[] contentBytes, PrivateKey privateKey) throws SignatureGenerationException {
         try {
-            RSAPrivateKey privateKey = keyProvider.getPrivateKey();
-            if (privateKey == null) {
-                throw new IllegalStateException("The given Private Key is null.");
-            }
-            return crypto.createSignatureFor(getDescription(), privateKey, headerBytes, payloadBytes);
-        } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException | IllegalStateException e) {
-            throw new SignatureGenerationException(this, e);
-        }
-    }
-
-    @Override
-    public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
-        try {
-            RSAPrivateKey privateKey = keyProvider.getPrivateKey();
             if (privateKey == null) {
                 throw new IllegalStateException("The given Private Key is null.");
             }
@@ -84,8 +72,8 @@ class RSAAlgorithm extends Algorithm {
     }
 
     @Override
-    public String getSigningKeyId() {
-        return keyProvider.getPrivateKeyId();
+    public PrivateKeyDetail<RSAPrivateKey> getPrivateKeyDetails() {
+        return keyProvider.getPrivateKeyDetails();
     }
 
     //Visible for testing

--- a/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
@@ -24,6 +24,7 @@ interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
      * Getter for the Private Key instance. Used to sign the content on the JWT signing stage.
      *
      * @return the Private Key instance
+     * @deprecated Use {@link KeyProvider#getPrivateKeyDetails()} instead
      */
     R getPrivateKey();
 
@@ -32,6 +33,27 @@ interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
      * This represents the `kid` claim and will be placed in the Header.
      *
      * @return the Key Id that identifies the Private Key or null if it's not specified.
+     * @deprecated Use {@link KeyProvider#getPrivateKeyDetails()} instead
      */
     String getPrivateKeyId();
+
+    /**
+     * Getter for the Private Key instance along with its Id.
+     * Used to sign the content on the JWT signing stage.
+     *
+     * @return the Private Key Details instance
+     */
+    default PrivateKeyDetail<R> getPrivateKeyDetails() {
+        return new PrivateKeyDetail<R>() {
+            @Override
+            public R getPrivateKey() {
+                return KeyProvider.this.getPrivateKey();
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return KeyProvider.this.getPrivateKeyId();
+            }
+        };
+    }
 }

--- a/lib/src/main/java/com/auth0/jwt/interfaces/PrivateKeyDetail.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/PrivateKeyDetail.java
@@ -1,0 +1,25 @@
+package com.auth0.jwt.interfaces;
+
+import java.security.PrivateKey;
+
+/**
+ * Generic representation of Private Key with its Key ID.
+ *
+ * @param <R> the class that represents the Private Key
+ */
+public interface PrivateKeyDetail<R extends PrivateKey> {
+    /**
+     * Getter for the Private Key instance. Used to sign the content on the JWT signing stage.
+     *
+     * @return the Private Key instance
+     */
+    R getPrivateKey();
+
+    /**
+     * Getter for the Id of the Private Key used to sign the tokens.
+     * This represents the `kid` claim and will be placed in the Header.
+     *
+     * @return the Key Id that identifies the Private Key or null if it's not specified.
+     */
+    String getPrivateKeyId();
+}

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -3,6 +3,7 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.impl.PublicClaims;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
+import com.auth0.jwt.interfaces.PrivateKeyDetail;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Rule;
@@ -155,8 +156,17 @@ public class JWTCreatorTest {
     public void shouldAddKeyIdIfAvailableFromRSAAlgorithms() throws Exception {
         RSAPrivateKey privateKey = (RSAPrivateKey) PemUtils.readPrivateKeyFromFile(PRIVATE_KEY_FILE_RSA, "RSA");
         RSAKeyProvider provider = mock(RSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("my-key-id");
-        when(provider.getPrivateKey()).thenReturn(privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<RSAPrivateKey>() {
+            @Override
+            public RSAPrivateKey getPrivateKey() {
+                return privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
 
         String signed = JWTCreator.init()
                 .sign(Algorithm.RSA256(provider));
@@ -171,8 +181,17 @@ public class JWTCreatorTest {
     public void shouldNotOverwriteKeyIdIfAddedFromRSAAlgorithms() throws Exception {
         RSAPrivateKey privateKey = (RSAPrivateKey) PemUtils.readPrivateKeyFromFile(PRIVATE_KEY_FILE_RSA, "RSA");
         RSAKeyProvider provider = mock(RSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("my-key-id");
-        when(provider.getPrivateKey()).thenReturn(privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<RSAPrivateKey>() {
+            @Override
+            public RSAPrivateKey getPrivateKey() {
+                return privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
 
         String signed = JWTCreator.init()
                 .withKeyId("real-key-id")
@@ -188,8 +207,17 @@ public class JWTCreatorTest {
     public void shouldAddKeyIdIfAvailableFromECDSAAlgorithms() throws Exception {
         ECPrivateKey privateKey = (ECPrivateKey) PemUtils.readPrivateKeyFromFile(PRIVATE_KEY_FILE_EC_256, "EC");
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("my-key-id");
-        when(provider.getPrivateKey()).thenReturn(privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
 
         String signed = JWTCreator.init()
                 .sign(Algorithm.ECDSA256(provider));
@@ -204,8 +232,17 @@ public class JWTCreatorTest {
     public void shouldNotOverwriteKeyIdIfAddedFromECDSAAlgorithms() throws Exception {
         ECPrivateKey privateKey = (ECPrivateKey) PemUtils.readPrivateKeyFromFile(PRIVATE_KEY_FILE_EC_256, "EC");
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("my-key-id");
-        when(provider.getPrivateKey()).thenReturn(privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
 
         String signed = JWTCreator.init()
                 .withKeyId("real-key-id")

--- a/lib/src/test/java/com/auth0/jwt/KeyRotationTest.java
+++ b/lib/src/test/java/com/auth0/jwt/KeyRotationTest.java
@@ -1,0 +1,118 @@
+package com.auth0.jwt;
+
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.ECDSAKeyProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.*;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class KeyRotationTest {
+    private static class IdentifiedKey {
+        private final String id;
+        private final KeyPair keyPair;
+
+        IdentifiedKey(final String id, final KeyPair keyPair) {
+            this.id = id;
+            this.keyPair = keyPair;
+        }
+
+        ECPublicKey getPublic() {
+            return (ECPublicKey) keyPair.getPublic();
+        }
+
+        ECPrivateKey getPrivate() {
+            return (ECPrivateKey) keyPair.getPrivate();
+        }
+    }
+
+    private static class KeyProvider implements ECDSAKeyProvider {
+        private final long rotationFrequency;
+
+        private final KeyPairGenerator keyPairGenerator;
+
+        private final ConcurrentHashMap<String, IdentifiedKey> keys = new ConcurrentHashMap<>();
+        private long currentKey = 0L;
+
+        KeyProvider(final long rotationFrequency) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+            this.rotationFrequency = rotationFrequency;
+            keyPairGenerator = KeyPairGenerator.getInstance("EC");
+            keyPairGenerator.initialize(new ECGenParameterSpec("NIST P-256"), SecureRandom.getInstanceStrong());
+        }
+
+        @Override
+        public ECPublicKey getPublicKeyById(final String keyId) {
+            return keys.get(keyId).getPublic();
+        }
+
+        private IdentifiedKey generateKey(final String id) {
+            return new IdentifiedKey(id, keyPairGenerator.generateKeyPair());
+        }
+
+        private IdentifiedKey currentKey() {
+            final long now = System.currentTimeMillis() / rotationFrequency;
+            final IdentifiedKey key;
+            if (now != currentKey) {
+                currentKey = now;
+                key = generateKey(String.valueOf(now));
+                keys.put(key.id, key);
+            } else {
+                key = keys.get(String.valueOf(now));
+            }
+            return key;
+        }
+
+        @Override
+        public ECPrivateKey getPrivateKey() {
+            return currentKey().getPrivate();
+        }
+
+        @Override
+        public String getPrivateKeyId() {
+            return currentKey().id;
+        }
+    }
+
+    @Test
+    public void generateAndValidate1000Tokens10sRotation() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        runTest(10_000, 10000);
+    }
+
+    @Test
+    public void generateAndValidate1000Tokens1sRotation() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        runTest(1_000, 10000);
+    }
+
+    @Test
+    public void generateAndValidate1000Tokens100msRotation() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        runTest(100, 10000);
+    }
+
+    @Test
+    public void generateAndValidate1000Tokens10msRotation() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        runTest(10, 10000);
+    }
+
+    private void runTest(final long rotationFrequency, final int iterations) throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        final KeyProvider provider = new KeyProvider(rotationFrequency);
+        final Algorithm algorithm = Algorithm.ECDSA256(provider);
+        final JWTVerifier verifier = JWTVerifier.init(algorithm).build();
+        for (int i = 0; i < iterations; i++) {
+            generateAndValidate(algorithm, verifier, i);
+        }
+    }
+
+    private void generateAndValidate(final Algorithm algorithm, final JWTVerifier verifier, final int iteration) {
+        try {
+            final String token = JWT.create().sign(algorithm);
+            verifier.verify(token);
+        } catch (final JWTVerificationException e) {
+            Assert.fail("Token " + iteration + " verification failed: " + e.getMessage());
+        }
+    }
+}

--- a/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/AlgorithmTest.java
@@ -9,6 +9,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
 import java.security.interfaces.*;
 
 import static org.hamcrest.Matchers.*;
@@ -560,10 +561,25 @@ public class AlgorithmTest {
         byte[] payload = new byte[]{0x04, 0x05, 0x06};
 
         byte[] signature = new byte[]{0x10, 0x11, 0x12};
-        when(algorithm.sign(any(byte[].class), any(byte[].class))).thenCallRealMethod();
-        when(algorithm.sign(contentCaptor.capture())).thenReturn(signature);
+        when(algorithm.sign(any(byte[].class), any(byte[].class), any(PrivateKey.class))).thenCallRealMethod();
+        when(algorithm.sign(contentCaptor.capture(), any(PrivateKey.class))).thenReturn(signature);
 
-        byte[] sign = algorithm.sign(header, payload);
+        byte[] sign = algorithm.sign(header, payload, new PrivateKey() {
+            @Override
+            public String getAlgorithm() {
+                return null;
+            }
+
+            @Override
+            public String getFormat() {
+                return null;
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return new byte[0];
+            }
+        });
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         bout.write(header);

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
+import com.auth0.jwt.interfaces.PrivateKeyDetail;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIn;
 import org.junit.Rule;
@@ -554,7 +555,17 @@ public class ECDSAAlgorithmTest {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
-        when(provider.getPrivateKey()).thenReturn((ECPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return (ECPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((ECPublicKey) publicKey);
         Algorithm algorithm = Algorithm.ECDSA256(provider);
 
@@ -572,7 +583,17 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA256(provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -612,7 +633,17 @@ public class ECDSAAlgorithmTest {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
-        when(provider.getPrivateKey()).thenReturn((ECPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return (ECPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((ECPublicKey) publicKey);
         Algorithm algorithm = Algorithm.ECDSA384(provider);
 
@@ -630,7 +661,17 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA384(provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -673,7 +714,17 @@ public class ECDSAAlgorithmTest {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
-        when(provider.getPrivateKey()).thenReturn((ECPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return (ECPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((ECPublicKey) publicKey);
         Algorithm algorithm = Algorithm.ECDSA512(provider);
 
@@ -691,7 +742,17 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA512(provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -714,7 +775,7 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
@@ -731,7 +792,7 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
@@ -748,7 +809,7 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(isA(SignatureException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
@@ -765,16 +826,26 @@ public class ECDSAAlgorithmTest {
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm("some-alg", "some-algorithm", 32, provider);
 
-        assertThat(algorithm.getSigningKeyId(), is(nullValue()));
+        assertThat(algorithm.getPrivateKeyDetails().getPrivateKeyId(), is(nullValue()));
     }
 
     @Test
     public void shouldReturnSigningKeyIdFromProvider() {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("keyId");
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "keyId";
+            }
+        });
         Algorithm algorithm = new ECDSAAlgorithm("some-alg", "some-algorithm", 32, provider);
 
-        assertThat(algorithm.getSigningKeyId(), is("keyId"));
+        assertThat(algorithm.getPrivateKeyDetails().getPrivateKeyId(), is("keyId"));
     }
 
     @Test
@@ -1192,7 +1263,17 @@ public class ECDSAAlgorithmTest {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA256(provider);
         algorithm.sign(new byte[0]);
     }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
+import com.auth0.jwt.interfaces.PrivateKeyDetail;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -552,7 +553,17 @@ public class ECDSABouncyCastleProviderTests {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
-        when(provider.getPrivateKey()).thenReturn((ECPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return (ECPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((ECPublicKey) publicKey);
         Algorithm algorithm = Algorithm.ECDSA256(provider);
         
@@ -570,7 +581,17 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA256(provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -610,7 +631,17 @@ public class ECDSABouncyCastleProviderTests {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE_384, "EC");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
-        when(provider.getPrivateKey()).thenReturn((ECPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return (ECPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((ECPublicKey) publicKey);
         Algorithm algorithm = Algorithm.ECDSA384(provider);
         
@@ -628,7 +659,17 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA384(provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -670,7 +711,17 @@ public class ECDSABouncyCastleProviderTests {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE_512, "EC");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
-        when(provider.getPrivateKey()).thenReturn((ECPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return (ECPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((ECPublicKey) publicKey);
         Algorithm algorithm = Algorithm.ECDSA512(provider);
         String jwt = asJWT(algorithm, ES512Header, auth0IssPayload);
@@ -687,7 +738,17 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(hasMessage(is("The given Private Key is null.")));
 
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKey()).thenReturn(null);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return null;
+            }
+        });
         Algorithm algorithm = Algorithm.ECDSA512(provider);
         algorithm.sign(new byte[0], new byte[0]);
     }
@@ -710,7 +771,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
@@ -727,7 +788,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
@@ -744,7 +805,7 @@ public class ECDSABouncyCastleProviderTests {
         exception.expectCause(isA(SignatureException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
@@ -761,16 +822,26 @@ public class ECDSABouncyCastleProviderTests {
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm("some-alg", "some-algorithm", 32, provider);
 
-        assertThat(algorithm.getSigningKeyId(), is(nullValue()));
+        assertThat(algorithm.getPrivateKeyDetails().getPrivateKeyId(), is(nullValue()));
     }
 
     @Test
     public void shouldReturnSigningKeyIdFromProvider() {
         ECDSAKeyProvider provider = mock(ECDSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("keyId");
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<ECPrivateKey>() {
+            @Override
+            public ECPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "keyId";
+            }
+        });
         Algorithm algorithm = new ECDSAAlgorithm("some-alg", "some-algorithm", 32, provider);
 
-        assertThat(algorithm.getSigningKeyId(), is("keyId"));
+        assertThat(algorithm.getPrivateKeyDetails().getPrivateKeyId(), is("keyId"));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/HMACAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/HMACAlgorithmTest.java
@@ -252,7 +252,7 @@ public class HMACAlgorithmTest {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(byte[].class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(byte[].class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         Algorithm algorithm = new HMACAlgorithm(crypto, "some-alg", "some-algorithm", "secret".getBytes(StandardCharsets.UTF_8));
@@ -266,7 +266,7 @@ public class HMACAlgorithmTest {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(byte[].class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(byte[].class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         Algorithm algorithm = new HMACAlgorithm(crypto, "some-alg", "some-algorithm", "secret".getBytes(StandardCharsets.UTF_8));
@@ -274,8 +274,8 @@ public class HMACAlgorithmTest {
     }
 
     @Test
-    public void shouldReturnNullSigningKeyId() {
-        assertThat(Algorithm.HMAC256("secret").getSigningKeyId(), is(nullValue()));
+    public void shouldReturnNullPrivateKeyDetails() {
+        assertThat(Algorithm.HMAC256("secret").getPrivateKeyDetails(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/NoneAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/NoneAlgorithmTest.java
@@ -41,8 +41,8 @@ public class NoneAlgorithmTest {
     }
 
     @Test
-    public void shouldReturnNullSigningKeyId() {
-        assertThat(Algorithm.none().getSigningKeyId(), is(nullValue()));
+    public void shouldReturnNullPrivateKeyDetails() {
+        assertThat(Algorithm.none().getPrivateKeyDetails(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/RSAAlgorithmTest.java
@@ -3,6 +3,7 @@ package com.auth0.jwt.algorithms;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.PrivateKeyDetail;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,6 +11,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.security.*;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -298,7 +300,17 @@ public class RSAAlgorithmTest {
         RSAKeyProvider provider = mock(RSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA");
-        when(provider.getPrivateKey()).thenReturn((RSAPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<RSAPrivateKey>() {
+            @Override
+            public RSAPrivateKey getPrivateKey() {
+                return (RSAPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((RSAPublicKey) publicKey);
         Algorithm algorithm = Algorithm.RSA256(provider);
         
@@ -362,7 +374,17 @@ public class RSAAlgorithmTest {
         RSAKeyProvider provider = mock(RSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA");
-        when(provider.getPrivateKey()).thenReturn((RSAPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<RSAPrivateKey>() {
+            @Override
+            public RSAPrivateKey getPrivateKey() {
+                return (RSAPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((RSAPublicKey) publicKey);
         Algorithm algorithm = Algorithm.RSA384(provider);
         
@@ -426,7 +448,17 @@ public class RSAAlgorithmTest {
         RSAKeyProvider provider = mock(RSAKeyProvider.class);
         PrivateKey privateKey = readPrivateKeyFromFile(PRIVATE_KEY_FILE, "RSA");
         PublicKey publicKey = readPublicKeyFromFile(PUBLIC_KEY_FILE, "RSA");
-        when(provider.getPrivateKey()).thenReturn((RSAPrivateKey) privateKey);
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<RSAPrivateKey>() {
+            @Override
+            public RSAPrivateKey getPrivateKey() {
+                return (RSAPrivateKey) privateKey;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "my-key-id";
+            }
+        });
         when(provider.getPublicKeyById(null)).thenReturn((RSAPublicKey) publicKey);
         Algorithm algorithm = Algorithm.RSA512(provider);
         
@@ -467,7 +499,7 @@ public class RSAAlgorithmTest {
         exception.expectCause(isA(NoSuchAlgorithmException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(NoSuchAlgorithmException.class);
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
@@ -484,7 +516,7 @@ public class RSAAlgorithmTest {
         exception.expectCause(isA(InvalidKeyException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(InvalidKeyException.class);
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
@@ -501,7 +533,7 @@ public class RSAAlgorithmTest {
         exception.expectCause(isA(SignatureException.class));
 
         CryptoHelper crypto = mock(CryptoHelper.class);
-        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class), any(byte[].class)))
+        when(crypto.createSignatureFor(anyString(), any(PrivateKey.class), any(byte[].class)))
                 .thenThrow(SignatureException.class);
 
         RSAPublicKey publicKey = mock(RSAPublicKey.class);
@@ -518,16 +550,26 @@ public class RSAAlgorithmTest {
         RSAKeyProvider provider = RSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new RSAAlgorithm("some-alg", "some-algorithm", provider);
 
-        assertThat(algorithm.getSigningKeyId(), is(nullValue()));
+        assertThat(algorithm.getPrivateKeyDetails().getPrivateKeyId(), is(nullValue()));
     }
 
     @Test
     public void shouldReturnSigningKeyIdFromProvider() {
         RSAKeyProvider provider = mock(RSAKeyProvider.class);
-        when(provider.getPrivateKeyId()).thenReturn("keyId");
+        when(provider.getPrivateKeyDetails()).thenReturn(new PrivateKeyDetail<RSAPrivateKey>() {
+            @Override
+            public RSAPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public String getPrivateKeyId() {
+                return "keyId";
+            }
+        });
         Algorithm algorithm = new RSAAlgorithm("some-alg", "some-algorithm", provider);
 
-        assertThat(algorithm.getSigningKeyId(), is("keyId"));
+        assertThat(algorithm.getPrivateKeyDetails().getPrivateKeyId(), is("keyId"));
     }
 
     @Test


### PR DESCRIPTION
### Changes
- Added PrivateKeyDetail class
- Deprecated getPrivateKey and getPrivateKeyId
- Default Implementation for getPrivateKeyDetails
- Getting the Private Key at the point of signing and passing it as parameters so that another getPrivateKeyDetails which can change the Key details

### References
https://github.com/auth0/java-jwt/issues/503
https://github.com/auth0/java-jwt/pull/517

### Testing
Added a Key Rotation Test (Proposed in #517). This test takes a long time to complete which increases the CI time.
Fixed existing mocks

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

