### PR TITLE
[SDK-3311] Added protection against CVE-2022-21449

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A Java implementation of [JSON Web Token (JWT) - RFC 7519](https://tools.ietf.org/html/rfc7519).
 
+> :warning:  **Important security note:** JVM has a critical vulnerability for ECDSA Algorithms - [CVE-2022-21449](https://nvd.nist.gov/vuln/detail/CVE-2022-21449). Please review the details of the vulnerability and update your environment.
+
 If you're looking for an **Android** version of the JWT Decoder take a look at our [JWTDecode.Android](https://github.com/auth0/JWTDecode.Android) library.
 
 > This library requires Java 8 or higher. The last version that supported Java 7 was 3.11.0.

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -188,11 +188,6 @@ class ECDSAAlgorithm extends Algorithm {
             throw new SignatureException("Invalid JOSE signature format.");
         }
 
-        // check for 0 r or s here since we have the values
-        if (BigInteger.ZERO.equals(r) || BigInteger.ZERO.equals(s)) {
-            throw new SignatureException("R or S value cannot be zero.");
-        }
-
         BigInteger order = publicKey.getParams().getOrder();
 
         // R and S must be less than N

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -158,7 +158,7 @@ class ECDSAAlgorithm extends Algorithm {
         }
 
         if (isAllZeros(joseSignature)) {
-            throw new SignatureException("Invalid Signature: All Zeros.");
+            throw new SignatureException("Invalid signature format.");
         }
 
         // get R
@@ -166,7 +166,7 @@ class ECDSAAlgorithm extends Algorithm {
         System.arraycopy(joseSignature, 0, rBytes, 0, ecNumberSize);
         BigInteger r = new BigInteger(1, rBytes);
         if(isAllZeros(rBytes)) {
-            throw new SignatureException("Invalid Signature: All Zeros for R value.");
+            throw new SignatureException("Invalid signature format.");
         }
 
         // get S
@@ -174,7 +174,7 @@ class ECDSAAlgorithm extends Algorithm {
         System.arraycopy(joseSignature, ecNumberSize, sBytes, 0, ecNumberSize);
         BigInteger s = new BigInteger(1, sBytes);
         if(isAllZeros(sBytes)) {
-            throw new SignatureException("Invalid Signature: All Zeros for S value.");
+            throw new SignatureException("Invalid signature format.");
         }
 
         //moved this check from JOSEToDER method
@@ -192,11 +192,11 @@ class ECDSAAlgorithm extends Algorithm {
 
         // R and S must be less than N
         if (order.compareTo(r) < 1) {
-            throw new SignatureException("The difference between R value and order should be greater than one.");
+            throw new SignatureException("Invalid signature format.");
         }
 
         if (order.compareTo(s) < 1){
-            throw new SignatureException("The difference between S value and order should be greater than one.");
+            throw new SignatureException("Invalid signature format.");
         }
     }
 

--- a/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
+++ b/lib/src/main/java/com/auth0/jwt/algorithms/ECDSAAlgorithm.java
@@ -191,8 +191,12 @@ class ECDSAAlgorithm extends Algorithm {
         BigInteger order = publicKey.getParams().getOrder();
 
         // R and S must be less than N
-        if (order.compareTo(r) < 1 || order.compareTo(s) < 1) {
-            throw new SignatureException("The difference between R or S value and order should be greater than one.");
+        if (order.compareTo(r) < 1) {
+            throw new SignatureException("The difference between R value and order should be greater than one.");
+        }
+
+        if (order.compareTo(s) < 1){
+            throw new SignatureException("The difference between S value and order should be greater than one.");
         }
     }
 

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -1429,7 +1429,7 @@ public class ECDSAAlgorithmTest {
     }
 
     @Test
-    public void signatureWithRSValueNotLessThanOrderShouldFail() throws Exception {
+    public void signatureWithRValueNotLessThanOrderShouldFail() throws Exception {
         exception.expect(SignatureException.class);
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
@@ -1440,6 +1440,24 @@ public class ECDSAAlgorithmTest {
 
         String[] chunks = jwtWithInvalidSig.split("\\.");
         byte[] invalidSignature = Base64.getUrlDecoder().decode(chunks[2]);
+
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, privateKey);
+        algorithm256.validateSignatureStructure(invalidSignature, publicKey);
+    }
+
+    @Test
+    public void signatureWithSValueNotLessThanOrderShouldFail() throws Exception {
+        exception.expect(SignatureException.class);
+
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
+
+        String signedJwt = JWT.create().sign(Algorithm.ECDSA256(publicKey, privateKey));
+        String jwtWithInvalidSig = signedJwt.substring(0, signedJwt.lastIndexOf('.') + 1) + "_____wAAAAD__________7zm-q2nF56E87nKwvxjJVH_____AAAAAP__________vOb6racXnoTzucrC_GMlUQ";
+
+        String[] chunks = jwtWithInvalidSig.split("\\.");
+        byte[] invalidSignature = Base64.getUrlDecoder().decode(chunks[2]);
+        invalidSignature[0] = Byte.MAX_VALUE;
 
         ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, privateKey);
         algorithm256.validateSignatureStructure(invalidSignature, publicKey);

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -1370,7 +1370,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithAllZerosShouldFail() throws Exception {
         exception.expect(SignatureException.class);
-        exception.expectMessage("Invalid Signature: All Zeros.");
+        exception.expectMessage("Invalid signature format.");
 
         ECPublicKey pubKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
 
@@ -1382,7 +1382,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithRZeroShouldFail() throws Exception {
         exception.expect(SignatureException.class);
-        exception.expectMessage("Invalid Signature: All Zeros for R value.");
+        exception.expectMessage("Invalid signature format.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
@@ -1408,7 +1408,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithSZeroShouldFail() throws Exception {
         exception.expect(SignatureException.class);
-        exception.expectMessage("Invalid Signature: All Zeros for S value.");
+        exception.expectMessage("Invalid signature format.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
@@ -1434,7 +1434,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithRValueNotLessThanOrderShouldFail() throws Exception {
         exception.expect(SignatureException.class);
-        exception.expectMessage("The difference between R value and order should be greater than one.");
+        exception.expectMessage("Invalid signature format.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
@@ -1452,7 +1452,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithSValueNotLessThanOrderShouldFail() throws Exception {
         exception.expect(SignatureException.class);
-        exception.expectMessage("The difference between S value and order should be greater than one.");
+        exception.expectMessage("Invalid signature format.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -1370,6 +1370,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithAllZerosShouldFail() throws Exception {
         exception.expect(SignatureException.class);
+        exception.expectMessage("Invalid Signature: All Zeros.");
 
         ECPublicKey pubKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
 
@@ -1381,6 +1382,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithRZeroShouldFail() throws Exception {
         exception.expect(SignatureException.class);
+        exception.expectMessage("Invalid Signature: All Zeros for R value.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
@@ -1406,6 +1408,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithSZeroShouldFail() throws Exception {
         exception.expect(SignatureException.class);
+        exception.expectMessage("Invalid Signature: All Zeros for S value.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
@@ -1431,6 +1434,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithRValueNotLessThanOrderShouldFail() throws Exception {
         exception.expect(SignatureException.class);
+        exception.expectMessage("The difference between R value and order should be greater than one.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
@@ -1448,6 +1452,7 @@ public class ECDSAAlgorithmTest {
     @Test
     public void signatureWithSValueNotLessThanOrderShouldFail() throws Exception {
         exception.expect(SignatureException.class);
+        exception.expectMessage("The difference between S value and order should be greater than one.");
 
         ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
         ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSAAlgorithmTest.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
+import com.auth0.jwt.interfaces.JWTVerifier;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIn;
 import org.junit.Assert;
@@ -12,11 +13,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -574,6 +577,10 @@ public class ECDSAAlgorithmTest {
                 .thenThrow(NoSuchAlgorithmException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
+        when(publicKey.getParams()).thenReturn(mock(ECParameterSpec.class));
+        byte[] a = new byte[64];
+        Arrays.fill(a, Byte.MAX_VALUE);
+        when(publicKey.getParams().getOrder()).thenReturn(new BigInteger(a));
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
@@ -592,6 +599,10 @@ public class ECDSAAlgorithmTest {
                 .thenThrow(InvalidKeyException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
+        when(publicKey.getParams()).thenReturn(mock(ECParameterSpec.class));
+        byte[] a = new byte[64];
+        Arrays.fill(a, Byte.MAX_VALUE);
+        when(publicKey.getParams().getOrder()).thenReturn(new BigInteger(a));
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
@@ -610,6 +621,10 @@ public class ECDSAAlgorithmTest {
                 .thenThrow(SignatureException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
+        when(publicKey.getParams()).thenReturn(mock(ECParameterSpec.class));
+        byte[] a = new byte[64];
+        Arrays.fill(a, Byte.MAX_VALUE);
+        when(publicKey.getParams().getOrder()).thenReturn(new BigInteger(a));
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
@@ -939,12 +954,13 @@ public class ECDSAAlgorithmTest {
 
     @Test
     public void shouldThrowOnJOSESignatureConversionIfDoesNotHaveExpectedLength() throws Exception {
-        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
         byte[] joseSignature = new byte[32 * 2 - 1];
         exception.expect(SignatureException.class);
         exception.expectMessage("Invalid JOSE signature format.");
 
-        algorithm256.JOSEToDER(joseSignature);
+        algorithm256.validateSignatureStructure(joseSignature, publicKey);
     }
 
     @Test
@@ -1309,4 +1325,123 @@ public class ECDSAAlgorithmTest {
         algorithm.sign(new byte[0]);
     }
 
+    @Test
+    public void invalidECDSA256SignatureShouldFailTokenVerification() throws Exception {
+        exception.expect(SignatureVerificationException.class);
+        exception.expectCause(isA(SignatureException.class));
+
+        String jwtWithInvalidSig = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0._____wAAAAD__________7zm-q2nF56E87nKwvxjJVH_____AAAAAP__________vOb6racXnoTzucrC_GMlUQ";
+
+        ECKey key256 = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECKey key384 = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
+        ECKey key512 = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
+        ECKey key256k = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256K, "EC");
+        JWTVerifier verifier256 = JWT.require(Algorithm.ECDSA256(key256)).build();
+        JWTVerifier verifier384 = JWT.require(Algorithm.ECDSA256(key384)).build();
+        JWTVerifier verifier512 = JWT.require(Algorithm.ECDSA256(key512)).build();
+        JWTVerifier verifier256k = JWT.require(Algorithm.ECDSA256(key256k)).build();
+        verifier256.verify(jwtWithInvalidSig);
+        verifier384.verify(jwtWithInvalidSig);
+        verifier512.verify(jwtWithInvalidSig);
+        verifier256k.verify(jwtWithInvalidSig);
+    }
+
+    @Test
+    public void emptyECDSA256SignatureShouldFailTokenVerification() throws Exception {
+        exception.expect(SignatureVerificationException.class);
+        exception.expectCause(isA(SignatureException.class));
+
+        String jwtWithInvalidSig = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        ECKey key256 = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECKey key384 = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_384, "EC");
+        ECKey key512 = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_512, "EC");
+        ECKey key256k = (ECKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256K, "EC");
+        JWTVerifier verifier256 = JWT.require(Algorithm.ECDSA256(key256)).build();
+        JWTVerifier verifier384 = JWT.require(Algorithm.ECDSA256(key384)).build();
+        JWTVerifier verifier512 = JWT.require(Algorithm.ECDSA256(key512)).build();
+        JWTVerifier verifier256k = JWT.require(Algorithm.ECDSA256(key256k)).build();
+        verifier256.verify(jwtWithInvalidSig);
+        verifier384.verify(jwtWithInvalidSig);
+        verifier512.verify(jwtWithInvalidSig);
+        verifier256k.verify(jwtWithInvalidSig);
+    }
+
+    @Test
+    public void signatureWithAllZerosShouldFail() throws Exception {
+        exception.expect(SignatureException.class);
+
+        ECPublicKey pubKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(pubKey, (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
+        byte[] signatureBytes = new byte[64];
+        algorithm256.validateSignatureStructure(signatureBytes, pubKey);
+    }
+
+    @Test
+    public void signatureWithRZeroShouldFail() throws Exception {
+        exception.expect(SignatureException.class);
+
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
+
+        String signedJwt = JWT.create().sign(Algorithm.ECDSA256(publicKey, privateKey));
+
+        String[] chunks = signedJwt.split("\\.");
+        byte[] signature = Base64.getUrlDecoder().decode(chunks[2]);
+
+        byte[] sigWithBlankR = new byte[signature.length];
+        for (int i = 0; i < signature.length; i++) {
+            if (i < signature.length / 2) {
+                sigWithBlankR[i] = 0;
+            } else {
+                sigWithBlankR[i] = signature[i];
+            }
+        }
+
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, privateKey);
+        algorithm256.validateSignatureStructure(sigWithBlankR, publicKey);
+    }
+
+    @Test
+    public void signatureWithSZeroShouldFail() throws Exception {
+        exception.expect(SignatureException.class);
+
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
+
+        String signedJwt = JWT.create().sign(Algorithm.ECDSA256(publicKey, privateKey));
+
+        String[] chunks = signedJwt.split("\\.");
+        byte[] signature = Base64.getUrlDecoder().decode(chunks[2]);
+
+        byte[] sigWithBlankS = new byte[signature.length];
+        for (int i = 0; i < signature.length; i++) {
+            if (i < signature.length / 2) {
+                sigWithBlankS[i] = signature[i];
+            } else {
+                sigWithBlankS[i] = 0;
+            }
+        }
+
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, privateKey);
+        algorithm256.validateSignatureStructure(sigWithBlankS, publicKey);
+    }
+
+    @Test
+    public void signatureWithRSValueNotLessThanOrderShouldFail() throws Exception {
+        exception.expect(SignatureException.class);
+
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECPrivateKey privateKey = (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC");
+
+        String signedJwt = JWT.create().sign(Algorithm.ECDSA256(publicKey, privateKey));
+        String jwtWithInvalidSig = signedJwt.substring(0, signedJwt.lastIndexOf('.') + 1) + "_____wAAAAD__________7zm-q2nF56E87nKwvxjJVH_____AAAAAP__________vOb6racXnoTzucrC_GMlUQ";
+
+        String[] chunks = jwtWithInvalidSig.split("\\.");
+        byte[] invalidSignature = Base64.getUrlDecoder().decode(chunks[2]);
+
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, privateKey);
+        algorithm256.validateSignatureStructure(invalidSignature, publicKey);
+    }
 }

--- a/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
+++ b/lib/src/test/java/com/auth0/jwt/algorithms/ECDSABouncyCastleProviderTests.java
@@ -11,11 +11,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.util.Arrays;
 import java.util.Base64;
 
 import static com.auth0.jwt.PemUtils.readPrivateKeyFromFile;
@@ -591,6 +594,10 @@ public class ECDSABouncyCastleProviderTests {
                 .thenThrow(NoSuchAlgorithmException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
+        when(publicKey.getParams()).thenReturn(mock(ECParameterSpec.class));
+        byte[] a = new byte[64];
+        Arrays.fill(a, Byte.MAX_VALUE);
+        when(publicKey.getParams().getOrder()).thenReturn(new BigInteger(a));
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
@@ -609,6 +616,10 @@ public class ECDSABouncyCastleProviderTests {
                 .thenThrow(InvalidKeyException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
+        when(publicKey.getParams()).thenReturn(mock(ECParameterSpec.class));
+        byte[] a = new byte[64];
+        Arrays.fill(a, Byte.MAX_VALUE);
+        when(publicKey.getParams().getOrder()).thenReturn(new BigInteger(a));
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
@@ -627,6 +638,10 @@ public class ECDSABouncyCastleProviderTests {
                 .thenThrow(SignatureException.class);
 
         ECPublicKey publicKey = mock(ECPublicKey.class);
+        when(publicKey.getParams()).thenReturn(mock(ECParameterSpec.class));
+        byte[] a = new byte[64];
+        Arrays.fill(a, Byte.MAX_VALUE);
+        when(publicKey.getParams().getOrder()).thenReturn(new BigInteger(a));
         ECPrivateKey privateKey = mock(ECPrivateKey.class);
         ECDSAKeyProvider provider = ECDSAAlgorithm.providerForKeys(publicKey, privateKey);
         Algorithm algorithm = new ECDSAAlgorithm(crypto, "some-alg", "some-algorithm", 32, provider);
@@ -935,12 +950,13 @@ public class ECDSABouncyCastleProviderTests {
 
     @Test
     public void shouldThrowOnJOSESignatureConversionIfDoesNotHaveExpectedLength() throws Exception {
-        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256((ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC"), (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
+        ECPublicKey publicKey = (ECPublicKey) readPublicKeyFromFile(PUBLIC_KEY_FILE_256, "EC");
+        ECDSAAlgorithm algorithm256 = (ECDSAAlgorithm) Algorithm.ECDSA256(publicKey, (ECPrivateKey) readPrivateKeyFromFile(PRIVATE_KEY_FILE_256, "EC"));
         byte[] joseSignature = new byte[32 * 2 - 1];
         exception.expect(SignatureException.class);
         exception.expectMessage("Invalid JOSE signature format.");
 
-        algorithm256.JOSEToDER(joseSignature);
+        algorithm256.validateSignatureStructure(joseSignature, publicKey);
     }
 
     @Test


### PR DESCRIPTION
### Changes
This PR will implement defence against CVE-2022-21449 by validating the signatures structure so that
- The entire signature is not filled with zero
- The value of R and S are not zero
- The value of R and S are not less than 1 compared to the ECDSA Algorithm's order

### References
- [CVE-2022-21449](https://nvd.nist.gov/vuln/detail/CVE-2022-21449)

### Testing
We have added Unit Tests to check for the vulnerable signature. We have ensured the logic we use to validate the signature is also unit tested

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not
