### PR TITLE
Release 3.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.19.2](https://github.com/auth0/java-jwt/tree/3.19.2) (2022-05-05)
+[Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.1...3.19.2)
+
+**Security**
+- [SDK-3311] Added protection against CVE-2022-21449 [\#579](https://github.com/auth0/java-jwt/pull/579) ([poovamraj](https://github.com/poovamraj))
+
 ## [3.19.1](https://github.com/auth0/java-jwt/tree/3.19.1) (2022-03-30)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.0...3.19.1)
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The library is available on both Maven Central and Bintray, and the Javadoc is p
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>java-jwt</artifactId>
-    <version>3.19.1</version>
+    <version>3.19.2</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation 'com.auth0:java-jwt:3.19.1'
+implementation 'com.auth0:java-jwt:3.19.2'
 ```
 
 ## Available Algorithms


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.1...3.19.2)

**Security**
- [SDK-3311] Added protection against CVE-2022-21449 [\#579](https://github.com/auth0/java-jwt/pull/579) ([poovamraj](https://github.com/poovamraj))

[SDK-3311]: https://auth0team.atlassian.net/browse/SDK-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ