### PR TITLE
[SDK-3170] reenable api-diff check for 4.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,16 +41,16 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
       _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
       TERM: dumb
-    api-diff:
-      docker:
-        - image: openjdk:11.0-jdk
-      steps:
-        - checkout-and-build
-        - run-api-diff
-      environment:
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-        _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
-        TERM: dumb
+  api-diff:
+    docker:
+      - image: openjdk:11.0-jdk
+    steps:
+      - checkout-and-build
+      - run-api-diff
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+      _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+      TERM: dumb
 
 workflows:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,14 @@ commands:
     steps:
       - run: ./gradlew check jacocoTestReport --continue --console=plain
       - codecov/upload
-#  TODO re-enable once 4.0.0 is released
-#  run-api-diff:
-#    steps:
-#      # run apiDiff task
-#      - run: ./gradlew apiDiff
-#      - store_artifacts:
-#          path: lib/build/reports/apiDiff/apiDiff.txt
-#      - store_artifacts:
-#          path: lib/build/reports/apiDiff/apiDiff.html
+  run-api-diff:
+    steps:
+      # run apiDiff task
+      - run: ./gradlew apiDiff
+      - store_artifacts:
+          path: lib/build/reports/apiDiff/apiDiff.txt
+      - store_artifacts:
+          path: lib/build/reports/apiDiff/apiDiff.html
 jobs:
   build:
     docker:
@@ -42,21 +41,21 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
       _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
       TERM: dumb
-  #  api-diff:
-  #    docker:
-  #      - image: openjdk:11.0-jdk
-  #    steps:
-  #      - checkout-and-build
-  #      - run-api-diff
-  #    environment:
-  #      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-  #      _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
-  #      TERM: dumb
+    api-diff:
+      docker:
+        - image: openjdk:11.0-jdk
+      steps:
+        - checkout-and-build
+        - run-api-diff
+      environment:
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+        _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+        TERM: dumb
 
 workflows:
   build-and-test:
     jobs:
       - build
-#  api-diff:
-#    jobs:
-#      - api-diff
+  api-diff:
+    jobs:
+      - api-diff

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,7 +17,7 @@ oss {
     repository "java-jwt"
     organization "auth0"
     description "Java implementation of JSON Web Token (JWT)"
-    baselineCompareVersion "3.18.2"
+    baselineCompareVersion "4.0.0"
 
     developers {
         auth0 {


### PR DESCRIPTION
### Changes

We previously disabled `api-diff` check for development for 4.0.0 since there were breaking changes. Now that 4.0.0 is released, we will enable 4.0.0 again

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
