### PR TITLE
Check for null token before splitting

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/TokenUtils.java
+++ b/lib/src/main/java/com/auth0/jwt/TokenUtils.java
@@ -12,6 +12,9 @@ abstract class TokenUtils {
      * @throws JWTDecodeException if the Token doesn't have 3 parts.
      */
     static String[] splitToken(String token) throws JWTDecodeException {
+        if (token == null) {
+            throw new JWTDecodeException("The token is null.");
+        }
         String[] parts = token.split("\\.");
         if (parts.length == 2 && token.endsWith(".")) {
             //Tokens with alg='none' have empty String as Signature.

--- a/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
+++ b/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
@@ -52,4 +52,11 @@ public class TokenUtilsTest {
         String token = "two.parts";
         TokenUtils.splitToken(token);
     }
+
+    @Test
+    public void shouldThrowOnSplitTokenWithNullValue() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage("The token is null.");
+        TokenUtils.splitToken(null);
+    }
 }


### PR DESCRIPTION
### Changes

Checks the token for `null` value before splitting the token parts.

Replaces #587 with additional test. Thanks @anderuraga for raising the original PR!