### PR TITLE
Update to gradle 6.9.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -44,7 +44,7 @@ java {
 compileJava {
     exclude 'module-info.java'
     // Required to be compatible with JDK 8+
-    options.compilerArgs = ['--release', "8"]
+    options.release = 8
 }
 
 javadoc {
@@ -99,7 +99,8 @@ task compileModuleInfoJava(type: JavaCompile) {
 }
 
 compileTestJava {
-    options.compilerArgs = ['--release', "8", "-Xlint:deprecation"]
+    options.release = 8
+    options.compilerArgs = ["-Xlint:deprecation"]
 }
 
 def testJava8 = tasks.register('testJava8', Test) {


### PR DESCRIPTION
Updates to Gradle 6.9.2. This addresses some issues using the toolchains feature with M1 chip. Needed to specify the release target via `options.release` instead of `compilerArgs` to resolve error `Cannot specify --release via 'CompileOptions.compilerArgs' when using 'JavaCompile.release'` ([discussion](https://github.com/auth0/oss-library-gradle-plugin/pull/32))