### PR TITLE
Add Ship CLI support

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,6 @@
+{
+  "files": {
+    "README.md": []
+  },
+  "prefixVersion": false
+}


### PR DESCRIPTION
Adds support for using the Ship CLI to generate the changelog and prepare the release PR. Note that this does not add support for publishing yet, as some work needs to be completed on the orb first. When available, we will update the `.shiprc` config to support publishing as well.