### PR TITLE
Optimise TokenUtils parsing

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/TokenUtils.java
+++ b/lib/src/main/java/com/auth0/jwt/TokenUtils.java
@@ -15,15 +15,33 @@ abstract class TokenUtils {
         if (token == null) {
             throw new JWTDecodeException("The token is null.");
         }
-        String[] parts = token.split("\\.");
-        if (parts.length == 2 && token.endsWith(".")) {
-            //Tokens with alg='none' have empty String as Signature.
-            parts = new String[]{parts[0], parts[1], ""};
+
+        char delimiter = '.';
+
+        int firstPeriodIndex = token.indexOf(delimiter);
+        if(firstPeriodIndex == -1) {
+           throw wrongNumberOfParts(0);
         }
-        if (parts.length != 3) {
-            throw new JWTDecodeException(
-                    String.format("The token was expected to have 3 parts, but got %s.", parts.length));
+
+        int secondPeriodIndex = token.indexOf(delimiter, firstPeriodIndex + 1);
+        if(secondPeriodIndex == -1) {
+            throw wrongNumberOfParts(2);
         }
+
+        // too many ?
+        if(token.indexOf(delimiter, secondPeriodIndex + 1) != -1) {
+            throw wrongNumberOfParts("> 3");
+        }
+
+        String[] parts = new String[3];
+        parts[0] = token.substring(0, firstPeriodIndex);
+        parts[1] = token.substring(firstPeriodIndex + 1, secondPeriodIndex);
+        parts[2] = token.substring(secondPeriodIndex + 1);
+
         return parts;
+    }
+
+    private static JWTDecodeException wrongNumberOfParts(Object partCount) {
+        throw new JWTDecodeException(String.format("The token was expected to have 3 parts, but got %s.", partCount));
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/TokenUtils.java
+++ b/lib/src/main/java/com/auth0/jwt/TokenUtils.java
@@ -19,17 +19,17 @@ abstract class TokenUtils {
         char delimiter = '.';
 
         int firstPeriodIndex = token.indexOf(delimiter);
-        if(firstPeriodIndex == -1) {
-           throw wrongNumberOfParts(0);
+        if (firstPeriodIndex == -1) {
+            throw wrongNumberOfParts(0);
         }
 
         int secondPeriodIndex = token.indexOf(delimiter, firstPeriodIndex + 1);
-        if(secondPeriodIndex == -1) {
+        if (secondPeriodIndex == -1) {
             throw wrongNumberOfParts(2);
         }
 
         // too many ?
-        if(token.indexOf(delimiter, secondPeriodIndex + 1) != -1) {
+        if (token.indexOf(delimiter, secondPeriodIndex + 1) != -1) {
             throw wrongNumberOfParts("> 3");
         }
 

--- a/lib/src/main/java/com/auth0/jwt/TokenUtils.java
+++ b/lib/src/main/java/com/auth0/jwt/TokenUtils.java
@@ -42,6 +42,6 @@ abstract class TokenUtils {
     }
 
     private static JWTDecodeException wrongNumberOfParts(Object partCount) {
-        throw new JWTDecodeException(String.format("The token was expected to have 3 parts, but got %s.", partCount));
+        return new JWTDecodeException(String.format("The token was expected to have 3 parts, but got %s.", partCount));
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -50,7 +50,7 @@ public class JWTDecoderTest {
     @Test
     public void shouldThrowIfMoreThan3Parts() {
         exception.expect(JWTDecodeException.class);
-        exception.expectMessage("The token was expected to have 3 parts, but got 4.");
+        exception.expectMessage("The token was expected to have 3 parts, but got > 3.");
         JWT.decode("this.has.four.parts");
     }
 

--- a/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
+++ b/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
@@ -70,7 +70,15 @@ public class TokenUtilsTest {
     }
 
     @Test
-    public void shouldThrowOnSplitTokenWithLessThan3Parts() {
+    public void shouldThrowOnSplitTokenWithNoParts() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage("The token was expected to have 3 parts, but got 0.");
+        String token = "notajwt";
+        TokenUtils.splitToken(token);
+    }
+
+    @Test
+    public void shouldThrowOnSplitTokenWith2Parts() {
         exception.expect(JWTDecodeException.class);
         exception.expectMessage("The token was expected to have 3 parts, but got 2.");
         String token = "two.parts";

--- a/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
+++ b/lib/src/test/java/com/auth0/jwt/TokenUtilsTest.java
@@ -14,6 +14,30 @@ public class TokenUtilsTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
+    public void toleratesEmptyFirstPart() {
+        String token = ".eyJpc3MiOiJhdXRoMCJ9.W1mx_Y0hbAMbPmfW9whT605AAcxB7REFuJiDAHk2Sdc";
+        String[] parts = TokenUtils.splitToken(token);
+
+        assertThat(parts, is(notNullValue()));
+        assertThat(parts, is(arrayWithSize(3)));
+        assertThat(parts[0], is(""));
+        assertThat(parts[1], is("eyJpc3MiOiJhdXRoMCJ9"));
+        assertThat(parts[2], is("W1mx_Y0hbAMbPmfW9whT605AAcxB7REFuJiDAHk2Sdc"));
+    }
+
+    @Test
+    public void toleratesEmptySecondPart() {
+        String token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0..W1mx_Y0hbAMbPmfW9whT605AAcxB7REFuJiDAHk2Sdc";
+        String[] parts = TokenUtils.splitToken(token);
+
+        assertThat(parts, is(notNullValue()));
+        assertThat(parts, is(arrayWithSize(3)));
+        assertThat(parts[0], is("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"));
+        assertThat(parts[1], is(""));
+        assertThat(parts[2], is("W1mx_Y0hbAMbPmfW9whT605AAcxB7REFuJiDAHk2Sdc"));
+    }
+
+    @Test
     public void shouldSplitToken() {
         String token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJhdXRoMCJ9.W1mx_Y0hbAMbPmfW9whT605AAcxB7REFuJiDAHk2Sdc";
         String[] parts = TokenUtils.splitToken(token);
@@ -34,13 +58,13 @@ public class TokenUtilsTest {
         assertThat(parts, is(arrayWithSize(3)));
         assertThat(parts[0], is("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"));
         assertThat(parts[1], is("eyJpc3MiOiJhdXRoMCJ9"));
-        assertThat(parts[2], is(isEmptyString()));
+        assertThat(parts[2], is(emptyString()));
     }
 
     @Test
     public void shouldThrowOnSplitTokenWithMoreThan3Parts() {
         exception.expect(JWTDecodeException.class);
-        exception.expectMessage("The token was expected to have 3 parts, but got 4.");
+        exception.expectMessage("The token was expected to have 3 parts, but got > 3.");
         String token = "this.has.four.parts";
         TokenUtils.splitToken(token);
     }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

_We've been using the project for a while and I'm a fan.  I was in for our 4.0 upgrade and thought I would see if I could find some small thing to start giving back.  This optimises the TokenUtils parsing by relying on the JWT format is very specific.  In particular:

1. The format is checked to be good before any array is allocated.
2. In the case of alg='none', two array allocations are not required._


### References

Please include relevant links supporting this change such as a:

_No references to note_


### Testing 

_Existing TokenUtils test had good coverage.  Added a couple of test cases for corner case odd string inputs._

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
