### PR TITLE
Update Claim#asString documentation

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/Claim.java
@@ -62,9 +62,10 @@ public interface Claim {
 
     /**
      * Get this Claim as a String.
-     * If the value isn't of type String or it can't be converted to a String, {@code null} will be returned.
+     * If the value isn't of type String, {@code null} will be returned. For a String representation of non-textual
+     * claim types, clients can call {@code toString()}.
      *
-     * @return the value as a String or null.
+     * @return the value as a String or null if the underlying value is not a string.
      */
     String asString();
 


### PR DESCRIPTION
The documentation for a claim's `asString()` method is misleading. We don't return the `toString()` result of all underlying claim types, as the JavaDoc's somewhat currently imply. Instead, we check if it is a text-based claim (i.e., a string) before returning its textual value.

Perhaps in the future we should just get the textual value regardless of underlying type, but that could have impact on clients relying on the `null` return values for non-string based claims.

This change updates the docs to reflect the actual behavior.

Closes #614 