### PR TITLE
Update .shiprc to only update lib version in build.gradle

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,7 +1,7 @@
 {
   "files": {
     "README.md": [],
-    "lib/build.gradle": []
+    "lib/build.gradle": ["version[[:blank:]]*=[[:blank:]]*{MAJOR}.{MINOR}.{PATCH}"]
   },
   "prefixVersion": false
 }


### PR DESCRIPTION
This change updates the `.shiprc` to ensure that only the `version = x.x.x` in `lib/build.gradle` is updated.