### PR TITLE
Fix .shiprc build.gradle version substitution pattern

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,7 +1,7 @@
 {
   "files": {
     "README.md": [],
-    "lib/build.gradle": ['version = "{MAJOR}.{MINOR}.{PATCH}"']
+    "lib/build.gradle": ["version = \"{MAJOR}.{MINOR}.{PATCH}\""]
   },
   "prefixVersion": false
 }

--- a/.shiprc
+++ b/.shiprc
@@ -1,7 +1,7 @@
 {
   "files": {
     "README.md": [],
-    "lib/build.gradle": ["version[[:blank:]]*=[[:blank:]]*{MAJOR}.{MINOR}.{PATCH}"]
+    "lib/build.gradle": ['version = "{MAJOR}.{MINOR}.{PATCH}"']
   },
   "prefixVersion": false
 }


### PR DESCRIPTION
Fixes the quotes in the build.gradle file version replacement pattern, and also removes the `[[blank]]*` in case that was also causing an issue (and is simpler without it anyways).