### PR TITLE
Bump `com.fasterxml.jackson.core:jackson-databind` to 2.13.4.2

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -65,7 +65,7 @@ javadoc {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
Resolves https://www.cve.org/CVERecord?id=CVE-2022-42003