### PR TITLE
Remove emoji to fix the broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Algorithm algorithmRS = Algorithm.RSA256(publicKey, privateKey);
 
 > Note: How you obtain or read keys is not in the scope of this library. For an example of how you might implement this, see [this gist](https://gist.github.com/lbalmaceda/9a0c7890c2965826c04119dcfb1a5469).
 
-##### :key: HMAC Key Length and Security
+##### HMAC Key Length and Security
 
 When using a Hash-based Message Authentication Code, e.g. HS256 or HS512, in order to comply with the strict requirements of the JSON Web Algorithms (JWA) specification (RFC7518), you **must** use a secret key which has the same (or larger) bit length as the size of the output hash. This is to avoid weakening the security strength of the authentication code (see NIST recommendations NIST SP 800-117). For example, when using HMAC256, the secret key length must be a minimum of 256 bits.
 


### PR DESCRIPTION
Problem: emoji in the section name breaks [already existing JavaDoc links](https://github.com/auth0/java-jwt/blob/c8d0ba995543c9cee50abe9f4aa4f9873b29489f/lib/src/main/java/com/auth0/jwt/algorithms/Algorithm.java#L135). Regression introduced in https://github.com/auth0/java-jwt/commit/df004b1bc55ed42f9ccb1d2b820bad08879ad273.

Solution: remove emoji to bring the anchor name back to its original state.