### PR TITLE
Update to the latest ship orb version (v3)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.7.2
+  ship: auth0/ship@0
   codecov: codecov/codecov@3
 
 commands:


### PR DESCRIPTION
We need at least `0.7.3` to successfully publish java libs. As discussed, we will just update to latest of v0 as the orb (that we own) has demonstrated stability. 