### PR TITLE
Update to gradle `6.9.3`

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -51,7 +51,7 @@ java {
 compileJava {
     exclude 'module-info.java'
     // Required to be compatible with JDK 8+
-    options.compilerArgs = ['--release', "8"]
+    options.release = 8
 }
 
 javadoc {


### PR DESCRIPTION
Updates to gradle 6.9.3 to fix gradle build issues when running on M1 silicon.