### PR TITLE
Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [4.2.1](https://github.com/auth0/java-jwt/tree/4.2.1) (2022-10-24)
+[Full Changelog](https://github.com/auth0/java-jwt/compare/4.2.0...4.2.1)
+
+**Security**
+- Use latest ship orb [\#634](https://github.com/auth0/java-jwt/pull/634) ([jimmyjames](https://github.com/jimmyjames))
+- Bump `com.fasterxml.jackson.core:jackson-databind` to 2.13.4.2 [\#630](https://github.com/auth0/java-jwt/pull/630) ([evansims](https://github.com/evansims))
+
 ## [4.2.0](https://github.com/auth0/java-jwt/tree/4.2.0) (2022-10-19)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/4.1.0...4.2.0)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This library is supported for Java 8, 11, and 17. For issues on non-LTS versions
 ### Gradle
 
 ```gradle
-implementation 'com.auth0:java-jwt:4.2.0'
+implementation 'com.auth0:java-jwt:4.2.1'
 ```
 
 ### Maven
@@ -48,7 +48,7 @@ implementation 'com.auth0:java-jwt:4.2.0'
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>java-jwt</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    version = "4.2.0"
+    version = "4.2.1"
 }
 
 plugins {


### PR DESCRIPTION
**Security**
- Bump `com.fasterxml.jackson.core:jackson-databind` to 2.13.4.2 [\#630](https://github.com/auth0/java-jwt/pull/630) ([evansims](https://github.com/evansims))
