### PR TITLE
Release 3.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.19.3](https://github.com/auth0/java-jwt/tree/3.19.3) (2022-10-24)
+[Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.2...3.19.3)
+
+**Security**
+- Update com.fasterxml.jackson.core:jackson-databind to 2.13.4.2 [\#631](https://github.com/auth0/java-jwt/pull/631) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [3.19.2](https://github.com/auth0/java-jwt/tree/3.19.2) (2022-05-05)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/3.19.1...3.19.2)
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The library is available on both Maven Central and Bintray, and the Javadoc is p
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>java-jwt</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation 'com.auth0:java-jwt:3.19.2'
+implementation 'com.auth0:java-jwt:3.19.3'
 ```
 
 ## Available Algorithms

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    version = "3.19.2"
+    version = "3.19.3"
 }
 
 plugins {


### PR DESCRIPTION
**Security**
- Update com.fasterxml.jackson.core:jackson-databind to 2.13.4.2 [\#631](https://github.com/auth0/java-jwt/pull/631) ([jimmyjames](https://github.com/jimmyjames))
