### PR TITLE
Release 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.2.2](https://github.com/auth0/java-jwt/tree/4.2.2) (2023-01-11)
+[Full Changelog](https://github.com/auth0/java-jwt/compare/4.2.1...4.2.2)
+
+This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
+Please review [the README note for additional details.](https://github.com/auth0/java-jwt/blob/master/README.md)
+
 ## [4.2.1](https://github.com/auth0/java-jwt/tree/4.2.1) (2022-10-24)
 [Full Changelog](https://github.com/auth0/java-jwt/compare/4.2.0...4.2.1)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **Note**
+> As part of our ongoing commitment to best security practices, we have rotated the signing keys used to sign previous releases of this SDK. As a result, new patch builds have been released using the new signing key. Please upgrade at your earliest convenience.
+>
+> While this change won't affect most developers, if you have implemented a dependency signature validation step in your build process, you may notice a warning that past releases can't be verified. This is expected, and a result of the key rotation process. Updating to the latest version will resolve this for you.
+
 ![A Java implementation of JSON Web Token (JWT) - RFC 7519.](https://cdn.auth0.com/website/sdks/banners/java-jwt-banner.png)
 
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/java-jwt.svg?style=flat-square)](https://circleci.com/gh/auth0/java-jwt/tree/master)
@@ -45,14 +50,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>java-jwt</artifactId>
-  <version>4.2.1</version>
+  <version>4.2.2</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:java-jwt:4.2.1'
+implementation 'com.auth0:java-jwt:4.2.2'
 ```
 
 ### Create a JWT


### PR DESCRIPTION
## [4.2.2](https://github.com/auth0/java-jwt/tree/4.2.2) (2023-01-11)
[Full Changelog](https://github.com/auth0/java-jwt/compare/4.2.1...4.2.2)

This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
Please review [the README note for additional details.](https://github.com/auth0/java-jwt/blob/master/README.md)