### PR TITLE
Fix for `exp` claim considered valid if equal to now

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -346,7 +346,7 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
                     throw new TokenExpiredException(String.format("The Token has expired on %s.", claimVal), claimVal);
                 }
             } else {
-                isValid = assertInstantIsPast(claimVal, leeway, now);
+                isValid = assertInstantIsLessThanOrEqualToNow(claimVal, leeway, now);
                 if (!isValid) {
                     throw new IncorrectClaimException(
                             String.format("The Token can't be used before %s.", claimVal), claimName, claim);
@@ -356,10 +356,10 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         }
 
         private boolean assertInstantIsFuture(Instant claimVal, long leeway, Instant now) {
-            return !(claimVal != null && now.minus(Duration.ofSeconds(leeway)).isAfter(claimVal));
+            return claimVal == null || now.minus(Duration.ofSeconds(leeway)).isBefore(claimVal);
         }
 
-        private boolean assertInstantIsPast(Instant claimVal, long leeway, Instant now) {
+        private boolean assertInstantIsLessThanOrEqualToNow(Instant claimVal, long leeway, Instant now) {
             return !(claimVal != null && now.plus(Duration.ofSeconds(leeway)).isBefore(claimVal));
         }
 

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Base64;
@@ -270,12 +271,12 @@ public class JWTTest {
     @Test
     public void shouldGetExpirationTime() {
         long seconds = 1477592L;
-        Clock clock = Clock.fixed(Instant.ofEpochSecond(seconds), ZoneId.of("UTC"));
+        Clock mockNow = Clock.fixed(Instant.ofEpochSecond(seconds - 1), ZoneId.of("UTC"));
 
         String token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTJ9.x_ZjkPkKYUV5tdvc0l8go6D_z2kez1MQcOxokXrDc3k";
         JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(Algorithm.HMAC256("secret"));
         DecodedJWT jwt = verification
-                .build(clock)
+                .build(mockNow)
                 .verify(token);
 
         assertThat(jwt, is(notNullValue()));


### PR DESCRIPTION
As discussed in #646, the current date/time must be before the `exp` claim's value.

From the [spec, section 4.1.4](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4) (emphasis added):

> The processing of the "exp" claim requires that the current date/time MUST be **before** the expiration date/time listed in the "exp" claim.

This change ensures that the current time is before the `exp` claim's value (if present).

Fixes #646 