### PR TITLE
Make KeyProvider interface public

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
+++ b/lib/src/main/java/com/auth0/jwt/interfaces/KeyProvider.java
@@ -10,7 +10,7 @@ import java.security.PublicKey;
  * @param <U> the class that represents the Public Key
  * @param <R> the class that represents the Private Key
  */
-interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
+public interface KeyProvider<U extends PublicKey, R extends PrivateKey> {
 
     /**
      * Getter for the Public Key instance with the given Id. Used to verify the signature on the JWT verification stage.


### PR DESCRIPTION
### Changes

- Make KeyProvider interface public

Sometimes it's handy to return KeyProvider in some user code. 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
