### PR TITLE
Preserve insertion order for claims

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -71,8 +71,8 @@ public final class JWTCreator {
         private final Map<String, Object> headerClaims;
 
         Builder() {
-            this.payloadClaims = new HashMap<>();
-            this.headerClaims = new HashMap<>();
+            this.payloadClaims = new LinkedHashMap<>();
+            this.headerClaims = new LinkedHashMap<>();
         }
 
         /**

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -112,7 +112,7 @@ public final class JWTCreator {
             }
 
             try {
-                Map<String, Object> headerClaims = mapper.readValue(headerClaimsJson, HashMap.class);
+                Map<String, Object> headerClaims = mapper.readValue(headerClaimsJson, LinkedHashMap.class);
                 return withHeader(headerClaims);
             } catch (JsonProcessingException e) {
                 throw new IllegalArgumentException("Invalid header JSON", e);
@@ -508,7 +508,7 @@ public final class JWTCreator {
             }
 
             try {
-                Map<String, Object> payloadClaims =  mapper.readValue(payloadClaimsJson, HashMap.class);
+                Map<String, Object> payloadClaims =  mapper.readValue(payloadClaimsJson, LinkedHashMap.class);
                 return withPayload(payloadClaims);
             } catch (JsonProcessingException e) {
                 throw new IllegalArgumentException("Invalid payload JSON", e);

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -973,7 +973,7 @@ public class JWTCreatorTest {
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
-        String[] parts = jwt.split("\\.")  ;
+        String[] parts = jwt.split("\\.");
         String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
 
         assertThat(payloadJson, JsonMatcher.hasEntry("stringClaim", stringClaim));

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -3,7 +3,6 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Rule;
@@ -974,7 +973,7 @@ public class JWTCreatorTest {
                 .sign(Algorithm.HMAC256("secret"));
 
         assertThat(jwt, is(notNullValue()));
-        String[] parts = jwt.split("\\.");
+        String[] parts = jwt.split("\\.")  ;
         String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
 
         assertThat(payloadJson, JsonMatcher.hasEntry("stringClaim", stringClaim));
@@ -1014,7 +1013,9 @@ public class JWTCreatorTest {
 
     @Test
     public void shouldPreserveInsertionOrder() throws Exception {
-        List<String> headerInsertionOrder = new ArrayList<>();
+        String taxonomyJson = "{\"class\": \"mammalia\", \"order\": \"carnivora\", \"family\": \"canidae\", \"genus\": \"vulpes\"}";
+        List<String> taxonomyClaims = Arrays.asList("class", "order", "family", "genus");
+        List<String> headerInsertionOrder = new ArrayList<>(taxonomyClaims);
         Map<String, Object> header = new LinkedHashMap<>();
         for (int i = 0; i < 10; i++) {
             String key = "h" + i;
@@ -1022,8 +1023,11 @@ public class JWTCreatorTest {
             headerInsertionOrder.add(key);
         }
 
-        List<String> payloadInsertionOrder = new ArrayList<>();
-        JWTCreator.Builder builder = JWTCreator.init().withHeader(header);
+        List<String> payloadInsertionOrder = new ArrayList<>(taxonomyClaims);
+        JWTCreator.Builder builder = JWTCreator.init()
+                .withHeader(taxonomyJson)
+                .withHeader(header)
+                .withPayload(taxonomyJson);
         for (int i = 0; i < 10; i++) {
             String name = "c" + i;
             builder = builder.withClaim(name, "v" + i);


### PR DESCRIPTION
### Changes

> Please describe both what is changing and why this is important. Include:

Make header and payload fields in the resulting JWT have the same order as they were added to the `JWTCreator.Builder`.
When looking at a decoded JWT it's easier to see if all expected claims are included when they aren't scrambled.

> - Endpoints added, deleted, deprecated, or changed
> - Classes and methods added, deleted, deprecated, or changed

Very small change, only changed `HashMap` to `LinkedHashMap` for `headerClaims` and `payloadClaims` in `JWTCreator.Builder`.

> - Any alternative designs or approaches considered

A more complicated variant could allow selection of different orderings, e.g. `scrambled` (current), `insertion order` (this) and `alphabetically sorted` (e.g. by using `TreeMap`).

> - ~~Screenshots of new or changed UI, if applicable~~

> - A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

Order was unspecified before (since `HashMap` was used), now it's deterministic.

### References

> Please include relevant links supporting this change such as a:
> 
> - support ticket
> - community post
> - StackOverflow post
> - support forum thread

None that I know of.

### Testing

> Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has  unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage (or at least doesn't reduce coverage)
- [x] This change has been tested on the latest version of Java or why not

I've added a test that verifies that both header and payload claims are in insertion order.
The test doesn't care about where any other header fields are inserted, such as `alg` or `typ` (they will be last since they're added in the `sign` method).

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
