### PR TITLE
update jackson to 2.14.2

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -72,7 +72,7 @@ javadoc {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
### Changes

Update Jackson to 2.14.2 ([release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14.2))