### PR TITLE
Empty string audience claim should be deserialized as empty string

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -54,7 +54,7 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         if (node == null || node.isNull() || !(node.isArray() || node.isTextual())) {
             return null;
         }
-        if (node.isTextual() && !node.asText().isEmpty()) {
+        if (node.isTextual()) {
             return Collections.singletonList(node.asText());
         }
 

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -145,14 +145,14 @@ public class PayloadDeserializerTest {
     }
 
     @Test
-    public void shouldGetEmptyStringArrayWhenParsingEmptyTextNode() {
+    public void shouldGetEmptyStringInArrayWhenParsingEmptyTextNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         TextNode textNode = new TextNode("");
         tree.put("key", textNode);
 
         List<String> values = deserializer.getStringOrArray(objectMapper, tree, "key");
         assertThat(values, is(notNullValue()));
-        assertThat(values, is(IsEmptyCollection.empty()));
+        assertThat(values, is(IsIterableContaining.hasItem("")));
     }
 
     @Test


### PR DESCRIPTION
### Changes

Fixes #662 - an empty audience string was being deserialized as an empty list, instead of a list with an empty string.
