### PR TITLE
empty expected audience array should throw InvalidClaimException

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -368,9 +368,15 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
                 List<String> expectedAudience,
                 boolean shouldContainAll
         ) {
-            if (actualAudience == null) {
-                return false;
-            } else if (shouldContainAll) {
+            // normalize to lists if null
+            actualAudience = actualAudience == null ? Collections.emptyList() : actualAudience;
+            expectedAudience = expectedAudience == null ? Collections.emptyList() : expectedAudience;
+
+            if (shouldContainAll) {
+                // containsAll([]) always returns true
+                if (expectedAudience.isEmpty() && !actualAudience.isEmpty()) {
+                    return false;
+                }
                 return actualAudience.containsAll(expectedAudience);
             } else {
                 return !Collections.disjoint(actualAudience, expectedAudience);

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -368,9 +368,11 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
                 List<String> expectedAudience,
                 boolean shouldContainAll
         ) {
-            // normalize to lists if null
-            actualAudience = actualAudience == null ? Collections.emptyList() : actualAudience;
-            expectedAudience = expectedAudience == null ? Collections.emptyList() : expectedAudience;
+            if (actualAudience == null && expectedAudience == null) {
+                return true;
+            } else if (actualAudience == null || expectedAudience == null) {
+                return false;
+            }
 
             if (shouldContainAll) {
                 // containsAll([]) always returns true

--- a/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTVerifier.java
@@ -364,12 +364,17 @@ public final class JWTVerifier implements com.auth0.jwt.interfaces.JWTVerifier {
         }
 
         private boolean assertValidAudienceClaim(
-                List<String> audience,
-                List<String> values,
+                List<String> actualAudience,
+                List<String> expectedAudience,
                 boolean shouldContainAll
         ) {
-            return !(audience == null || (shouldContainAll && !audience.containsAll(values))
-                    || (!shouldContainAll && Collections.disjoint(audience, values)));
+            if (actualAudience == null) {
+                return false;
+            } else if (shouldContainAll) {
+                return actualAudience.containsAll(expectedAudience);
+            } else {
+                return !Collections.disjoint(actualAudience, expectedAudience);
+            }
         }
 
         private void assertPositive(long leeway) {

--- a/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTVerifierTest.java
@@ -311,6 +311,21 @@ public class JWTVerifierTest {
     }
 
     @Test
+    public void shouldThrowWhenExpectedEmptyList() {
+        IncorrectClaimException e = assertThrows(null, IncorrectClaimException.class, () -> {
+            // Token 'aud': 'wide audience'
+            String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ3aWRlIGF1ZGllbmNlIn0.c9anq03XepcuEKWEVsPk9cck0sIIfrT6hHbBsCar49o";
+            JWTVerifier.init(Algorithm.HMAC256("secret"))
+                    .withAnyOfAudience(new String[0])
+                    .build()
+                    .verify(token);
+        });
+        assertThat(e.getMessage(), is("The Claim 'aud' value doesn't contain the required audience."));
+        assertThat(e.getClaimName(), is(RegisteredClaims.AUDIENCE));
+        assertThat(e.getClaimValue().asString(), is("wide audience"));
+    }
+
+    @Test
     public void shouldNotReplaceWhenMultipleChecksAreAdded() {
         JWTVerifier verifier = JWTVerifier.init(Algorithm.HMAC256("secret"))
                 .withAudience((String[]) null)


### PR DESCRIPTION
### Changes

Currently, validating a JWT expecting an empty string array fails with a NPE, instead of an `InvalidClaimException`, as discussed in #674. This change fixes that.

It also includes a small refactor to the audience validation logic, replacing the terse conditional with clearer and more extendable logic. That change was done in a commit prior to making any logic changes to ensure no unintended changes.