### PR TITLE
Get back clarification about public and private key usage

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -99,6 +99,10 @@ See the [JavaDoc](https://javadoc.io/doc/com.auth0/java-jwt/latest/com/auth0/jwt
 A `KeyProvider` can be used to obtain the keys needed for signing and verifying a JWT. How these keys are constructed are beyond the scope of this library, but the [jwks-rsa-java](https://github.com/auth0/jwks-rsa-java) library provides the ability to obtain the public key from a JWK.
 The example below demonstrates this for the RSA algorithm (`ECDSAKeyProvider` can be used for ECDSA).
 
+When using RSA or ECDSA algorithms and you just need to **sign** JWTs you can avoid specifying a Public Key by returning a `null` value in `getPublicKeyById` in `KeyProvider` implementation.
+
+The same can be done with the Private Key when you just need to **verify** JWTs by returning a `null` value in `getPrivateKey` and `getPrivateKeyId` in `KeyProvider` implementation.
+
 ```java
 JwkProvider provider = new JwkProviderBuilder("https://samples.auth0.com/")
         .cached(10, 24, TimeUnit.HOURS)
@@ -110,17 +114,19 @@ final String privateKeyId = // private key ID
 RSAKeyProvider keyProvider = new RSAKeyProvider() {
     @Override
     public RSAPublicKey getPublicKeyById(String kid) {
-        return (RSAPublicKey) jwkProvider.get(kid).getPublicKey();
+        // return null if key is used only for signing.
+        return (RSAPublicKey) provider.get(kid).getPublicKey();
     }
 
     @Override
     public RSAPrivateKey getPrivateKey() {
-        // return the private key used 
+        // return the private key used or null if key is used only for verification.
         return rsaPrivateKey;
     }
 
     @Override
     public String getPrivateKeyId() {
+        // return id of the private key used or null if key is used only for verification.
         return rsaPrivateKeyId;
     }
 };


### PR DESCRIPTION
Hi there, thanks for the nice library!
While trying to use it at [CrateDB](https://github.com/crate/crate) some minor doc issues have been noticed.

There was an [issue](https://github.com/auth0/java-jwt/issues/554) referring to unclarity of private keys usage. 

Also there was a general hint referred in some comments: [1](https://github.com/auth0/java-jwt/issues/291#issuecomment-431893085), [2](https://github.com/auth0/java-jwt/issues/324#issuecomment-470732751), [3](https://github.com/auth0/java-jwt/issues/253#issuecomment-391377994) and a [community post](https://community.auth0.com/t/rsa256-jwks-jwt-validation-using-auth0s-java-jwt-and-jwks-rsa-java/13149)

All this was removed in https://github.com/auth0/java-jwt/commit/d0ebc3f50581f3341a9b214f32612926b8b1a201

This PR gets back those as it's still might be unclear.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
