### PR TITLE
Migrate jackson 2.x to 3.x

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   rl-scanner:
     uses: ./.github/workflows/rl-secure.yml
     with:
-      java-version: 11
+      java-version: 17
       artifact-name: 'java-jwt.tgz'
     secrets:
       RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/java-release.yml
     needs: rl-scanner
     with:
-      java-version: 11.0.21-tem
+      java-version: 17.0.12-tem
     secrets:
       ossr-username: ${{ secrets.OSSR_USERNAME }}
       ossr-token: ${{ secrets.OSSR_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: snyk/actions/gradle-jdk11@9adf32b1121593767fc3c057af55b55db032dc04 # pin@1.0.0
+      - uses: snyk/actions/gradle-jdk17@master # pin@0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -19,7 +19,7 @@ tasks.withType(Javadoc).configureEach {
 
 javadoc {
     // Specify the Java version that the project will use
-    options.addStringOption('-release', "11")
+    options.addStringOption('-release', "17")
 }
 artifacts {
     archives sourcesJar, javadocJar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -112,8 +112,8 @@ javadoc {
 }
 
 dependencies {
-    implementation 'tools.jackson.core:jackson-core:3.0.4'
-    implementation 'tools.jackson.core:jackson-databind:3.0.4'
+    implementation 'tools.jackson.core:jackson-core:3.1.0'
+    implementation 'tools.jackson.core:jackson-databind:3.1.0'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
     testImplementation 'junit:junit:4.13.2'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:31.1-jre'
-    }
-}
-
 plugins {
     id 'java'
     id 'jacoco'
@@ -102,29 +91,29 @@ private static File getBaselineJar(Project project, String baselineVersion) {
 
 ext {
     baselineCompareVersion = '4.1.0'
-    testInJavaVersions = [8, 11, 17, 21]
+    testInJavaVersions = [17, 21]
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
 compileJava {
-    exclude 'module-info.java'
-    // Required to be compatible with JDK 8+
-    options.release = 8
+    options.release = 17
+    options.compilerArgs << "-Xlint:unchecked"
 }
 
 javadoc {
     // Exclude internal implementation package from javadoc
     excludes = ['com/auth0/jwt/impl', 'module-info.java']
+    modularity.inferModulePath = false
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.21.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.1'
+    implementation 'tools.jackson.core:jackson-core:3.0.4'
+    implementation 'tools.jackson.core:jackson-databind:3.0.4'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
     testImplementation 'junit:junit:4.13.2'
@@ -155,37 +144,9 @@ test {
     }
 }
 
-task compileModuleInfoJava(type: JavaCompile) {
-    classpath = files()
-    source = 'src/main/java/module-info.java'
-    destinationDir = compileJava.destinationDir
-    doLast {
-        def descriptor = new File(compileJava.destinationDir, 'module-info.class')
-        def dest = new File(compileJava.destinationDir, 'META-INF/versions/9')
-        ant.move file: descriptor, todir: dest
-    }
-
-    doFirst {
-        options.compilerArgs = [
-                '--release', '9',
-                '--module-path', compileJava.classpath.asPath
-        ]
-    }
-}
-
 compileTestJava {
-    options.release = 8
+    options.release = 17
     options.compilerArgs = ["-Xlint:deprecation"]
-}
-
-def testJava8 = tasks.register('testJava8', Test) {
-    description = 'Runs unit tests on Java 8.'
-    group = 'verification'
-
-    javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    })
-    shouldRunAfter(tasks.named('test'))
 }
 
 def testJava17 = tasks.register('testJava17', Test) {
@@ -209,7 +170,6 @@ def testJava21 = tasks.register('testJava21', Test) {
 }
 
 tasks.named('check') {
-    dependsOn(testJava8)
     dependsOn(testJava17)
     dependsOn(testJava21)
 }
@@ -217,9 +177,6 @@ tasks.named('check') {
 jar {
     manifest.attributes('Multi-Release': 'true')
 }
-
-compileModuleInfoJava.dependsOn compileJava
-classes.dependsOn compileModuleInfoJava
 
 // you can pass any arguments JMH accepts via Gradle args.
 // Example: ./gradlew runJMH --args="-lrf"

--- a/lib/src/main/java/com/auth0/jwt/JWTCreator.java
+++ b/lib/src/main/java/com/auth0/jwt/JWTCreator.java
@@ -4,11 +4,11 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.SignatureGenerationException;
 import com.auth0.jwt.impl.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.core.JacksonException;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -38,8 +38,8 @@ public final class JWTCreator {
 
         mapper = JsonMapper.builder()
                 .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-                .build()
-                .registerModule(module);
+                .addModule(module)
+                .build();
     }
 
     private JWTCreator(Algorithm algorithm, Map<String, Object> headerClaims, Map<String, Object> payloadClaims)
@@ -48,7 +48,7 @@ public final class JWTCreator {
         try {
             headerJson = mapper.writeValueAsString(new HeaderClaimsHolder(headerClaims));
             payloadJson = mapper.writeValueAsString(new PayloadClaimsHolder(payloadClaims));
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new JWTCreationException("Some of the Claims couldn't be converted to a valid JSON format.", e);
         }
     }
@@ -114,7 +114,7 @@ public final class JWTCreator {
             try {
                 Map<String, Object> headerClaims = mapper.readValue(headerClaimsJson, LinkedHashMap.class);
                 return withHeader(headerClaims);
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 throw new IllegalArgumentException("Invalid header JSON", e);
             }
         }
@@ -510,7 +510,7 @@ public final class JWTCreator {
             try {
                 Map<String, Object> payloadClaims =  mapper.readValue(payloadClaimsJson, LinkedHashMap.class);
                 return withPayload(payloadClaims);
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 throw new IllegalArgumentException("Invalid payload JSON", e);
             }
         }

--- a/lib/src/main/java/com/auth0/jwt/impl/BasicHeader.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/BasicHeader.java
@@ -2,8 +2,8 @@ package com.auth0.jwt.impl;
 
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.Header;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -22,7 +22,7 @@ class BasicHeader implements Header, Serializable {
     private final String contentType;
     private final String keyId;
     private final Map<String, JsonNode> tree;
-    private final ObjectCodec objectCodec;
+    private final DeserializationContext context;
 
     BasicHeader(
             String algorithm,
@@ -30,14 +30,14 @@ class BasicHeader implements Header, Serializable {
             String contentType,
             String keyId,
             Map<String, JsonNode> tree,
-            ObjectCodec objectCodec
+            DeserializationContext context
     ) {
         this.algorithm = algorithm;
         this.type = type;
         this.contentType = contentType;
         this.keyId = keyId;
         this.tree = tree == null ? Collections.emptyMap() : Collections.unmodifiableMap(tree);
-        this.objectCodec = objectCodec;
+        this.context = context;
     }
 
     Map<String, JsonNode> getTree() {
@@ -66,6 +66,6 @@ class BasicHeader implements Header, Serializable {
 
     @Override
     public Claim getHeaderClaim(String name) {
-        return extractClaim(name, tree, objectCodec);
+        return extractClaim(name, tree, context);
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/HeaderDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/HeaderDeserializer.java
@@ -3,13 +3,13 @@ package com.auth0.jwt.impl;
 import com.auth0.jwt.HeaderParams;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Header;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -26,8 +26,8 @@ class HeaderDeserializer extends StdDeserializer<Header> {
     }
 
     @Override
-    public Header deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        Map<String, JsonNode> tree = p.getCodec().readValue(p, new TypeReference<Map<String, JsonNode>>() {
+    public Header deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        Map<String, JsonNode> tree = ctxt.readValue(p, new TypeReference<>() {
         });
         if (tree == null) {
             throw new JWTDecodeException("Parsing the Header's JSON resulted on a Null map");
@@ -37,7 +37,7 @@ class HeaderDeserializer extends StdDeserializer<Header> {
         String type = getString(tree, HeaderParams.TYPE);
         String contentType = getString(tree, HeaderParams.CONTENT_TYPE);
         String keyId = getString(tree, HeaderParams.KEY_ID);
-        return new BasicHeader(algorithm, type, contentType, keyId, tree, p.getCodec());
+        return new BasicHeader(algorithm, type, contentType, keyId, tree, ctxt);
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {
@@ -45,6 +45,6 @@ class HeaderDeserializer extends StdDeserializer<Header> {
         if (node == null || node.isNull()) {
             return null;
         }
-        return node.asText(null);
+        return node.asString(null);
     }
 }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadImpl.java
@@ -2,8 +2,8 @@ package com.auth0.jwt.impl;
 
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.Payload;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -34,7 +34,7 @@ class PayloadImpl implements Payload, Serializable {
     private final Instant issuedAt;
     private final String jwtId;
     private final Map<String, JsonNode> tree;
-    private final ObjectCodec objectCodec;
+    private final DeserializationContext context;
 
     PayloadImpl(
             String issuer,
@@ -45,7 +45,7 @@ class PayloadImpl implements Payload, Serializable {
             Instant issuedAt,
             String jwtId,
             Map<String, JsonNode> tree,
-            ObjectCodec objectCodec
+            DeserializationContext context
     ) {
         this.issuer = issuer;
         this.subject = subject;
@@ -55,7 +55,7 @@ class PayloadImpl implements Payload, Serializable {
         this.issuedAt = issuedAt;
         this.jwtId = jwtId;
         this.tree = tree != null ? Collections.unmodifiableMap(tree) : Collections.emptyMap();
-        this.objectCodec = objectCodec;
+        this.context = context;
     }
 
     Map<String, JsonNode> getTree() {
@@ -115,14 +115,14 @@ class PayloadImpl implements Payload, Serializable {
 
     @Override
     public Claim getClaim(String name) {
-        return extractClaim(name, tree, objectCodec);
+        return extractClaim(name, tree, context);
     }
 
     @Override
     public Map<String, Claim> getClaims() {
         Map<String, Claim> claims = new HashMap<>(tree.size() * 2);
         for (String name : tree.keySet()) {
-            claims.put(name, extractClaim(name, tree, objectCodec));
+            claims.put(name, extractClaim(name, tree, context));
         }
         return Collections.unmodifiableMap(claims);
     }

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadSerializer.java
@@ -1,9 +1,9 @@
 package com.auth0.jwt.impl;
 
 import com.auth0.jwt.RegisteredClaims;
-import com.fasterxml.jackson.core.JsonGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +22,7 @@ public class PayloadSerializer extends ClaimsSerializer<PayloadClaimsHolder> {
     }
 
     @Override
-    protected void writeClaim(Map.Entry<String, Object> entry, JsonGenerator gen) throws IOException {
+    protected void writeClaim(Map.Entry<String, Object> entry, JsonGenerator gen) throws JacksonException {
         if (RegisteredClaims.AUDIENCE.equals(entry.getKey())) {
             writeAudience(gen, entry);
         } else {
@@ -34,9 +34,9 @@ public class PayloadSerializer extends ClaimsSerializer<PayloadClaimsHolder> {
      * Audience may be a list of strings or a single string. This is needed to properly handle the aud claim when
      * added with the {@linkplain com.auth0.jwt.JWTCreator.Builder#withPayload(Map)} method.
      */
-    private void writeAudience(JsonGenerator gen, Map.Entry<String, Object> e) throws IOException {
+    private void writeAudience(JsonGenerator gen, Map.Entry<String, Object> e) throws JacksonException {
         if (e.getValue() instanceof String) {
-            gen.writeFieldName(e.getKey());
+            gen.writeName(e.getKey());
             gen.writeString((String) e.getValue());
         } else {
             List<String> audArray = new ArrayList<>();
@@ -51,10 +51,10 @@ public class PayloadSerializer extends ClaimsSerializer<PayloadClaimsHolder> {
                 }
             }
             if (audArray.size() == 1) {
-                gen.writeFieldName(e.getKey());
+                gen.writeName(e.getKey());
                 gen.writeString(audArray.get(0));
             } else if (audArray.size() > 1) {
-                gen.writeFieldName(e.getKey());
+                gen.writeName(e.getKey());
                 gen.writeStartArray();
                 for (String aud : audArray) {
                     gen.writeString(aud);

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module com.auth0.jwt {
-    requires com.fasterxml.jackson.databind;
+    requires tools.jackson.core;
+    requires tools.jackson.databind;
 
     exports com.auth0.jwt;
     exports com.auth0.jwt.algorithms;

--- a/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTCreatorTest.java
@@ -3,8 +3,8 @@ package com.auth0.jwt;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.ECDSAKeyProvider;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -1043,16 +1043,14 @@ public class JWTCreatorTest {
 
         ObjectMapper objectMapper = new ObjectMapper();
 
-        List<String> headerFields = new ArrayList<>();
-        objectMapper.readValue(headerJson, ObjectNode.class)
-                .fieldNames().forEachRemaining(headerFields::add);
+        List<String> headerFields = new ArrayList<>(
+                objectMapper.readValue(headerJson, ObjectNode.class).propertyNames());
         headerFields.retainAll(headerInsertionOrder);
         assertThat("Header insertion order should be preserved",
                 headerFields, is(equalTo(headerInsertionOrder)));
 
-        List<String> payloadFields = new ArrayList<>();
-        objectMapper.readValue(payloadJson, ObjectNode.class)
-                .fieldNames().forEachRemaining(payloadFields::add);
+        List<String> payloadFields = new ArrayList<>(
+                objectMapper.readValue(payloadJson, ObjectNode.class).propertyNames());
         payloadFields.retainAll(payloadInsertionOrder);
         assertThat("Claim insertion order should be preserved",
                 payloadFields, is(equalTo(payloadInsertionOrder)));

--- a/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTDecoderTest.java
@@ -341,8 +341,10 @@ public class JWTDecoderTest {
 
         assertThat(originalJwt, is(instanceOf(Serializable.class)));
 
-        byte[] serialized = serialize(originalJwt);
-        DecodedJWT deserializedJwt = (DecodedJWT) deserialize(serialized);
+        byte[] serializedToken = serialize(originalJwt.getToken());
+        String deserializedToken = (String) deserialize(serializedToken);
+
+        DecodedJWT deserializedJwt = JWT.decode(deserializedToken);
 
         assertThat(originalJwt.getHeader(), is(equalTo(deserializedJwt.getHeader())));
         assertThat(originalJwt.getPayload(), is(equalTo(deserializedJwt.getPayload())));

--- a/lib/src/test/java/com/auth0/jwt/impl/BasicHeaderTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/BasicHeaderTest.java
@@ -1,18 +1,18 @@
 package com.auth0.jwt.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import tools.jackson.databind.node.StringNode;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -21,20 +21,20 @@ public class BasicHeaderTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
     
-    private ObjectReader objectReader = new ObjectMapper().reader();
+    private final DeserializationContext context = getDefaultObjectMapper()._deserializationContext();
 
     @SuppressWarnings("Convert2Diamond")
     @Test
     public void shouldHaveUnmodifiableTreeWhenInstantiatedWithNonNullTree() {
         exception.expect(UnsupportedOperationException.class);
-        BasicHeader header = new BasicHeader(null, null, null, null, new HashMap<String, JsonNode>(), objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, new HashMap<String, JsonNode>(), context);
         header.getTree().put("something", null);
     }
 
     @Test
     public void shouldHaveUnmodifiableTreeWhenInstantiatedWithNullTree() {
         exception.expect(UnsupportedOperationException.class);
-        BasicHeader header = new BasicHeader(null, null, null, null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, null, context);
         header.getTree().put("something", null);
     }
 
@@ -43,7 +43,7 @@ public class BasicHeaderTest {
         HashMap<String, JsonNode> map = new HashMap<>();
         JsonNode node = NullNode.getInstance();
         map.put("key", node);
-        BasicHeader header = new BasicHeader(null, null, null, null, map, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, map, context);
 
         assertThat(header.getTree(), is(notNullValue()));
         assertThat(header.getTree(), is(IsMapContaining.hasEntry("key", node)));
@@ -51,7 +51,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetAlgorithm() {
-        BasicHeader header = new BasicHeader("HS256", null, null, null, null, objectReader);
+        BasicHeader header = new BasicHeader("HS256", null, null, null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getAlgorithm(), is(notNullValue()));
@@ -60,7 +60,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetNullAlgorithmIfMissing() {
-        BasicHeader header = new BasicHeader(null, null, null, null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getAlgorithm(), is(nullValue()));
@@ -68,7 +68,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetType() {
-        BasicHeader header = new BasicHeader(null, "jwt", null, null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, "jwt", null, null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getType(), is(notNullValue()));
@@ -77,7 +77,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetNullTypeIfMissing() {
-        BasicHeader header = new BasicHeader(null, null, null, null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getType(), is(nullValue()));
@@ -85,7 +85,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetContentType() {
-        BasicHeader header = new BasicHeader(null, null, "content", null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, "content", null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getContentType(), is(notNullValue()));
@@ -94,7 +94,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetNullContentTypeIfMissing() {
-        BasicHeader header = new BasicHeader(null, null, null, null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getContentType(), is(nullValue()));
@@ -102,7 +102,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetKeyId() {
-        BasicHeader header = new BasicHeader(null, null, null, "key", null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, "key", null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getKeyId(), is(notNullValue()));
@@ -111,7 +111,7 @@ public class BasicHeaderTest {
 
     @Test
     public void shouldGetNullKeyIdIfMissing() {
-        BasicHeader header = new BasicHeader(null, null, null, null, null, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, null, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getKeyId(), is(nullValue()));
@@ -120,8 +120,8 @@ public class BasicHeaderTest {
     @Test
     public void shouldGetExtraClaim() {
         Map<String, JsonNode> tree = new HashMap<>();
-        tree.put("extraClaim", new TextNode("extraValue"));
-        BasicHeader header = new BasicHeader(null, null, null, null, tree, objectReader);
+        tree.put("extraClaim", new StringNode("extraValue"));
+        BasicHeader header = new BasicHeader(null, null, null, null, tree, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getHeaderClaim("extraClaim"), is(instanceOf(JsonNodeClaim.class)));
@@ -131,7 +131,7 @@ public class BasicHeaderTest {
     @Test
     public void shouldGetNotNullExtraClaimIfMissing() {
         Map<String, JsonNode> tree = new HashMap<>();
-        BasicHeader header = new BasicHeader(null, null, null, null, tree, objectReader);
+        BasicHeader header = new BasicHeader(null, null, null, null, tree, context);
 
         assertThat(header, is(notNullValue()));
         assertThat(header.getHeaderClaim("missing"), is(notNullValue()));

--- a/lib/src/test/java/com/auth0/jwt/impl/JWTParserTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JWTParserTest.java
@@ -3,19 +3,18 @@ package com.auth0.jwt.impl;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Header;
 import com.auth0.jwt.interfaces.Payload;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.SerializationFeature;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import tools.jackson.databind.json.JsonMapper;
 
 import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,11 +38,13 @@ public class JWTParserTest {
         assertThat(mapper.isEnabled(SerializationFeature.FAIL_ON_EMPTY_BEANS), is(false));
     }
 
+
     @Test
     public void shouldAddDeserializers() {
-        ObjectMapper mapper = mock(ObjectMapper.class);
-        JWTParser.addDeserializers(mapper);
-        verify(mapper).registerModule(any(Module.class));
+        JsonMapper.Builder builder = JsonMapper.builder();
+        JWTParser.addDeserializers(builder);
+        ObjectMapper mapper = builder.build();
+        assertThat(mapper, is(notNullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -1,16 +1,16 @@
 package com.auth0.jwt.impl;
 
 import com.auth0.jwt.interfaces.Claim;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsIterableContaining;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import tools.jackson.databind.node.StringNode;
 
 import java.time.Instant;
 import java.util.*;
@@ -29,28 +29,29 @@ public class PayloadImplTest {
     private final Instant notBefore = Instant.now();
     private final Instant issuedAt = Instant.now();
 
-    private ObjectMapper objectMapper;
+    private DeserializationContext context;
 
     @Before
     public void setUp() {
-        objectMapper = getDefaultObjectMapper();
+        ObjectMapper mapper = getDefaultObjectMapper();
+        context = mapper._deserializationContext();
 
         Map<String, JsonNode> tree = new HashMap<>();
-        tree.put("extraClaim", new TextNode("extraValue"));
-        payload = new PayloadImpl("issuer", "subject", Collections.singletonList("audience"), expiresAt, notBefore, issuedAt, "jwtId", tree, objectMapper);
+        tree.put("extraClaim", new StringNode("extraValue"));
+        payload = new PayloadImpl("issuer", "subject", Collections.singletonList("audience"), expiresAt, notBefore, issuedAt, "jwtId", tree, context);
     }
 
     @Test
     public void shouldHaveUnmodifiableTree() {
         exception.expect(UnsupportedOperationException.class);
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, new HashMap<>(), objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, new HashMap<>(), context);
         payload.getTree().put("something", null);
     }
 
     @Test
     public void shouldHaveUnmodifiableAudience() {
         exception.expect(UnsupportedOperationException.class);
-        PayloadImpl payload = new PayloadImpl(null, null, new ArrayList<>(), null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, new ArrayList<>(), null, null, null, null, null, context);
         payload.getAudience().add("something");
     }
 
@@ -62,7 +63,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullIssuerIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getIssuer(), is(nullValue()));
     }
@@ -75,7 +76,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullSubjectIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getSubject(), is(nullValue()));
     }
@@ -90,7 +91,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullAudienceIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getAudience(), is(nullValue()));
     }
@@ -104,7 +105,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullExpiresAtIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getExpiresAt(), is(nullValue()));
         assertThat(payload.getExpiresAtAsInstant(), is(nullValue()));
@@ -119,7 +120,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullNotBeforeIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getNotBefore(), is(nullValue()));
         assertThat(payload.getNotBeforeAsInstant(), is(nullValue()));
@@ -134,7 +135,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullIssuedAtIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getIssuedAt(), is(nullValue()));
         assertThat(payload.getIssuedAtAsInstant(), is(nullValue()));
@@ -148,7 +149,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNullJWTIdIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getId(), is(nullValue()));
     }
@@ -162,7 +163,7 @@ public class PayloadImplTest {
 
     @Test
     public void shouldGetNotNullExtraClaimIfMissing() {
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, objectMapper);
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, null, context);
         assertThat(payload, is(notNullValue()));
         assertThat(payload.getClaim("missing"), is(notNullValue()));
         assertThat(payload.getClaim("missing").isMissing(), is(true));
@@ -172,9 +173,9 @@ public class PayloadImplTest {
     @Test
     public void shouldGetClaims() {
         Map<String, JsonNode> tree = new HashMap<>();
-        tree.put("extraClaim", new TextNode("extraValue"));
-        tree.put("sub", new TextNode("auth0"));
-        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, tree, objectMapper);
+        tree.put("extraClaim", new StringNode("extraValue"));
+        tree.put("sub", new StringNode("auth0"));
+        PayloadImpl payload = new PayloadImpl(null, null, null, null, null, null, null, tree, context);
         assertThat(payload, is(notNullValue()));
         Map<String, Claim> claims = payload.getClaims();
         assertThat(claims, is(notNullValue()));


### PR DESCRIPTION
### Disclaimer

Moving to jackson 3 (and implicitly java 17) are maybe a real breaking change, I don't know the policy of maintainers about older java versions compatibilities, but well, I did this work for myself in first place, so at least you can take a look

### Changes

- Bump java baseline to 17 in build.gradle + CI files (the minimum supported java version for jackson 3.x)
- Update gradle to 7.x (for java 17 support)
- Remove Java 8/11 tests because these versions are no longer supported by Jackson3.

From jackson3 migration guide (link bellow):
- Update Java package from com.fasterxml.jackson.[core/databind] -> tools.jackson.[core/databind]
- Replace removed ObjectCodec by the right implementation of ObjectReadContext/ObjectWriteContext interfaces (which are DeserializationContext and SerializationContext)
- JsonProcessingException -> JacksonException
- JsonGenerator.writeObject() -> JsonGenerator.writePOJO()
- JsonGenerator.writeFieldName() -> JsonGenerator.writeName()
- JsonNode.asText() -> JsonNode.asString()
- JsonNode.isTextual() -> JsonNode.isString()
- JsonParser.getCodec() -> JsonParser.objectReadContext()


### References

- [jackson3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)
- Related to #730 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
