### PR TITLE
Chore: Bump update commons-beanutils dependency

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -32,6 +32,11 @@ configurations {
 checkstyle {
     toolVersion '10.0'
 }
+configurations.checkstyle {
+    resolutionStrategy {
+        force 'commons-beanutils:commons-beanutils:1.11.0'
+    }
+}
 //We are disabling lint checks for tests
 tasks.named("checkstyleTest").configure({
     enabled = false


### PR DESCRIPTION
### Changes

This PR contains bump upgrade of commons-beanutils dependency to `1.11.0`