### PR TITLE
Chore: Add SCA scan workflow

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -1,0 +1,15 @@
+name: SCA
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  snyk-cli:
+    uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
+    with:
+      additional-arguments: "--exclude=README.md"
+      java-version: "11"
+    secrets: inherit


### PR DESCRIPTION
### Changes

- Add Snyk SCA (Software Composition Analysis) scanning via the `auth0/devsecops-tooling` reusable workflow                                     
- New workflow `.github/workflows/sca_scan.yml`                                 
- Triggers on push and pull request to `master`                                 
- Configures Java version to `11` to match the project's toolchain              
- Excludes `README.md` from scanning