### PR TITLE
Report out-of-range NumericDate claims distinctly from non-numeric ones

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -74,9 +74,19 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
         if (node == null || node.isNull()) {
             return null;
         }
-        if (!node.canConvertToLong()) {
+        // A NumericDate per RFC 7519 is a JSON number and may be written in scientific notation
+        // (for example 1.7e9). Split the two failure modes so the thrown error is accurate: a
+        // genuinely non-numeric value, versus a numeric value that is out of the range a long can
+        // hold (such as 1.733162101e+26). Previously both produced "non-numeric date value", which
+        // is wrong for the second case and made large/scientific values look unsupported.
+        if (!node.isNumber()) {
             throw new JWTDecodeException(
                     String.format("The claim '%s' contained a non-numeric date value.", claimName));
+        }
+        if (!node.canConvertToLong()) {
+            throw new JWTDecodeException(String.format(
+                    "The claim '%s' value (%s) is out of the range representable as a NumericDate.",
+                    claimName, node.asText()));
         }
         return Instant.ofEpochSecond(node.asLong());
     }

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -241,6 +241,34 @@ public class PayloadDeserializerTest {
         assertThat(instant.toEpochMilli(), is(2147493647L * 1000));
     }
 
+    // https://github.com/auth0/java-jwt/issues/706 - a NumericDate may be written in scientific
+    // notation. An in-range value must still resolve to the right instant.
+    @Test
+    public void shouldGetInstantWhenParsingScientificNotationNode() {
+        Map<String, JsonNode> tree = new HashMap<>();
+        DoubleNode node = new DoubleNode(1.7e9);
+        tree.put("key", node);
+
+        Instant instant = deserializer.getInstantFromSeconds(tree, "key");
+        assertThat(instant, is(notNullValue()));
+        assertThat(instant, is(Instant.ofEpochSecond(1_700_000_000L)));
+    }
+
+    // A numeric value that does not fit a long (the exact value reported in issue #706) must be
+    // rejected as out of range, not mislabeled as non-numeric.
+    @Test
+    public void shouldThrowOutOfRangeWhenNumericDateExceedsLong() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage(
+                "The claim 'key' value (1.733162101E26) is out of the range representable as a NumericDate.");
+
+        Map<String, JsonNode> tree = new HashMap<>();
+        DoubleNode node = new DoubleNode(1.733162101e+26);
+        tree.put("key", node);
+
+        deserializer.getInstantFromSeconds(tree, "key");
+    }
+
     @Test
     public void shouldGetNullStringWhenParsingNullNode() {
         Map<String, JsonNode> tree = new HashMap<>();


### PR DESCRIPTION
Fixes #706

## What is actually happening

While looking into this I found that in-range scientific notation already decodes correctly. A claim like `{"exp": 1.7e9}` is parsed by Jackson as a `DoubleNode` whose `canConvertToLong()` is true, and `getInstantFromSeconds` already handles it and returns `Instant.ofEpochSecond(1_700_000_000)`.

The value in the report, `1.733162101e+26`, is different: it is about `1.7e26` seconds (a year around `5.5e18`), which overflows `long` and is not representable as a NumericDate or an `Instant`. So it genuinely cannot be decoded to a date. The defect is that `PayloadDeserializer.getInstantFromSeconds` reported it as `The claim 'exp' contained a non-numeric date value`, which is misleading: the value is numeric, it is just out of range.

## Fix

Split the two failure modes in `getInstantFromSeconds`:

- not a number: keep the existing `non-numeric date value` message.
- numeric but overflows `long`: a new, accurate message, `The claim '<name>' value (<value>) is out of the range representable as a NumericDate.`

In-range scientific-notation values continue to decode unchanged. Clamping an absurd overflow value to some wrong year would be worse than a clear rejection, so the out-of-range case is rejected with the precise error.

## Tests

Added to `PayloadDeserializerTest`:

- `shouldGetInstantWhenParsingScientificNotationNode`: `1.7e9` decodes to `Instant.ofEpochSecond(1_700_000_000)` (documents that in-range scientific notation works).
- `shouldThrowOutOfRangeWhenNumericDateExceedsLong`: `1.733162101e+26` raises the new out-of-range message.

The existing non-numeric and normal-integer tests still pass. The directly affected suites (`PayloadDeserializerTest`, `JsonNodeClaimTest`, `PayloadImplTest`, `JWTVerifierTest`, `JWTDecoderTest`) run green. I ran these on JDK 11 because the repo's Gradle wrapper (6.9.2) rejects newer JDKs; CI will exercise the full version matrix.

## Scope

This is narrower than the title might suggest: scientific notation is already supported for representable values, so this PR fixes the misleading error for out-of-range values and adds the missing test coverage rather than adding a new feature. A separate pre-existing edge (a plain integer that passes `canConvertToLong()` but still overflows `Instant.ofEpochSecond`) is orthogonal to this issue and not addressed here.
