### PR TITLE
Preserve IOException cause in JWTParser decode errors

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/JWTParser.java
@@ -44,7 +44,7 @@ public class JWTParser implements JWTPartsParser {
         try {
             return payloadReader.readValue(json);
         } catch (IOException e) {
-            throw decodeException(json);
+            throw decodeException(json, e);
         }
     }
 
@@ -57,7 +57,7 @@ public class JWTParser implements JWTPartsParser {
         try {
             return headerReader.readValue(json);
         } catch (IOException e) {
-            throw decodeException(json);
+            throw decodeException(json, e);
         }
     }
 
@@ -88,5 +88,10 @@ public class JWTParser implements JWTPartsParser {
 
     private static JWTDecodeException decodeException(String json) {
         return new JWTDecodeException(String.format("The string '%s' doesn't have a valid JSON format.", json));
+    }
+
+    private static JWTDecodeException decodeException(String json, Throwable cause) {
+        return new JWTDecodeException(
+                String.format("The string '%s' doesn't have a valid JSON format.", json), cause);
     }
 }

--- a/lib/src/test/java/com/auth0/jwt/impl/JWTParserTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/JWTParserTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +16,7 @@ import org.junit.rules.ExpectedException;
 import static com.auth0.jwt.impl.JWTParser.getDefaultObjectMapper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -112,5 +114,16 @@ public class JWTParserTest {
         exception.expect(JWTDecodeException.class);
         exception.expectMessage("The string '}{' doesn't have a valid JSON format.");
         parser.parsePayload("}{");
+    }
+
+    @Test
+    public void shouldPreserveCauseWhenParsingInvalidJson() {
+        try {
+            parser.parsePayload("}{");
+            fail("Expected JWTDecodeException to be thrown");
+        } catch (JWTDecodeException e) {
+            assertThat(e.getCause(), is(notNullValue()));
+            assertThat(e.getCause(), is(instanceOf(IOException.class)));
+        }
     }
 }


### PR DESCRIPTION
### Changes

`JWTParser.parsePayload` and `JWTParser.parseHeader` catch the Jackson `IOException`
thrown while parsing a token's JSON, but rethrow it as a `JWTDecodeException` without
passing the original exception as the cause. As a result, Jackson's parsing details,
including the message and source location, are lost from the exception chain.

This PR forwards the caught `IOException` as the cause:

* Added a private `decodeException(String json, Throwable cause)` overload in `JWTParser`
  that builds the same message and passes the cause through.
* Updated the two `catch (IOException e)` sites in `parsePayload` and `parseHeader` to use it.
* No public API change: `JWTDecodeException` already has a `(String, Throwable)` constructor.
* No behavior change beyond the fix: the exception type and message are unchanged;
  only `getCause()` on the parse-failure path changes from `null` to the underlying Jackson exception.

Before:

```
getCause() : null
```

After:

```
getCause() : com.fasterxml.jackson.core.JsonParseException: Unexpected close marker '}' ...
```

### References

Found via static analysis: PMD's `PreserveStackTrace` rule flags both catch sites.

No related support ticket or community post.

### Testing

* Added `JWTParserTest.shouldPreserveCauseWhenParsingInvalidJson`, which asserts the thrown
  `JWTDecodeException`'s cause is the underlying `IOException`.

* Ran the full module suite with `./gradlew :java-jwt:test`: **680 tests, 0 failures**

* [x] This change adds unit test coverage

* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the Auth0 general contribution guidelines
* [x] I have read the Auth0 Code of Conduct
* [x] All existing and new tests complete without errors
