### PR TITLE
fix: reject NumericDates outside Instant range

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.*;
 
@@ -88,7 +89,13 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
                     "The claim '%s' value (%s) is out of the range representable as a NumericDate.",
                     claimName, node.asText()));
         }
-        return Instant.ofEpochSecond(node.asLong());
+        try {
+            return Instant.ofEpochSecond(node.asLong());
+        } catch (DateTimeException e) {
+            throw new JWTDecodeException(String.format(
+                    "The claim '%s' value (%s) is out of the range representable as a NumericDate.",
+                    claimName, node.asText()), e);
+        }
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {

--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.*;
 
@@ -89,13 +88,13 @@ class PayloadDeserializer extends StdDeserializer<Payload> {
                     "The claim '%s' value (%s) is out of the range representable as a NumericDate.",
                     claimName, node.asText()));
         }
-        try {
-            return Instant.ofEpochSecond(node.asLong());
-        } catch (DateTimeException e) {
+        long seconds = node.asLong();
+        if (seconds < Instant.MIN.getEpochSecond() || seconds > Instant.MAX.getEpochSecond()) {
             throw new JWTDecodeException(String.format(
                     "The claim '%s' value (%s) is out of the range representable as a NumericDate.",
-                    claimName, node.asText()), e);
+                    claimName, node.asText()));
         }
+        return Instant.ofEpochSecond(seconds);
     }
 
     String getString(Map<String, JsonNode> tree, String claimName) {

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -270,6 +270,18 @@ public class PayloadDeserializerTest {
     }
 
     @Test
+    public void shouldThrowOutOfRangeWhenNumericDateExceedsInstantRange() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage(
+                "The claim 'key' value (9223372036854775807) is out of the range representable as a NumericDate.");
+
+        Map<String, JsonNode> tree = new HashMap<>();
+        tree.put("key", new LongNode(Long.MAX_VALUE));
+
+        deserializer.getInstantFromSeconds(tree, "key");
+    }
+
+    @Test
     public void shouldGetNullStringWhenParsingNullNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         NullNode node = NullNode.getInstance();

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -282,6 +282,18 @@ public class PayloadDeserializerTest {
     }
 
     @Test
+    public void shouldThrowOutOfRangeWhenNumericDatePrecedesInstantRange() {
+        exception.expect(JWTDecodeException.class);
+        exception.expectMessage(
+                "The claim 'key' value (-9223372036854775808) is out of the range representable as a NumericDate.");
+
+        Map<String, JsonNode> tree = new HashMap<>();
+        tree.put("key", new LongNode(Long.MIN_VALUE));
+
+        deserializer.getInstantFromSeconds(tree, "key");
+    }
+
+    @Test
     public void shouldGetNullStringWhenParsingNullNode() {
         Map<String, JsonNode> tree = new HashMap<>();
         NullNode node = NullNode.getInstance();


### PR DESCRIPTION
Fixes #782

Registered NumericDate claims that fit in a `long` but fall outside `java.time.Instant`'s epoch-second range are now rejected through the library's existing `JWTDecodeException` boundary.

The range check uses `Instant.MIN` and `Instant.MAX` directly and covers both overflow and underflow with regression tests for `Long.MAX_VALUE` and `Long.MIN_VALUE`.

Validation:

- `./gradlew :java-jwt:test --tests com.auth0.jwt.impl.PayloadDeserializerTest -x :java-jwt:compileModuleInfoJava`
- `./gradlew :java-jwt:test -x :java-jwt:compileModuleInfoJava`