### PR TITLE
chore: remove unused imports

### DIFF
--- a/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
+++ b/lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;

--- a/lib/src/test/java/com/auth0/jwt/JWTTest.java
+++ b/lib/src/test/java/com/auth0/jwt/JWTTest.java
@@ -12,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Base64;

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.*;
 import org.hamcrest.collection.IsCollectionWithSize;
-import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsIterableContaining;
 import org.junit.Before;
 import org.junit.Rule;

--- a/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
+++ b/lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java
@@ -3,7 +3,6 @@ package com.auth0.jwt.impl;
 import com.auth0.jwt.interfaces.Claim;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.IsIterableContaining;

--- a/lib/src/test/java/com/auth0/jwt/interfaces/VerificationTest.java
+++ b/lib/src/test/java/com/auth0/jwt/interfaces/VerificationTest.java
@@ -12,7 +12,6 @@ import java.util.function.BiPredicate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThrows;
 
 /**
  * Tests for any default method implementations in the {@link Verification} interface.


### PR DESCRIPTION
## Changes

Fixed  [#793](https://github.com/auth0/java-jwt/issues/793)

**From #620 (`9024318`, Jan 2023)** — this PR replaced a stored `ObjectReader` field with a fresh `ObjectCodec` obtained from the `JsonParser` at deserialize time, removing every usage of `ObjectReader`, but left the import behind in two places:
- `lib/src/main/java/com/auth0/jwt/impl/PayloadDeserializer.java` (line 12): `import com.fasterxml.jackson.databind.ObjectReader;`
- `lib/src/test/java/com/auth0/jwt/impl/PayloadImplTest.java` (line 6): `import com.fasterxml.jackson.databind.ObjectReader;`

**From `d8fe9a2` (Jun 2023)** — this commit removed an `assertThat(values, is(IsEmptyCollection.empty()))` assertion but left the import:
- `lib/src/test/java/com/auth0/jwt/impl/PayloadDeserializerTest.java` (line 14): `import org.hamcrest.collection.IsEmptyCollection;`

**Two more, found via a repo-wide scan for the same pattern:**
- `lib/src/test/java/com/auth0/jwt/JWTTest.java` (line 15): `import java.time.Duration;`
- `lib/src/test/java/com/auth0/jwt/interfaces/VerificationTest.java` (line 15): `import static org.junit.Assert.assertThrows;`

## Validation

- Ran `./gradlew build`
- Verified the project compiles successfully after removing unused imports.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
