### PR TITLE
ci: handle security workflows for fork pull requests

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -24,6 +24,8 @@ jobs:
 
   check:
     name: Check for Vulnerabilities
+    # Repository secrets are unavailable to workflows from external forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This resolves two CI workflow problems:\n\n- Skip Snyk for external fork pull requests because GitHub withholds the repository-owned SNYK_TOKEN from those runs. Internal pull requests, pushes, merge queues, manual dispatches, and scheduled scans retain the Snyk check.\n- Remove the empty .github/workflows/semgrep.yml. GitHub registers it as an active workflow, then immediately fails it because it has no workflow definition or jobs.\n\nThe actual Gradle wrapper-validation workflow passes.